### PR TITLE
Allow basic auth to be configured on the upstream

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -113,6 +113,7 @@ An example [oauth2_proxy.cfg]({{ site.gitweb }}/contrib/oauth2_proxy.cfg.example
 | `-tls-cert-file` | string | path to certificate file | |
 | `-tls-key-file` | string | path to private key file | |
 | `-upstream` | string \| list | the http url(s) of the upstream endpoint, file:// paths for static files or `static://<status_code>` for static response. Routing is based on the path | |
+| `-upstream-authorization-header` | string | The Authorization header that needs to be set towards the upstream. Useful in for example accessing services with a shared secret like Basic Auth | |
 | `-validate-url` | string | Access token validation endpoint | |
 | `-version` | n/a | print version string | |
 | `-whitelist-domain` | string \| list | allowed domains for redirection after authentication. Prefix domain with a `.` to allow subdomains (eg `.example.com`) | |

--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ func main() {
 	flagSet.String("tls-cert-file", "", "path to certificate file")
 	flagSet.String("tls-key-file", "", "path to private key file")
 	flagSet.String("redirect-url", "", "the OAuth Redirect URL. ie: \"https://internalapp.yourcompany.com/oauth2/callback\"")
+	flagSet.String("upstream-authorization-header", "", "the content of the authorization header that needs to be set towards the upstream resource")
 	flagSet.Bool("set-xauthrequest", false, "set X-Auth-Request-User and X-Auth-Request-Email response headers (useful in Nginx auth_request mode)")
 	flagSet.Var(&upstreams, "upstream", "the http url(s) of the upstream endpoint, file:// paths for static files or static://<status_code> for static response. Routing is based on the path")
 	flagSet.Bool("pass-basic-auth", true, "pass HTTP Basic Auth, X-Forwarded-User and X-Forwarded-Email information to upstream")

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -81,32 +81,33 @@ type OAuthProxy struct {
 	AuthOnlyPath      string
 	UserInfoPath      string
 
-	redirectURL          *url.URL // the url to receive requests at
-	whitelistDomains     []string
-	provider             providers.Provider
-	providerNameOverride string
-	sessionStore         sessionsapi.SessionStore
-	ProxyPrefix          string
-	SignInMessage        string
-	HtpasswdFile         *HtpasswdFile
-	DisplayHtpasswdForm  bool
-	serveMux             http.Handler
-	SetXAuthRequest      bool
-	PassBasicAuth        bool
-	SkipProviderButton   bool
-	PassUserHeaders      bool
-	BasicAuthPassword    string
-	PassAccessToken      bool
-	SetAuthorization     bool
-	PassAuthorization    bool
-	skipAuthRegex        []string
-	skipAuthPreflight    bool
-	skipJwtBearerTokens  bool
-	jwtBearerVerifiers   []*oidc.IDTokenVerifier
-	compiledRegex        []*regexp.Regexp
-	templates            *template.Template
-	Banner               string
-	Footer               string
+	redirectURL                 *url.URL // the url to receive requests at
+	whitelistDomains            []string
+	provider                    providers.Provider
+	providerNameOverride        string
+	sessionStore                sessionsapi.SessionStore
+	ProxyPrefix                 string
+	SignInMessage               string
+	HtpasswdFile                *HtpasswdFile
+	DisplayHtpasswdForm         bool
+	serveMux                    http.Handler
+	SetXAuthRequest             bool
+	UpstreamAuthorizationHeader string
+	PassBasicAuth               bool
+	SkipProviderButton          bool
+	PassUserHeaders             bool
+	BasicAuthPassword           string
+	PassAccessToken             bool
+	SetAuthorization            bool
+	PassAuthorization           bool
+	skipAuthRegex               []string
+	skipAuthPreflight           bool
+	skipJwtBearerTokens         bool
+	jwtBearerVerifiers          []*oidc.IDTokenVerifier
+	compiledRegex               []*regexp.Regexp
+	templates                   *template.Template
+	Banner                      string
+	Footer                      string
 }
 
 // UpstreamProxy represents an upstream server to proxy to
@@ -286,29 +287,30 @@ func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 		AuthOnlyPath:      fmt.Sprintf("%s/auth", opts.ProxyPrefix),
 		UserInfoPath:      fmt.Sprintf("%s/userinfo", opts.ProxyPrefix),
 
-		ProxyPrefix:          opts.ProxyPrefix,
-		provider:             opts.provider,
-		providerNameOverride: opts.ProviderName,
-		sessionStore:         opts.sessionStore,
-		serveMux:             serveMux,
-		redirectURL:          redirectURL,
-		whitelistDomains:     opts.WhitelistDomains,
-		skipAuthRegex:        opts.SkipAuthRegex,
-		skipAuthPreflight:    opts.SkipAuthPreflight,
-		skipJwtBearerTokens:  opts.SkipJwtBearerTokens,
-		jwtBearerVerifiers:   opts.jwtBearerVerifiers,
-		compiledRegex:        opts.CompiledRegex,
-		SetXAuthRequest:      opts.SetXAuthRequest,
-		PassBasicAuth:        opts.PassBasicAuth,
-		PassUserHeaders:      opts.PassUserHeaders,
-		BasicAuthPassword:    opts.BasicAuthPassword,
-		PassAccessToken:      opts.PassAccessToken,
-		SetAuthorization:     opts.SetAuthorization,
-		PassAuthorization:    opts.PassAuthorization,
-		SkipProviderButton:   opts.SkipProviderButton,
-		templates:            loadTemplates(opts.CustomTemplatesDir),
-		Banner:               opts.Banner,
-		Footer:               opts.Footer,
+		ProxyPrefix:                 opts.ProxyPrefix,
+		provider:                    opts.provider,
+		providerNameOverride:        opts.ProviderName,
+		sessionStore:                opts.sessionStore,
+		serveMux:                    serveMux,
+		redirectURL:                 redirectURL,
+		whitelistDomains:            opts.WhitelistDomains,
+		skipAuthRegex:               opts.SkipAuthRegex,
+		skipAuthPreflight:           opts.SkipAuthPreflight,
+		skipJwtBearerTokens:         opts.SkipJwtBearerTokens,
+		jwtBearerVerifiers:          opts.jwtBearerVerifiers,
+		compiledRegex:               opts.CompiledRegex,
+		SetXAuthRequest:             opts.SetXAuthRequest,
+		PassBasicAuth:               opts.PassBasicAuth,
+		PassUserHeaders:             opts.PassUserHeaders,
+		BasicAuthPassword:           opts.BasicAuthPassword,
+		PassAccessToken:             opts.PassAccessToken,
+		SetAuthorization:            opts.SetAuthorization,
+		UpstreamAuthorizationHeader: opts.UpstreamAuthorizationHeader,
+		PassAuthorization:           opts.PassAuthorization,
+		SkipProviderButton:          opts.SkipProviderButton,
+		templates:                   loadTemplates(opts.CustomTemplatesDir),
+		Banner:                      opts.Banner,
+		Footer:                      opts.Footer,
 	}
 }
 
