### PR TITLE
Fix redirects on /sign_in when -skip-provider-button is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,11 @@
 
 ## Changes since v3.2.0
 
-- [#180](https://github.com/pusher/outh2_proxy/pull/180) Minor refactor of core proxying path (@aeijdenberg).
-- [#175](https://github.com/pusher/outh2_proxy/pull/175) Bump go-oidc to v2.0.0 (@aeijdenberg).
+- [#150](https://github.com/pusher/oauth2_proxy/pull/150) Fix redirects on /sign_in when -skip-provider-button is set
+- [#180](https://github.com/pusher/oauth2_proxy/pull/180) Minor refactor of core proxying path (@aeijdenberg).
+- [#175](https://github.com/pusher/oauth2_proxy/pull/175) Bump go-oidc to v2.0.0 (@aeijdenberg).
   - Includes fix for potential signature checking issue when OIDC discovery is skipped.
-- [#155](https://github.com/pusher/outh2_proxy/pull/155) Add RedisSessionStore implementation (@brianv0, @JoelSpeed)
+- [#155](https://github.com/pusher/oauth2_proxy/pull/155) Add RedisSessionStore implementation (@brianv0, @JoelSpeed)
   - Implement flags to configure the redis session store
     - `-session-store-type=redis` Sets the store type to redis
     - `-redis-connection-url` Sets the Redis connection URL
@@ -25,12 +26,12 @@
     - `-redis-sentinel-master-name` Sets the Sentinel master name, if sentinel is enabled
     - `-redis-sentinel-connection-urls` Defines the Redis Sentinel Connection URLs, if sentinel is enabled
   - Introduces the concept of a session ticket. Tickets are composed of the cookie name, a session ID, and a secret.
-  - Redis Sessions are stored encrypted with a per-session secret 
+  - Redis Sessions are stored encrypted with a per-session secret
   - Added tests for server based session stores
-- [#168](https://github.com/pusher/outh2_proxy/pull/168) Drop Go 1.11 support in Travis (@JoelSpeed)
-- [#169](https://github.com/pusher/outh2_proxy/pull/169) Update Alpine to 3.9 (@kskewes)
-- [#148](https://github.com/pusher/outh2_proxy/pull/148) Implement SessionStore interface within proxy (@JoelSpeed)
-- [#147](https://github.com/pusher/outh2_proxy/pull/147) Add SessionStore interfaces and initial implementation (@JoelSpeed)
+- [#168](https://github.com/pusher/oauth2_proxy/pull/168) Drop Go 1.11 support in Travis (@JoelSpeed)
+- [#169](https://github.com/pusher/oauth2_proxy/pull/169) Update Alpine to 3.9 (@kskewes)
+- [#148](https://github.com/pusher/oauth2_proxy/pull/148) Implement SessionStore interface within proxy (@JoelSpeed)
+- [#147](https://github.com/pusher/oauth2_proxy/pull/147) Add SessionStore interfaces and initial implementation (@JoelSpeed)
   - Allows for multiple different session storage implementations including client and server side
   - Adds tests suite for interface to ensure consistency across implementations
   - Refactor some configuration options (around cookies) into packages

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -389,10 +389,9 @@ func (p *OAuthProxy) ErrorPage(rw http.ResponseWriter, code int, title string, m
 	p.templates.ExecuteTemplate(rw, "error.html", t)
 }
 
-// SignInPage writes the sing in template to the response
+// SignInPage writes the sign-in template to the response
 func (p *OAuthProxy) SignInPage(rw http.ResponseWriter, req *http.Request, code int) {
 	p.ClearSessionCookie(rw, req)
-	rw.WriteHeader(code)
 
 	redirecURL := req.URL.RequestURI()
 	if req.Header.Get("X-Auth-Request-Redirect") != "" {
@@ -401,6 +400,14 @@ func (p *OAuthProxy) SignInPage(rw http.ResponseWriter, req *http.Request, code 
 	if redirecURL == p.SignInPath {
 		redirecURL = "/"
 	}
+
+	if p.SkipProviderButton {
+		req.Form.Set("rd", redirecURL)
+		p.OAuthStart(rw, req)
+		return
+	}
+
+	rw.WriteHeader(code)
 
 	t := struct {
 		ProviderName  string
@@ -543,11 +550,7 @@ func (p *OAuthProxy) SignIn(rw http.ResponseWriter, req *http.Request) {
 		p.SaveSession(rw, req, session)
 		http.Redirect(rw, req, redirect, 302)
 	} else {
-		if p.SkipProviderButton {
-			p.OAuthStart(rw, req)
-		} else {
-			p.SignInPage(rw, req, http.StatusOK)
-		}
+		p.SignInPage(rw, req, http.StatusOK)
 	}
 }
 


### PR DESCRIPTION
Push the logic down a level: now the dispatch happens in SignInPage, where the correct redirect URI is known.

Fixes #30, hopefully

## How Has This Been Tested?

Manually tested /oauth2/sign_in and /oauth2/start endpoints with and without -skip-provider-button, with `X-Auth-Request-Redirect` header set for /oauth2/sign_in requests, and the `rd=` URL parameter set for /oauth2/start requests.

## Checklist:

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
