### PR TITLE
oauthproxy: allow custom timeout for proxy requests

### DIFF
--- a/options.go
+++ b/options.go
@@ -39,6 +39,7 @@ type Options struct {
 	ClientSecret    string `flag:"client-secret" cfg:"client_secret" env:"OAUTH2_PROXY_CLIENT_SECRET"`
 	TLSCertFile     string `flag:"tls-cert-file" cfg:"tls_cert_file" env:"OAUTH2_PROXY_TLS_CERT_FILE"`
 	TLSKeyFile      string `flag:"tls-key-file" cfg:"tls_key_file" env:"OAUTH2_PROXY_TLS_KEY_FILE"`
+	ProxyTimeOut    time.Duration    `flag:"proxy-time-out" cfg:"proxy_time_out" env:"OAUTH2_PROXY_PROXY_TIME_OUT"`
 
 	AuthenticatedEmailsFile  string   `flag:"authenticated-emails-file" cfg:"authenticated_emails_file" env:"OAUTH2_PROXY_AUTHENTICATED_EMAILS_FILE"`
 	KeycloakGroup            string   `flag:"keycloak-group" cfg:"keycloak_group" env:"OAUTH2_PROXY_KEYCLOAK_GROUP"`
@@ -145,6 +146,7 @@ func NewOptions() *Options {
 		ProxyWebSockets:     true,
 		HTTPAddress:         "127.0.0.1:4180",
 		HTTPSAddress:        ":443",
+		ProxyTimeOut:        30, //TIME_OUT in seconds
 		DisplayHtpasswdForm: true,
 		CookieOptions: options.CookieOptions{
 			CookieName:     "_oauth2_proxy",

--- a/options_test.go
+++ b/options_test.go
@@ -83,6 +83,14 @@ func TestRedirectURL(t *testing.T) {
 	assert.Equal(t, expected, o.redirectURL)
 }
 
+func TestProxyTimeOut(t *testing.T) {
+	o := testOptions()
+	o.ProxyTimeOut = 40
+	assert.Equal(t, nil, o.Validate())
+	expected := 40
+	assert.Equal(t, expected, o.ProxyTimeOut)
+}
+
 func TestProxyURLs(t *testing.T) {
 	o := testOptions()
 	o.Upstreams = append(o.Upstreams, "http://127.0.0.1:8081")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Allows the user to pass the custom time out flag for reverse proxied requests

## Motivation and Context
It solves https://github.com/pusher/oauth2_proxy/issues/222
Also, it's a great start for my #Hacktoberfest 

## How Has This Been Tested?

I have added some test case
This is my first Contribution to this repo so not sure about full guidelines but will try to improve this PR in coming time
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