@@ -977,6 +979,11 @@ func (p *OAuthProxy) addHeadersForProxying(rw http.ResponseWriter, req *http.Req
 		} else {
 			rw.Header().Del("Authorization")
 		}
+	}
+
+	if len(p.UpstreamAuthorizationHeader) > 0 {
+		logger.Printf("setting basic auth")
+		req.Header["Authorization"] = []string{fmt.Sprintf("%s", p.UpstreamAuthorizationHeader)}
 	}
 
 	if session.Email == "" {

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -982,7 +982,6 @@ func (p *OAuthProxy) addHeadersForProxying(rw http.ResponseWriter, req *http.Req
 	}
 
 	if len(p.UpstreamAuthorizationHeader) > 0 {
-		logger.Printf("setting basic auth")
 		req.Header["Authorization"] = []string{fmt.Sprintf("%s", p.UpstreamAuthorizationHeader)}
 	}
 

--- a/options.go
+++ b/options.go
@@ -82,6 +82,7 @@ type Options struct {
 	SSLUpstreamInsecureSkipVerify bool          `flag:"ssl-upstream-insecure-skip-verify" cfg:"ssl_upstream_insecure_skip_verify" env:"OAUTH2_PROXY_SSL_UPSTREAM_INSECURE_SKIP_VERIFY"`
 	SetXAuthRequest               bool          `flag:"set-xauthrequest" cfg:"set_xauthrequest" env:"OAUTH2_PROXY_SET_XAUTHREQUEST"`
 	SetAuthorization              bool          `flag:"set-authorization-header" cfg:"set_authorization_header" env:"OAUTH2_PROXY_SET_AUTHORIZATION_HEADER"`
+	UpstreamAuthorizationHeader   string        `flag:"upstream-authorization-header" cfg:"upstream_authorization_header" env:"OAUTH2_PROXY_UPSTREAM_AUTHORIZATION_HEADER"`
 	PassAuthorization             bool          `flag:"pass-authorization-header" cfg:"pass_authorization_header" env:"OAUTH2_PROXY_PASS_AUTHORIZATION_HEADER"`
 	SkipAuthPreflight             bool          `flag:"skip-auth-preflight" cfg:"skip_auth_preflight" env:"OAUTH2_PROXY_SKIP_AUTH_PREFLIGHT"`
 	FlushInterval                 time.Duration `flag:"flush-interval" cfg:"flush_interval" env:"OAUTH2_PROXY_FLUSH_INTERVAL"`
@@ -168,6 +169,7 @@ func NewOptions() *Options {
 		PassAccessToken:                  false,
 		PassHostHeader:                   true,
 		SetAuthorization:                 false,
+		UpstreamAuthorizationHeader:      "",
 		PassAuthorization:                false,
 		ApprovalPrompt:                   "force",
 		InsecureOIDCAllowUnverifiedEmail: false,


### PR DESCRIPTION
When forwarding the request to an upstream, it is possible that this upstream has a required authorization header. The proxy currently has no way of setting the basic auth or any other authorization header.

## Description

Adds an option to set the upstream authorization header

## Motivation and Context

The upstream has a hard requirement (Apache Karaf) on a user and couldn't disable this user. We needed to set the Authorization header, eg Basic Auth. I wanted to make it configurable so that also Bearer or any other form is allowed as it is plain text. Use on your own risk. 

## How Has This Been Tested?

We're using this in production now as a fork and it works like magic

## Checklist:

- [X] My change requires a change to the documentation or CHANGELOG.
- [X] I have updated the documentation/CHANGELOG accordingly.
- [X] I have created a feature (non-master) branch for my PR.
