### PR TITLE
fix: optionally prevent approval_prompt being sent

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -21,7 +21,7 @@ An example [oauth2_proxy.cfg]({{ site.gitweb }}/contrib/oauth2_proxy.cfg.example
 | Option | Type | Description | Default |
 | ------ | ---- | ----------- | ------- |
 | `-acr-values` | string | optional, used by login.gov | `"http://idmanagement.gov/ns/assurance/loa/1"` |
-| `-approval-prompt` | string | OAuth approval_prompt | `"force"` |
+| `-approval-prompt` | string | OAuth approval_prompt, if empty the header will not be sent | `"force"` |
 | `-auth-logging` | bool | Log authentication attempts | true |
 | `-auth-logging-format` | string | Template for authentication log lines | see [Logging Configuration](#logging-configuration) |
 | `-authenticated-emails-file` | string | authenticate against emails via file (one per line) | |

--- a/main.go
+++ b/main.go
@@ -124,7 +124,7 @@ func main() {
 	flagSet.String("resource", "", "The resource that is protected (Azure AD only)")
 	flagSet.String("validate-url", "", "Access token validation endpoint")
 	flagSet.String("scope", "", "OAuth scope specification")
-	flagSet.String("approval-prompt", "force", "OAuth approval_prompt")
+	flagSet.String("approval-prompt", "force", "OAuth approval_prompt, if empty the header will not be sent")
 
 	flagSet.String("signature-key", "", "GAP-Signature request signature key (algorithm:secretkey)")
 	flagSet.String("acr-values", "http://idmanagement.gov/ns/assurance/loa/1", "acr values string:  optional, used by login.gov")

--- a/providers/logingov.go
+++ b/providers/logingov.go
@@ -265,7 +265,9 @@ func (p *LoginGovProvider) GetLoginURL(redirectURI, state string) string {
 	a = *p.LoginURL
 	params, _ := url.ParseQuery(a.RawQuery)
 	params.Set("redirect_uri", redirectURI)
-	params.Set("approval_prompt", p.ApprovalPrompt)
+	if p.ApprovalPrompt != "" {
+		params.Set("approval_prompt", p.ApprovalPrompt)
+	}
 	params.Add("scope", p.Scope)
 	params.Set("client_id", p.ClientID)
 	params.Set("response_type", "code")

--- a/providers/provider_default.go
+++ b/providers/provider_default.go
@@ -86,7 +86,9 @@ func (p *ProviderData) GetLoginURL(redirectURI, state string) string {
 	a = *p.LoginURL
 	params, _ := url.ParseQuery(a.RawQuery)
 	params.Set("redirect_uri", redirectURI)
-	params.Set("approval_prompt", p.ApprovalPrompt)
+	if p.ApprovalPrompt != "" {
+		params.Set("approval_prompt", p.ApprovalPrompt)
+	}
 	params.Add("scope", p.Scope)
 	params.Set("client_id", p.ClientID)
 	params.Set("response_type", "code")


### PR DESCRIPTION


This is one way to resolve #191 but I'm not sure it's the best - it may be better to allow prompt to be sent instead somehow?

## Motivation and Context

fixes #191

## How Has This Been Tested?

Against Auth0 which delegates to Google

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My change requires a change to the documentation or CHANGELOG.
- [X] I have updated the documentation/CHANGELOG accordingly.
- [X] I have created a feature (non-master) branch for my PR.
