### PR TITLE
Use builtin function String() of http.Cookie for size calc

### DIFF
--- a/pkg/sessions/cookie/session_store.go
+++ b/pkg/sessions/cookie/session_store.go
@@ -129,7 +129,7 @@ func NewCookieSessionStore(opts *options.SessionOptions, cookieOpts *options.Coo
 // it into a slice of cookies which fit within the 4kb cookie limit indexing
 // the cookies from 0
 func splitCookie(c *http.Cookie) []*http.Cookie {
-	if len(c.Value) < maxCookieLength {
+	if len(c.String()) < maxCookieLength {
 		return []*http.Cookie{c}
 	}
 	cookies := []*http.Cookie{}

--- a/pkg/sessions/cookie/session_store.go
+++ b/pkg/sessions/cookie/session_store.go
@@ -99,7 +99,7 @@ func (s *SessionStore) makeSessionCookie(req *http.Request, value string, now ti
 		value = encryption.SignedValue(s.CookieOptions.CookieSecret, s.CookieOptions.CookieName, value, now)
 	}
 	c := s.makeCookie(req, s.CookieOptions.CookieName, value, s.CookieOptions.CookieExpire, now)
-	if len(c.Value) > 4096-len(s.CookieOptions.CookieName) {
+	if len(c.String()) > 4096 {
 		return splitCookie(c)
 	}
 	return []*http.Cookie{c}

--- a/pkg/sessions/session_store_test.go
+++ b/pkg/sessions/session_store_test.go
@@ -95,6 +95,11 @@ var _ = Describe("NewSessionStore", func() {
 				}
 			})
 
+			It("have a cookie size no greater than 4096", func() {
+				for _, cookie := range cookies {
+					Expect(len(cookie.String())).To(BeNumerically("<", 4096))
+				}
+			})
 		})
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Using the full stringified version of the cookie when determining if the cookie is to be split or not

<!--- Describe your changes in detail -->

## Motivation and Context
Using a builtin string representation of the cookie and its size for determining if the cookie is to be split or not.
https://golang.org/src/net/http/cookie.go


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Cookies whose values are just on the edge of the limit but cross the threshold once directives are included will not be split and cause 400 errors upstream.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
