### PR TITLE
Add Dropsolid OAuth provider and "providerize" GetJwtSession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [#363](https://github.com/pusher/oauth2_proxy/pull/363) Extension of Redis Session Store to Support Redis Cluster (@yan-dblinf)
 - [#353](https://github.com/pusher/oauth2_proxy/pull/353) Fix login page fragment handling after soft reload on Firefox (@ffdybuster)
 - [#355](https://github.com/pusher/oauth2_proxy/pull/355) Add Client Secret File support for providers that rotate client secret via file system (@pasha-r)
+- [#395](https://github.com/pusher/oauth2_proxy/pull/395) Add Dropsolid OAuth provider and "providerize" GetJwtSession (@nickveenhof)
 
 # v5.0.0
 

--- a/docs/2_auth.md
+++ b/docs/2_auth.md
@@ -21,6 +21,7 @@ Valid providers are :
 - [login.gov](#logingov-provider)
 - [Nextcloud](#nextcloud-provider)
 - [DigitalOcean](#digitalocean-auth-provider)
+- [Dropsolid](#dropsolid-auth-provider)
 
 The provider can be selected using the `provider` configuration value.
 
@@ -334,6 +335,31 @@ To use the provider, pass the following options:
    --provider=digitalocean
    --client-id=<Client ID>
    --client-secret=<Client Secret>
+```
+
+ Alternatively, set the equivalent options in the config file. The redirect URL defaults to `https://<requested host header>/oauth2/callback`. If you need to change it, you can use the `--redirect-url` command-line option.
+
+### Dropsolid Auth Provider
+
+1. [Create a new OAuth application](https://platform.dropsolid.com)
+2. Note the Client ID and Client Secret.
+
+To use the provider, pass the following options:
+
+```
+   --provider=dropsolid
+   --client-id=<Client ID>
+   --client-secret=<Client Secret>
+```
+
+The provider also supports checking JWT tokens that were created by the Dropsolid Platform. pass the following options for this flow
+
+```
+   --provider=dropsolid
+   --client-id=<Client ID>
+   --client-secret=<Client Secret>
+   --skip-jwt-bearer-tokens=true 
+   --extra-jwt-issuers=https://platform.dropsolid.com=<Client ID>
 ```
 
  Alternatively, set the equivalent options in the config file. The redirect URL defaults to `https://<requested host header>/oauth2/callback`. If you need to change it, you can use the `--redirect-url` command-line option.

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -1034,7 +1034,6 @@ func TestAuthSkippedForPreflightRequests(t *testing.T) {
 	opts.provider = NewTestProvider(upstreamURL, "")
 
 	proxy := NewOAuthProxy(opts, func(string) bool { return false })
-	logger.Printf("%+v", proxy)
 	rw := httptest.NewRecorder()
 	req, _ := http.NewRequest("OPTIONS", "/preflight-request", nil)
 	proxy.ServeHTTP(rw, req)
@@ -1443,7 +1442,6 @@ func TestJwtUnauthorizedOnGroupValidationFailure(t *testing.T) {
 	}
 	test.proxy.ServeHTTP(test.rw, test.req)
 	if test.rw.Code != http.StatusUnauthorized {
-		logger.Printf("%v", test.rw.Code)
 		t.Fatalf("expected 401 got %d", test.rw.Code)
 	}
 }

--- a/options.go
+++ b/options.go
@@ -496,9 +496,6 @@ func parseProviderInfo(o *Options, msgs []string) []string {
 			}
 		}
 	}
-	//case *providers.DropsolidProvider:
-	//	p.PubJWKURL, msgs = parseURL(o.PubJWKURL, "pubjwk", msgs)
-	//}
 	return msgs
 }
 

--- a/options.go
+++ b/options.go
@@ -495,9 +495,9 @@ func parseProviderInfo(o *Options, msgs []string) []string {
 				p.JWTKey = signKey
 			}
 		}
-	case *providers.DropsolidProvider:
-		p.PubJWKURL, msgs = parseURL(o.PubJWKURL, "pubjwk", msgs)
-	}
+	//case *providers.DropsolidProvider:
+	//	p.PubJWKURL, msgs = parseURL(o.PubJWKURL, "pubjwk", msgs)
+	//}
 	return msgs
 }
 

--- a/options.go
+++ b/options.go
@@ -412,6 +412,7 @@ func parseProviderInfo(o *Options, msgs []string) []string {
 	p.ProfileURL, msgs = parseURL(o.ProfileURL, "profile", msgs)
 	p.ValidateURL, msgs = parseURL(o.ValidateURL, "validate", msgs)
 	p.ProtectedResource, msgs = parseURL(o.ProtectedResource, "resource", msgs)
+	p.JwtBearerVerifiers = o.jwtBearerVerifiers
 
 	o.provider = providers.New(o.Provider, p)
 	switch p := o.provider.(type) {
@@ -494,6 +495,8 @@ func parseProviderInfo(o *Options, msgs []string) []string {
 				p.JWTKey = signKey
 			}
 		}
+	case *providers.DropsolidProvider:
+		p.PubJWKURL, msgs = parseURL(o.PubJWKURL, "pubjwk", msgs)
 	}
 	return msgs
 }

--- a/options.go
+++ b/options.go
@@ -495,6 +495,7 @@ func parseProviderInfo(o *Options, msgs []string) []string {
 				p.JWTKey = signKey
 			}
 		}
+	}
 	//case *providers.DropsolidProvider:
 	//	p.PubJWKURL, msgs = parseURL(o.PubJWKURL, "pubjwk", msgs)
 	//}

