### PR TITLE
Session ticket passthrough when skip-JWT-bearer-tokens and redis store is enabled

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -105,6 +105,7 @@ An example [oauth2_proxy.cfg]({{ site.gitweb }}/contrib/oauth2_proxy.cfg.example
 | `-skip-jwt-bearer-tokens` | bool | will skip requests that have verified JWT bearer tokens | false |
 | `-skip-oidc-discovery` | bool | bypass OIDC endpoint discovery. `-login-url`, `-redeem-url` and `-oidc-jwks-url` must be configured in this case | false |
 | `-skip-provider-button` | bool | will skip sign-in-page to directly reach the next step: oauth/start | false |
+| `-skip-session-tickets` | bool | will skip requests that have verified session tickets if session-store-type is redis and skip-jwt-bearer-tokens is set | false |
 | `-ssl-insecure-skip-verify` | bool | skip validation of certificates presented when using HTTPS providers | false |
 | `-ssl-upstream-insecure-skip-verify` | bool | skip validation of certificates presented when using HTTPS upstreams | false |
 | `-standard-logging` | bool | Log standard runtime information | true |

--- a/main.go
+++ b/main.go
@@ -55,7 +55,7 @@ func main() {
 	flagSet.Duration("flush-interval", time.Duration(1)*time.Second, "period between response flushing when streaming responses")
 	flagSet.Bool("skip-jwt-bearer-tokens", false, "will skip requests that have verified JWT bearer tokens (default false)")
 	flagSet.Var(&jwtIssuers, "extra-jwt-issuers", "if skip-jwt-bearer-tokens is set, a list of extra JWT issuer=audience pairs (where the issuer URL has a .well-known/openid-configuration or a .well-known/jwks.json)")
-	flagSet.Bool("skip-session-tickets", false, "if session-store-type is redis and skip-jwt-bearer-tokens is set, requests that have verified session tickets will be skipped (default false)")
+	flagSet.Bool("skip-session-tickets", false, "will skip requests that have verified session tickets if session-store-type is redis and skip-jwt-bearer-tokens is set (default false)")
 
 	flagSet.Var(&emailDomains, "email-domain", "authenticate emails with the specified domain (may be given multiple times). Use * to authenticate any email")
 	flagSet.Var(&whitelistDomains, "whitelist-domain", "allowed domains for redirection after authentication. Prefix domain with a . to allow subdomains (eg .example.com)")

--- a/main.go
+++ b/main.go
@@ -55,6 +55,7 @@ func main() {
 	flagSet.Duration("flush-interval", time.Duration(1)*time.Second, "period between response flushing when streaming responses")
 	flagSet.Bool("skip-jwt-bearer-tokens", false, "will skip requests that have verified JWT bearer tokens (default false)")
 	flagSet.Var(&jwtIssuers, "extra-jwt-issuers", "if skip-jwt-bearer-tokens is set, a list of extra JWT issuer=audience pairs (where the issuer URL has a .well-known/openid-configuration or a .well-known/jwks.json)")
+	flagSet.Bool("skip-session-tickets", false, "if session-store-type is redis and skip-jwt-bearer-tokens is set, requests that have verified session tickets will be skipped (default false)")
 
 	flagSet.Var(&emailDomains, "email-domain", "authenticate emails with the specified domain (may be given multiple times). Use * to authenticate any email")
 	flagSet.Var(&whitelistDomains, "whitelist-domain", "allowed domains for redirection after authentication. Prefix domain with a . to allow subdomains (eg .example.com)")

--- a/options.go
+++ b/options.go
@@ -70,6 +70,7 @@ type Options struct {
 	Upstreams                     []string      `flag:"upstream" cfg:"upstreams" env:"OAUTH2_PROXY_UPSTREAMS"`
 	SkipAuthRegex                 []string      `flag:"skip-auth-regex" cfg:"skip_auth_regex" env:"OAUTH2_PROXY_SKIP_AUTH_REGEX"`
 	SkipJwtBearerTokens           bool          `flag:"skip-jwt-bearer-tokens" cfg:"skip_jwt_bearer_tokens" env:"OAUTH2_PROXY_SKIP_JWT_BEARER_TOKENS"`
+	SkipSessionTickets            bool          `flag:"skip-session-tickets" cfg:"skip_session_tickets" env:"OAUTH2_PROXY_SKIP_SESSION_TICKETS"`
 	ExtraJwtIssuers               []string      `flag:"extra-jwt-issuers" cfg:"extra_jwt_issuers" env:"OAUTH2_PROXY_EXTRA_JWT_ISSUERS"`
 	PassBasicAuth                 bool          `flag:"pass-basic-auth" cfg:"pass_basic_auth" env:"OAUTH2_PROXY_PASS_BASIC_AUTH"`
 	BasicAuthPassword             string        `flag:"basic-auth-password" cfg:"basic_auth_password" env:"OAUTH2_PROXY_BASIC_AUTH_PASSWORD"`
@@ -351,6 +352,15 @@ func (o *Options) Validate() error {
 		msgs = append(msgs, fmt.Sprintf("error initialising session storage: %v", err))
 	} else {
 		o.sessionStore = sessionStore
+	}
+
+	if o.SkipSessionTickets {
+		if o.SessionOptions.Type != options.RedisSessionStoreType {
+			msgs = append(msgs, "skipping session tickets requires redis session store")
+		}
+		if !o.SkipJwtBearerTokens {
+			msgs = append(msgs, "skipping session tickets requires skip JWT bearer tokens enabled")
+		}
 	}
 
 	if o.CookieRefresh >= o.CookieExpire {

--- a/pkg/sessions/redis/redis_store.go
+++ b/pkg/sessions/redis/redis_store.go
@@ -149,15 +149,15 @@ func (store *SessionStore) Load(req *http.Request) (*sessions.SessionState, erro
 	if !ok {
 		return nil, fmt.Errorf("Cookie Signature not valid")
 	}
-	session, err := store.loadSessionFromString(val)
+	session, err := store.LoadSessionFromString(val)
 	if err != nil {
 		return nil, fmt.Errorf("error loading session: %s", err)
 	}
 	return session, nil
 }
 
-// loadSessionFromString loads the session based on the ticket value
-func (store *SessionStore) loadSessionFromString(value string) (*sessions.SessionState, error) {
+// LoadSessionFromString loads the session based on the ticket value
+func (store *SessionStore) LoadSessionFromString(value string) (*sessions.SessionState, error) {
 	ticket, err := decodeTicket(store.CookieOptions.CookieName, value)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Description
When using Redis session store and JWT Bearer passthrough, a ticket to a session, and subsequently an IDToken, can be used in place of providing a JWT. 

This pull request adds a flag to support for ticket passthrough when both the Redis session store and `--skip-jwt-bearer-tokens` features are enabled.

## Motivation and Context
Implements  #375

After implementing JWT bearer passthrough, we still ran into issues with JWT tokens being too long, especially for legacy HTTP clients. When using the redis store, we were able to inject a session derived from the JWT, just as the bearer passthrough does, into the redis session store and issue tickets to users instead. This has enabled us to implement an "App Password" pattern for our APIs and Services.

An example of code which can be used to inject a session based on a JWT is here, implemented in python:
https://gist.github.com/brianv0/9609748b8b77daf6d974598f5dee197c

## How Has This Been Tested?
This code has been slightly adapted (with CLI options) from our fork which we have been using the last year. A unit test to verify the feature works has been added.

## Checklist:

- [X] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [X] I have created a feature (non-master) branch for my PR.

/cc @rra