### PR TITLE
Implement subdomain-based routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - [#483](https://github.com/oauth2-proxy/oauth2-proxy/pull/483) Warn users when session cookies are split (@JoelSpeed)
 - [#488](https://github.com/oauth2-proxy/oauth2-proxy/pull/488) Set-Basic-Auth should default to false (@JoelSpeed)
 - [#494](https://github.com/oauth2-proxy/oauth2-proxy/pull/494) Upstream websockets TLS certificate validation now depends on ssl-upstream-insecure-skip-verify
+- [#204](https://github.com/oauth2-proxy/oauth2_proxy/pull/204) Add subdomain-based routing. It is now possible to route based on domain name and path.
 
 # v5.1.0
 
@@ -144,6 +145,7 @@ N/A
 - [#265](https://github.com/oauth2-proxy/oauth2-proxy/pull/265) Add upstream with static response (@cgroschupp)
 - [#317](https://github.com/oauth2-proxy/oauth2-proxy/pull/317) Add build for FreeBSD (@fnkr)
 - [#296](https://github.com/oauth2-proxy/oauth2-proxy/pull/296) Allow to override provider's name for sign-in page (@ffdybuster)
+- [#204](https://github.com/pusher/oauth2_proxy/pull/204) Add subdomain-based routing. It is now possible to route based on domain name and path.
 
 # v4.0.0
 

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -136,6 +136,19 @@ Static file paths are configured as a file:// URL. `file:///var/www/static/` wil
 
 Multiple upstreams can either be configured by supplying a comma separated list to the `-upstream` parameter, supplying the parameter multiple times or provinding a list in the [config file](#config-file). When multiple upstreams are used routing to them will be based on the path they are set up with.
 
+Subdomain-based routing is possible by prepending a subdomain followed by a `|` to the upstream URL, like this:
+
+```
+test |http://127.0.0.1:8082/
+other|http://127.0.0.1:8083/
+other|http://127.0.0.1:8084/path/
+     |http://127.0.0.1:8085/
+```
+
+Assuming cookie domain is set to `.example.com`, the requests `test.example.com`, `other.example.com`, `other.example.com/path/` and `example.com` will all be routed to different upstreams. Any spacing around the `|` separator is ignored.
+
+When using subdomain-based routing, `whitelist_domains` must be configured to allow each subdomain (or the entire cookie domain, e.g. `.example.com`).
+
 ### Environment variables
 
 Every command line argument can be specified as an environment variable by

--- a/options_test.go
+++ b/options_test.go
@@ -142,11 +142,25 @@ func TestRedirectURL(t *testing.T) {
 func TestProxyURLs(t *testing.T) {
 	o := testOptions()
 	o.Upstreams = append(o.Upstreams, "http://127.0.0.1:8081")
+	o.Upstreams = append(o.Upstreams, "|http://127.0.0.1:8082")
+	o.Upstreams = append(o.Upstreams, "  |http://127.0.0.1:8083/x/")
+	o.Upstreams = append(o.Upstreams, "sub.domain|http://127.0.0.1:8082/abc")
+	o.Upstreams = append(o.Upstreams, " sub.domain\t | http://127.0.0.1:8083/abc/")
 	assert.Equal(t, nil, o.Validate())
-	expected := []*url.URL{
-		{Scheme: "http", Host: "127.0.0.1:8080", Path: "/"},
-		// note the '/' was added
-		{Scheme: "http", Host: "127.0.0.1:8081", Path: "/"},
+	expected := map[string][]*url.URL{
+		"*": {
+			{Scheme: "http", Host: "127.0.0.1:8080", Path: "/"},
+			// note the '/' was added
+			{Scheme: "http", Host: "127.0.0.1:8081", Path: "/"},
+		},
+		"": {
+			{Scheme: "http", Host: "127.0.0.1:8082", Path: "/"},
+			{Scheme: "http", Host: "127.0.0.1:8083", Path: "/x/"},
+		},
+		"sub.domain": {
+			{Scheme: "http", Host: "127.0.0.1:8082", Path: "/abc"},
+			{Scheme: "http", Host: "127.0.0.1:8083", Path: "/abc/"},
+		},
 	}
 	assert.Equal(t, expected, o.proxyURLs)
 }


### PR DESCRIPTION
This PR adds subdomain-based routing.

## Description

This PR makes it possible to route based on domain name in addition to by path, for example:

```
upstreams = [
    http://default-upstream:8082/
    delta|http://delta-service:8083/
    echo|http://echo-service:8080/
    echo|http://echo-service-api:8080/api/
]
cookie_domain = ".mydomain.com"
```

With this new config it's possible to route `https://delta.mydomain.com/`, `https://echo.mydomain.com/` as well as `https://echo.mydomain.com/api/` differently.

## Motivation and Context

Sometimes it is desirable to route not only based on the path, but also on the subdomain. This allows the use of the same oauth2 callback URL and oauth2_proxy for multiple sites in the same domain.

## How Has This Been Tested?

We tested this patch in our production domain. A modified version (based on the bitly/google-oauth-proxy) has been running successfully for us for a few years now.

## Checklist:

- [X] My change requires a change to the documentation or CHANGELOG.
- [X] I have updated the documentation/CHANGELOG accordingly.
- [X] I have created a feature (non-master) branch for my PR.