--- a/providers/dropsolid.go
+++ b/providers/dropsolid.go
@@ -135,7 +135,6 @@ func (p *DropsolidProvider) GetEmailAddress(s *sessions.SessionState) (string, e
 
 // ValidateSessionState validates the AccessToken
 func (p *DropsolidProvider) ValidateSessionState(s *sessions.SessionState) bool {
-	logger.Printf("validating token")
 	return validateToken(p, s.AccessToken, getDropsolidHeader(s.AccessToken))
 }
 
@@ -146,7 +145,6 @@ func (p *DropsolidProvider) Redeem(redirectURL, code string) (s *sessions.Sessio
 		err = errors.New("missing code")
 		return
 	}
-	logger.Printf("%v", "Got into the redeem")
 
 	params := url.Values{}
 	params.Add("redirect_uri", redirectURL)

--- a/providers/dropsolid.go
+++ b/providers/dropsolid.go
@@ -1,23 +1,45 @@
 package providers
 
 import (
-	"errors"
+	"bytes"
 	"fmt"
 	"net/http"
 	"net/url"
+	"io/ioutil"
+	"encoding/json"
+    "crypto/rsa"
+	"time"
+	"errors"
+	"context"
 
+	//"gopkg.in/square/go-jose.v2"
+	//"github.com/coreos/go-oidc"
+	"github.com/dgrijalva/jwt-go"
+    "github.com/pusher/oauth2_proxy/pkg/logger"
 	"github.com/pusher/oauth2_proxy/pkg/apis/sessions"
-	"github.com/pusher/oauth2_proxy/pkg/requests"
 )
 
-// DigitalOceanProvider represents a DigitalOcean based Identity Provider
+// DropsolidProvider represents a Dropsolid Platform based Identity Provider
 type DropsolidProvider struct {
 	*ProviderData
+	JWTKey    *rsa.PrivateKey
+	PubJWKURL *url.URL
 }
 
-// NewDigitalOceanProvider initiates a new DigitalOceanProvider
+type dropsolidJwtClaims struct {
+	Scopes     []string   `json:"scopes"`
+	jwt.StandardClaims
+}
+
+type dropsolidUserInfo struct {
+	UserId        string   `json:"sub"`
+	Email         string   `json:"email"`
+}
+
+// NewDropsolidProvider initiates a new DropsolidProvider
 func NewDropsolidProvider(p *ProviderData) *DropsolidProvider {
 	p.ProviderName = "Dropsolid"
+
 	if p.LoginURL.String() == "" {
 		p.LoginURL = &url.URL{Scheme: "https",
 			Host: "platform.dropsolid.com",
@@ -36,8 +58,13 @@ func NewDropsolidProvider(p *ProviderData) *DropsolidProvider {
 			Path: "/oauth/user.info",
 		}
 	}
+
+	if p.ValidateURL.String() == "" {
+		p.ValidateURL = p.ProfileURL
+	}
+
 	if p.Scope == "" {
-		p.Scope = "openid"
+		p.Scope = "openid email"
 	}
 	return &DropsolidProvider{ProviderData: p}
 }
@@ -49,53 +76,319 @@ func getDropsolidHeader(accessToken string) http.Header {
 	return header
 }
 
-// GetUserName returns the Account user name
-func (p *DropsolidProvider) GetUserName(s *sessions.SessionState) (string, error) {
-	if s.AccessToken == "" {
-		return "", errors.New("missing access token")
-	}
 
+func (p *DropsolidProvider) getUserInfo(s *sessions.SessionState) (*dropsolidUserInfo, error) {
+	// Retrieve user info JSON
 	req, err := http.NewRequest("GET", p.ProfileURL.String(), nil)
 	if err != nil {
-		return "", err
+		return nil, fmt.Errorf("failed to create user info request: %v", err)
 	}
-	req.Header = getDropsolidHeader(s.AccessToken)
+	req.Header.Set("Authorization", "Bearer "+s.AccessToken)
 
-	json, err := requests.Request(req)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return "", err
+		return nil, fmt.Errorf("failed to perform user info request: %v", err)
+	}
+	var body []byte
+	body, err = ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read user info response: %v", err)
 	}
 
-	userId, err := json.GetPath("sub").String()
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("got %d during user info request: %s", resp.StatusCode, body)
+	}
 
-	return userId, nil
+	var userInfo dropsolidUserInfo
+	err = json.Unmarshal(body, &userInfo)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse user info: %v", err)
+	}
+	// handle json did not match error
+    if userInfo.UserId == "" || userInfo.Email == "" {
+        return nil, fmt.Errorf("failed to parse user info: %v", err)
+    }
+
+	return &userInfo, nil
+}
+
+// GetUserName returns the Account user name
+func (p *DropsolidProvider) GetUserName(s *sessions.SessionState) (string, error) {
+	// Retrieve user info
+	userInfo, err := p.getUserInfo(s)
+	if err != nil {
+		return "", fmt.Errorf("failed to retrieve user info: %v", err)
+	}
+
+	return userInfo.UserId, nil
 }
 
 
 // GetEmailAddress returns the Account email address
 func (p *DropsolidProvider) GetEmailAddress(s *sessions.SessionState) (string, error) {
-	if s.AccessToken == "" {
-		return "", errors.New("missing access token")
-	}
-	req, err := http.NewRequest("GET", p.ProfileURL.String(), nil)
+	// Retrieve user info
+	userInfo, err := p.getUserInfo(s)
 	if err != nil {
-		return "", err
-	}
-	req.Header = getDropsolidHeader(s.AccessToken)
-
-	json, err := requests.Request(req)
-	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to retrieve user info: %v", err)
 	}
 
-	email, err := json.GetPath("email").String()
-	if err != nil {
-		return "", err
-	}
-	return email, nil
+	return userInfo.Email, nil
 }
 
 // ValidateSessionState validates the AccessToken
 func (p *DropsolidProvider) ValidateSessionState(s *sessions.SessionState) bool {
+	logger.Printf("validating token")
 	return validateToken(p, s.AccessToken, getDropsolidHeader(s.AccessToken))
+}
+
+// Redeem provides a Dropsolid implementation of the OAuth2 token redemption process
+// which also supports the refresh flow.
+func (p *DropsolidProvider) Redeem(redirectURL, code string) (s *sessions.SessionState, err error) {
+	if code == "" {
+		err = errors.New("missing code")
+		return
+	}
+	logger.Printf("%v", "Got into the redeem")
+
+	params := url.Values{}
+	params.Add("redirect_uri", redirectURL)
+	params.Add("client_id", p.ClientID)
+	params.Add("client_secret", p.ClientSecret)
+	params.Add("code", code)
+	params.Add("grant_type", "authorization_code")
+
+	var req *http.Request
+	req, err = http.NewRequest("POST", p.RedeemURL.String(), bytes.NewBufferString(params.Encode()))
+	if err != nil {
+		return
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	var resp *http.Response
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	var body []byte
+	body, err = ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return
+	}
+
+	if resp.StatusCode != 200 {
+		err = fmt.Errorf("got %d from %q %s", resp.StatusCode, p.RedeemURL.String(), body)
+		return
+	}
+
+	// blindly try json and x-www-form-urlencoded
+	var jsonResponse struct {
+		AccessToken string `json:"access_token"`
+		ExpiresIn int64 `json:"expires_in"`
+		TokenType string `json:"token_type"`
+		RefreshToken string `json:"refresh_token"`
+	}
+	err = json.Unmarshal(body, &jsonResponse)
+
+	if err != nil {
+		return
+	}
+
+	// Validate the JWT Token
+	c, err := p.validateJwtTokenAndGetClaims(jsonResponse.AccessToken)
+	//token, err := jwt.ParseWithClaims(jsonResponse.AccessToken, &dropsolidJwtClaims{}, p.getPublicKeyFromJwtBearerVerfifier)
+	// If the JWT validation fails, something is really wrong. 
+	// Do not allow to continue.
+	if (err != nil) {
+		return
+	}
+	claims := c.(*dropsolidJwtClaims)
+	if (err != nil) {
+		return
+	}
+	// Check the expiration date in the JWT
+	// Decode the JWT token data.
+	//claims := token.Claims.(*dropsolidJwtClaims)
+	// Check if it needs a refresh based on the JWT expiry date
+	t := time.Unix(claims.ExpiresAt, 0)
+
+	if err == nil {
+		s = &sessions.SessionState{
+			AccessToken: jsonResponse.AccessToken,
+			RefreshToken: jsonResponse.RefreshToken,
+			CreatedAt:    time.Now(),
+			ExpiresOn:    t,
+		}
+		return
+	}
+
+	var v url.Values
+	v, err = url.ParseQuery(string(body))
+	if err != nil {
+		return
+	}
+	if a := v.Get("access_token"); a != "" {
+		s = &sessions.SessionState{AccessToken: a, CreatedAt: time.Now()}
+	} else {
+		err = fmt.Errorf("no access token found %s", body)
+	}
+	return
+}
+
+/*func (p *DropsolidProvider) getPublicKeyFromJwtBearerVerfifier(token *jwt.Token) (interface{}, error) {
+	// @Todo, refactor this to use the p.JwtBearerVerifiers data.
+	resp, myerr := http.Get(p.PubJWKURL.String())
+	if myerr != nil {
+		return nil, myerr
+	}
+	if resp.StatusCode != 200 {
+		myerr = fmt.Errorf("got %d from %q", resp.StatusCode, p.PubJWKURL.String())
+		return nil, myerr
+	}
+	body, myerr := ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+	if myerr != nil {
+		return nil, myerr
+	}
+
+	var pubkeys jose.JSONWebKeySet
+	myerr = json.Unmarshal(body, &pubkeys)
+	if myerr != nil {
+		return nil, myerr
+	}
+	pubkey := pubkeys.Keys[0]
+	return pubkey.Key, nil
+}*/
+
+// RefreshSessionIfNeeded checks if the session has expired and uses the
+// RefreshToken to fetch a new ID token if required
+func (p *DropsolidProvider) RefreshSessionIfNeeded(s *sessions.SessionState) (bool, error) {
+	// do not refresh when there is no session, when the session is not expired or when the token is seen as valid.
+	// The session stays valid.
+	if s == nil || s.ExpiresOn.After(time.Now()) || s.RefreshToken == "" {
+		return false, nil
+	}
+
+	newToken, newRefreshToken, err := p.redeemRefreshToken(s.RefreshToken)
+	if err != nil {
+		return false, err
+	}
+
+	// Validate the JWT Token
+	c, err := p.validateJwtTokenAndGetClaims(newToken)
+	// If the JWT validation fails, something is really wrong. 
+	// Do not allow to continue.
+	if (err != nil) {
+		return false, err
+	}
+	claims := c.(*dropsolidJwtClaims)
+	if (err != nil) {
+		return false, err
+	}
+	// Check the expiration date in the JWT
+	// Decode the JWT token data.
+	t := time.Unix(claims.ExpiresAt, 0)
+	origExpiration := s.ExpiresOn
+	s.AccessToken = newToken
+	s.RefreshToken = newRefreshToken
+	s.ExpiresOn = t
+	logger.Printf("Refreshed access token %s (expired on %s)", s, origExpiration)
+
+	return true, nil
+}
+
+func (p *DropsolidProvider) redeemRefreshToken(refreshToken string) (newToken string, newRefreshToken string, err error) {
+	params := url.Values{}
+	params.Add("client_id", p.ClientID)
+	params.Add("client_secret", p.ClientSecret)
+	params.Add("refresh_token", refreshToken)
+	params.Add("grant_type", "refresh_token")
+	var req *http.Request
+	req, err = http.NewRequest("POST", p.RedeemURL.String(), bytes.NewBufferString(params.Encode()))
+	if err != nil {
+		return
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return
+	}
+	var body []byte
+	body, err = ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return
+	}
+
+	if resp.StatusCode != 200 {
+		err = fmt.Errorf("got %d from %q %s", resp.StatusCode, p.RedeemURL.String(), body)
+		return
+	}
+
+	var data struct {
+		AccessToken string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`		
+		ExpiresIn   int64  `json:"expires_in"`
+	}
+	err = json.Unmarshal(body, &data)
+	if err != nil {
+		return
+	}
+	newToken = data.AccessToken
+	newRefreshToken = data.RefreshToken
+	// we ignore ExpiresIn in favor of the data in the JWT token.
+	return
+}
+
+func (p *DropsolidProvider) validateJwtTokenAndGetClaims(rawBearerToken string) (interface{}, error) {
+	ctx := context.Background()
+	for _, verifier := range p.JwtBearerVerifiers {
+		bearerToken, err := verifier.Verify(ctx, rawBearerToken)
+
+		if err != nil {
+			logger.Printf("failed to verify bearer token: %v", err)
+			continue
+		}
+
+		var claims dropsolidJwtClaims
+		if err := bearerToken.Claims(&claims); err != nil {
+			return nil, fmt.Errorf("failed to parse bearer token claims: %v", err)
+		}
+
+		return claims, nil
+	}
+	return nil, fmt.Errorf("failed to process the raw bearer token or there were no bearer verifiers present")
+}
+
+// GetJwtSession loads a session based on a JWT token in the authorization header.
+func (p *DropsolidProvider) GetJwtSession(rawBearerToken string) (*sessions.SessionState, error) {
+	// Validate the JWT Token
+	c, err := p.validateJwtTokenAndGetClaims(rawBearerToken)
+	if (err != nil) {
+		return nil, err
+	}
+
+	claims := c.(*dropsolidJwtClaims)
+	if (err != nil) {
+		return nil, err
+	}
+
+	// Check the expiration date in the JWT
+	t := time.Unix(claims.ExpiresAt, 0)
+	session := &sessions.SessionState{
+		AccessToken:  rawBearerToken,
+		CreatedAt:    time.Now(),
+		ExpiresOn:    t,
+		User:         claims.Subject,
+	}
+
+	// Get email address
+	email, err := p.GetEmailAddress(session)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve email")
+	}
+	session.Email = email
+	return session, nil
 }

--- a/providers/dropsolid.go
+++ b/providers/dropsolid.go
@@ -203,13 +203,13 @@ func (p *DropsolidProvider) Redeem(redirectURL, code string) (s *sessions.Sessio
 	if (err != nil) {
 		return
 	}
-	claims := c.(*dropsolidJwtClaims)
+	claims := c.(dropsolidJwtClaims)
 	if (err != nil) {
 		return
 	}
 	// Check the expiration date in the JWT
 	// Decode the JWT token data.
-	//claims := token.Claims.(*dropsolidJwtClaims)
+	//claims := token.Claims.(dropsolidJwtClaims)
 	// Check if it needs a refresh based on the JWT expiry date
 	t := time.Unix(claims.ExpiresAt, 0)
 
@@ -370,7 +370,7 @@ func (p *DropsolidProvider) GetJwtSession(rawBearerToken string) (*sessions.Sess
 		return nil, err
 	}
 
-	claims := c.(*dropsolidJwtClaims)
+	claims := c.(dropsolidJwtClaims)
 	if (err != nil) {
 		return nil, err
 	}

--- a/providers/dropsolid.go
+++ b/providers/dropsolid.go
@@ -1,0 +1,101 @@
+package providers
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/pusher/oauth2_proxy/pkg/apis/sessions"
+	"github.com/pusher/oauth2_proxy/pkg/requests"
+)
+
+// DigitalOceanProvider represents a DigitalOcean based Identity Provider
+type DropsolidProvider struct {
+	*ProviderData
+}
+
+// NewDigitalOceanProvider initiates a new DigitalOceanProvider
+func NewDropsolidProvider(p *ProviderData) *DropsolidProvider {
+	p.ProviderName = "Dropsolid"
+	if p.LoginURL.String() == "" {
+		p.LoginURL = &url.URL{Scheme: "https",
+			Host: "platform.dropsolid.com",
+			Path: "/oauth/authorize",
+		}
+	}
+	if p.RedeemURL.String() == "" {
+		p.RedeemURL = &url.URL{Scheme: "https",
+			Host: "platform.dropsolid.com",
+			Path: "/oauth/token",
+		}
+	}
+	if p.ProfileURL.String() == "" {
+		p.ProfileURL = &url.URL{Scheme: "https",
+			Host: "platform.dropsolid.com",
+			Path: "/oauth/user.info",
+		}
+	}
+	if p.Scope == "" {
+		p.Scope = "openid"
+	}
+	return &DropsolidProvider{ProviderData: p}
+}
+
+func getDropsolidHeader(accessToken string) http.Header {
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
+	header.Set("Authorization", fmt.Sprintf("Bearer %s", accessToken))
+	return header
+}
+
+// GetUserName returns the Account user name
+func (p *DropsolidProvider) GetUserName(s *sessions.SessionState) (string, error) {
+	if s.AccessToken == "" {
+		return "", errors.New("missing access token")
+	}
+
+	req, err := http.NewRequest("GET", p.ProfileURL.String(), nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header = getDropsolidHeader(s.AccessToken)
+
+	json, err := requests.Request(req)
+	if err != nil {
+		return "", err
+	}
+
+	userId, err := json.GetPath("sub").String()
+
+	return userId, nil
+}
+
+
+// GetEmailAddress returns the Account email address
+func (p *DropsolidProvider) GetEmailAddress(s *sessions.SessionState) (string, error) {
+	if s.AccessToken == "" {
+		return "", errors.New("missing access token")
+	}
+	req, err := http.NewRequest("GET", p.ProfileURL.String(), nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header = getDropsolidHeader(s.AccessToken)
+
+	json, err := requests.Request(req)
+	if err != nil {
+		return "", err
+	}
+
+	email, err := json.GetPath("email").String()
+	if err != nil {
+		return "", err
+	}
+	return email, nil
+}
+
+// ValidateSessionState validates the AccessToken
+func (p *DropsolidProvider) ValidateSessionState(s *sessions.SessionState) bool {
+	return validateToken(p, s.AccessToken, getDropsolidHeader(s.AccessToken))
+}

--- a/providers/dropsolid.go
+++ b/providers/dropsolid.go
@@ -12,8 +12,6 @@ import (
 	"errors"
 	"context"
 
-	//"gopkg.in/square/go-jose.v2"
-	//"github.com/coreos/go-oidc"
 	"github.com/dgrijalva/jwt-go"
     "github.com/pusher/oauth2_proxy/pkg/logger"
 	"github.com/pusher/oauth2_proxy/pkg/apis/sessions"

--- a/providers/dropsolid.go
+++ b/providers/dropsolid.go
@@ -23,7 +23,6 @@ import (
 type DropsolidProvider struct {
 	*ProviderData
 	JWTKey    *rsa.PrivateKey
-//	PubJWKURL *url.URL
 }
 
 type dropsolidJwtClaims struct {

--- a/providers/dropsolid.go
+++ b/providers/dropsolid.go
@@ -23,7 +23,7 @@ import (
 type DropsolidProvider struct {
 	*ProviderData
 	JWTKey    *rsa.PrivateKey
-	PubJWKURL *url.URL
+//	PubJWKURL *url.URL
 }
 
 type dropsolidJwtClaims struct {
@@ -235,31 +235,6 @@ func (p *DropsolidProvider) Redeem(redirectURL, code string) (s *sessions.Sessio
 	}
 	return
 }
-
-/*func (p *DropsolidProvider) getPublicKeyFromJwtBearerVerfifier(token *jwt.Token) (interface{}, error) {
-	// @Todo, refactor this to use the p.JwtBearerVerifiers data.
-	resp, myerr := http.Get(p.PubJWKURL.String())
-	if myerr != nil {
-		return nil, myerr
-	}
-	if resp.StatusCode != 200 {
-		myerr = fmt.Errorf("got %d from %q", resp.StatusCode, p.PubJWKURL.String())
-		return nil, myerr
-	}
-	body, myerr := ioutil.ReadAll(resp.Body)
-	resp.Body.Close()
-	if myerr != nil {
-		return nil, myerr
-	}
-
-	var pubkeys jose.JSONWebKeySet
-	myerr = json.Unmarshal(body, &pubkeys)
-	if myerr != nil {
-		return nil, myerr
-	}
-	pubkey := pubkeys.Keys[0]
-	return pubkey.Key, nil
-}*/
 
 // RefreshSessionIfNeeded checks if the session has expired and uses the
 // RefreshToken to fetch a new ID token if required

--- a/providers/dropsolid.go
+++ b/providers/dropsolid.go
@@ -190,7 +190,7 @@ func (p *DropsolidProvider) Redeem(redirectURL, code string) (s *sessions.Sessio
 
 	// Validate the JWT Token
 	c, err := p.validateJwtTokenAndGetClaims(jsonResponse.AccessToken)
-	//token, err := jwt.ParseWithClaims(jsonResponse.AccessToken, &dropsolidJwtClaims{}, p.getPublicKeyFromJwtBearerVerfifier)
+
 	// If the JWT validation fails, something is really wrong.
 	// Do not allow to continue.
 	if err != nil {
@@ -200,9 +200,6 @@ func (p *DropsolidProvider) Redeem(redirectURL, code string) (s *sessions.Sessio
 	if err != nil {
 		return
 	}
-	// Check the expiration date in the JWT
-	// Decode the JWT token data.
-	//claims := token.Claims.(dropsolidJwtClaims)
 	// Check if it needs a refresh based on the JWT expiry date
 	t := time.Unix(claims.ExpiresAt, 0)
 

--- a/providers/dropsolid_test.go
+++ b/providers/dropsolid_test.go
@@ -28,7 +28,7 @@ func testDropsolidProvider(hostname string) *DropsolidProvider {
 }
 
 func testDropsolidBackend(payload string) *httptest.Server {
-	path := "/v2/account"
+	path := "/oauth/user.info"
 
 	return httptest.NewServer(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
@@ -47,15 +47,15 @@ func TestDropsolidProviderDefaults(t *testing.T) {
 	p := testDropsolidProvider("")
 	assert.NotEqual(t, nil, p)
 	assert.Equal(t, "Dropsolid", p.Data().ProviderName)
-	assert.Equal(t, "https://cloud.Dropsolid.com/v1/oauth/authorize",
+	assert.Equal(t, "https://platform.dropsolid.com/oauth/authorize",
 		p.Data().LoginURL.String())
-	assert.Equal(t, "https://cloud.Dropsolid.com/v1/oauth/token",
+	assert.Equal(t, "https://platform.dropsolid.com/oauth/token",
 		p.Data().RedeemURL.String())
-	assert.Equal(t, "https://api.Dropsolid.com/v2/account",
+	assert.Equal(t, "https://platform.dropsolid.com/oauth/user.info",
 		p.Data().ProfileURL.String())
-	assert.Equal(t, "https://api.Dropsolid.com/v2/account",
+	assert.Equal(t, "https://platform.dropsolid.com/oauth/user.info",
 		p.Data().ValidateURL.String())
-	assert.Equal(t, "read", p.Data().Scope)
+	assert.Equal(t, "openid email", p.Data().Scope)
 }
 
 func TestDropsolidProviderOverrides(t *testing.T) {
@@ -92,7 +92,7 @@ func TestDropsolidProviderOverrides(t *testing.T) {
 }
 
 func TestDropsolidProviderGetEmailAddress(t *testing.T) {
-	b := testDropsolidBackend(`{"account": {"email": "user@example.com"}}`)
+	b := testDropsolidBackend(`{"sub": "23", "email":"user@example.com"}`)
 	defer b.Close()
 
 	bURL, _ := url.Parse(b.URL)

--- a/providers/dropsolid_test.go
+++ b/providers/dropsolid_test.go
@@ -1,0 +1,134 @@
+package providers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/pusher/oauth2_proxy/pkg/apis/sessions"
+	"github.com/stretchr/testify/assert"
+)
+
+func testDropsolidProvider(hostname string) *DropsolidProvider {
+	p := NewDropsolidProvider(
+		&ProviderData{
+			ProviderName: "",
+			LoginURL:     &url.URL{},
+			RedeemURL:    &url.URL{},
+			ProfileURL:   &url.URL{},
+			ValidateURL:  &url.URL{},
+			Scope:        ""})
+	if hostname != "" {
+		updateURL(p.Data().LoginURL, hostname)
+		updateURL(p.Data().RedeemURL, hostname)
+		updateURL(p.Data().ProfileURL, hostname)
+	}
+	return p
+}
+
+func testDropsolidBackend(payload string) *httptest.Server {
+	path := "/v2/account"
+
+	return httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != path {
+				w.WriteHeader(404)
+			} else if r.Header.Get("Authorization") != "Bearer imaginary_access_token" {
+				w.WriteHeader(403)
+			} else {
+				w.WriteHeader(200)
+				w.Write([]byte(payload))
+			}
+		}))
+}
+
+func TestDropsolidProviderDefaults(t *testing.T) {
+	p := testDropsolidProvider("")
+	assert.NotEqual(t, nil, p)
+	assert.Equal(t, "Dropsolid", p.Data().ProviderName)
+	assert.Equal(t, "https://cloud.Dropsolid.com/v1/oauth/authorize",
+		p.Data().LoginURL.String())
+	assert.Equal(t, "https://cloud.Dropsolid.com/v1/oauth/token",
+		p.Data().RedeemURL.String())
+	assert.Equal(t, "https://api.Dropsolid.com/v2/account",
+		p.Data().ProfileURL.String())
+	assert.Equal(t, "https://api.Dropsolid.com/v2/account",
+		p.Data().ValidateURL.String())
+	assert.Equal(t, "read", p.Data().Scope)
+}
+
+func TestDropsolidProviderOverrides(t *testing.T) {
+	p := NewDropsolidProvider(
+		&ProviderData{
+			LoginURL: &url.URL{
+				Scheme: "https",
+				Host:   "example.com",
+				Path:   "/oauth/auth"},
+			RedeemURL: &url.URL{
+				Scheme: "https",
+				Host:   "example.com",
+				Path:   "/oauth/token"},
+			ProfileURL: &url.URL{
+				Scheme: "https",
+				Host:   "example.com",
+				Path:   "/oauth/profile"},
+			ValidateURL: &url.URL{
+				Scheme: "https",
+				Host:   "example.com",
+				Path:   "/oauth/tokeninfo"},
+			Scope: "profile"})
+	assert.NotEqual(t, nil, p)
+	assert.Equal(t, "Dropsolid", p.Data().ProviderName)
+	assert.Equal(t, "https://example.com/oauth/auth",
+		p.Data().LoginURL.String())
+	assert.Equal(t, "https://example.com/oauth/token",
+		p.Data().RedeemURL.String())
+	assert.Equal(t, "https://example.com/oauth/profile",
+		p.Data().ProfileURL.String())
+	assert.Equal(t, "https://example.com/oauth/tokeninfo",
+		p.Data().ValidateURL.String())
+	assert.Equal(t, "profile", p.Data().Scope)
+}
+
+func TestDropsolidProviderGetEmailAddress(t *testing.T) {
+	b := testDropsolidBackend(`{"account": {"email": "user@example.com"}}`)
+	defer b.Close()
+
+	bURL, _ := url.Parse(b.URL)
+	p := testDropsolidProvider(bURL.Host)
+
+	session := &sessions.SessionState{AccessToken: "imaginary_access_token"}
+	email, err := p.GetEmailAddress(session)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "user@example.com", email)
+}
+
+func TestDropsolidProviderGetEmailAddressFailedRequest(t *testing.T) {
+	b := testDropsolidBackend("unused payload")
+	defer b.Close()
+
+	bURL, _ := url.Parse(b.URL)
+	p := testDropsolidProvider(bURL.Host)
+
+	// We'll trigger a request failure by using an unexpected access
+	// token. Alternatively, we could allow the parsing of the payload as
+	// JSON to fail.
+	session := &sessions.SessionState{AccessToken: "unexpected_access_token"}
+	email, err := p.GetEmailAddress(session)
+	assert.NotEqual(t, nil, err)
+	assert.Equal(t, "", email)
+}
+
+func TestDropsolidProviderGetEmailAddressEmailNotPresentInPayload(t *testing.T) {
+	b := testDropsolidBackend("{\"foo\": \"bar\"}")
+	defer b.Close()
+
+	bURL, _ := url.Parse(b.URL)
+	p := testDropsolidProvider(bURL.Host)
+
+	session := &sessions.SessionState{AccessToken: "imaginary_access_token"}
+	email, err := p.GetEmailAddress(session)
+	assert.NotEqual(t, nil, err)
+	assert.Equal(t, "", email)
+}

--- a/providers/provider_data.go
+++ b/providers/provider_data.go
@@ -5,24 +5,25 @@ import (
 	"github.com/pusher/oauth2_proxy/pkg/logger"
 	"io/ioutil"
 	"net/url"
+
 	oidc "github.com/coreos/go-oidc"
 )
 
 // ProviderData contains information required to configure all implementations
 // of OAuth2 providers
 type ProviderData struct {
-	ProviderName      string
-	ClientID          string
-	ClientSecret      string
+	ProviderName       string
+	ClientID           string
+	ClientSecret       string
 	ClientSecretFile  string
-	LoginURL          *url.URL
-	RedeemURL         *url.URL
-	ProfileURL        *url.URL
-	ProtectedResource *url.URL
-	ValidateURL       *url.URL
-	Scope             string
-	ApprovalPrompt    string
-    JwtBearerVerifiers []*oidc.IDTokenVerifier
+	LoginURL           *url.URL
+	RedeemURL          *url.URL
+	ProfileURL         *url.URL
+	ProtectedResource  *url.URL
+	ValidateURL        *url.URL
+	Scope              string
+	ApprovalPrompt     string
+	JwtBearerVerifiers []*oidc.IDTokenVerifier
 }
 
 // Data returns the ProviderData

--- a/providers/provider_data.go
+++ b/providers/provider_data.go
@@ -15,7 +15,7 @@ type ProviderData struct {
 	ProviderName       string
 	ClientID           string
 	ClientSecret       string
-	ClientSecretFile  string
+	ClientSecretFile   string
 	LoginURL           *url.URL
 	RedeemURL          *url.URL
 	ProfileURL         *url.URL

--- a/providers/provider_data.go
+++ b/providers/provider_data.go
@@ -5,6 +5,7 @@ import (
 	"github.com/pusher/oauth2_proxy/pkg/logger"
 	"io/ioutil"
 	"net/url"
+	oidc "github.com/coreos/go-oidc"
 )
 
 // ProviderData contains information required to configure all implementations
@@ -21,6 +22,7 @@ type ProviderData struct {
 	ValidateURL       *url.URL
 	Scope             string
 	ApprovalPrompt    string
+    JwtBearerVerifiers []*oidc.IDTokenVerifier
 }
 
 // Data returns the ProviderData

--- a/providers/provider_default.go
+++ b/providers/provider_default.go
@@ -2,17 +2,17 @@ package providers
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/pusher/oauth2_proxy/pkg/apis/sessions"
+	"github.com/pusher/oauth2_proxy/pkg/encryption"
+	"github.com/pusher/oauth2_proxy/pkg/logger"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"time"
-	"context"
-	"github.com/pusher/oauth2_proxy/pkg/apis/sessions"
-	"github.com/pusher/oauth2_proxy/pkg/encryption"
-    "github.com/pusher/oauth2_proxy/pkg/logger"
 )
 
 // Redeem provides a default implementation of the OAuth2 token redemption process
@@ -137,13 +137,12 @@ func (p *ProviderData) RefreshSessionIfNeeded(s *sessions.SessionState) (bool, e
 	return false, nil
 }
 
-
 // GetJwtSession loads a session based on a JWT token in the authorization header.
 func (p *ProviderData) GetJwtSession(rawBearerToken string) (*sessions.SessionState, error) {
 	ctx := context.Background()
 	var session *sessions.SessionState
 
-	if (p == nil) {
+	if p == nil {
 		return nil, fmt.Errorf("No JwtBearerVerifiers found")
 	}
 

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -44,6 +44,8 @@ func New(provider string, p *ProviderData) Provider {
 		return NewNextcloudProvider(p)
 	case "digitalocean":
 		return NewDigitalOceanProvider(p)
+	case "dropsolid":
+		return NewDropsolidProvider(p)		
 	default:
 		return NewGoogleProvider(p)
 	}

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -17,6 +17,7 @@ type Provider interface {
 	RefreshSessionIfNeeded(*sessions.SessionState) (bool, error)
 	SessionFromCookie(string, *encryption.Cipher) (*sessions.SessionState, error)
 	CookieForSession(*sessions.SessionState, *encryption.Cipher) (string, error)
+	GetJwtSession(string) (*sessions.SessionState, error)
 }
 
 // New provides a new Provider based on the configured provider string

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -46,7 +46,7 @@ func New(provider string, p *ProviderData) Provider {
 	case "digitalocean":
 		return NewDigitalOceanProvider(p)
 	case "dropsolid":
-		return NewDropsolidProvider(p)		
+		return NewDropsolidProvider(p)
 	default:
 		return NewGoogleProvider(p)
 	}


### PR DESCRIPTION
## Description

This change adds a provider for the OAuth service of Dropsolid. When adding the provider I noticed that GetJwtSession was not overridable per provider and this was necessary as the JWT token structure was not inheritable and extendable. In our particular case we needed to convert the JWT token to the dropsolidJwtClaims struct so that we have access to the scopes parameter. 

## Motivation and Context

It solves 2 problems at once. 
1) It adds Dropsolid as a provider
2) It abstracts the GetJwtSession's claim extraction to a per provider logic, but with a sane default.
I know that might not be advisable so I'm open to splitting it up as soon as I get some feedback on the approach.

It does fix an open issue or at least a suggestion that was raised by @xynova https://github.com/pusher/oauth2_proxy/issues/18#issuecomment-509883257

"It might be interesting to maybe have the GetJwtSession's claim extraction to be configurable via provider in the same way p.provider.GetEmailAddress(s) is, so that sub can be set from upn instead?"

## How Has This Been Tested?

We're testing this as we speak but have been able to get multiple login flows working. The options to run them are as follows:

 ./oauth2_proxy -provider=dropsolid -client-id=abcd -client-secret=abcd -cookie-secret=abcd -email-domain=* -upstream="http://localhost:portnumber" -pass-access-token -pass-user-headers --pass-host-header=false --skip-jwt-bearer-tokens=true -extra-jwt-issuers=dropsolidurl=abcd

This is tested on OSX & Ubuntu. Using go 1.13. Also make test succeeds on both systems

## Checklist:

- [X] My change requires a change to the documentation or CHANGELOG.
- [X] I have updated the documentation/CHANGELOG accordingly.
- [X] I have created a feature (non-master) branch for my PR. (I missed this in my previous PR, apologies)

I did not change the documentation yet. Awaiting more feedback.