### PR TITLE
Allow OIDC library options to be passed through the CLI so that it becomes possible to skip JWT Client ID, Expiry date or Issuer verification

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -104,6 +104,9 @@ An example [oauth2_proxy.cfg]({{ site.gitweb }}/contrib/oauth2_proxy.cfg.example
 | `-skip-auth-preflight` | bool | will skip authentication for OPTIONS requests | false |
 | `-skip-auth-regex` | string | bypass authentication for requests paths that match (may be given multiple times) | |
 | `-skip-jwt-bearer-tokens` | bool | will skip requests that have verified JWT bearer tokens | false |
+| `-skip-jwt-clientid-check` | bool | will skip the client ID JWT verification that is enabled by default in the OIDC library used for JWT validation. | false |
+| `-skip-jwt-expiry-check` | bool | will skip the Expiry Date JWT verification that is enabled by default in the OIDC library used for JWT validation. | false |
+| `-skip-jwt-issuer-check` | bool | will skip the Issuer JWT verification that is enabled by default in the OIDC library used for JWT validation. | false |
 | `-skip-oidc-discovery` | bool | bypass OIDC endpoint discovery. `-login-url`, `-redeem-url` and `-oidc-jwks-url` must be configured in this case | false |
 | `-skip-provider-button` | bool | will skip sign-in-page to directly reach the next step: oauth/start | false |
 | `-ssl-insecure-skip-verify` | bool | skip validation of certificates presented when using HTTPS providers | false |

--- a/main.go
+++ b/main.go
@@ -54,6 +54,9 @@ func main() {
 	flagSet.Bool("ssl-upstream-insecure-skip-verify", false, "skip validation of certificates presented when using HTTPS upstreams")
 	flagSet.Duration("flush-interval", time.Duration(1)*time.Second, "period between response flushing when streaming responses")
 	flagSet.Bool("skip-jwt-bearer-tokens", false, "will skip requests that have verified JWT bearer tokens (default false)")
+	flagSet.Bool("skip-jwt-clientid-check", false, "will skip the client ID JWT verification that is enabled by default in the OIDC library used for JWT validation. (default false)")
+	flagSet.Bool("skip-jwt-expiry-check", false, "will skip the Expiry Date JWT verification that is enabled by default in the OIDC library used for JWT validation. (default false)")
+	flagSet.Bool("skip-jwt-issuer-check", false, "will skip the Issuer JWT verification that is enabled by default in the OIDC library used for JWT validation. (default false)")
 	flagSet.Var(&jwtIssuers, "extra-jwt-issuers", "if skip-jwt-bearer-tokens is set, a list of extra JWT issuer=audience pairs (where the issuer URL has a .well-known/openid-configuration or a .well-known/jwks.json)")
 
 	flagSet.Var(&emailDomains, "email-domain", "authenticate emails with the specified domain (may be given multiple times). Use * to authenticate any email")

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -102,6 +102,9 @@ type OAuthProxy struct {
 	skipAuthRegex        []string
 	skipAuthPreflight    bool
 	skipJwtBearerTokens  bool
+	SkipJwtClientIDCheck bool
+	SkipJwtExpiryCheck   bool
+	SkipJwtIssuerCheck   bool
 	jwtBearerVerifiers   []*oidc.IDTokenVerifier
 	compiledRegex        []*regexp.Regexp
 	templates            *template.Template
@@ -296,6 +299,9 @@ func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 		skipAuthRegex:        opts.SkipAuthRegex,
 		skipAuthPreflight:    opts.SkipAuthPreflight,
 		skipJwtBearerTokens:  opts.SkipJwtBearerTokens,
+		SkipJwtClientIDCheck: opts.SkipJwtClientIDCheck,
+		SkipJwtExpiryCheck:   opts.SkipJwtExpiryCheck,
+		SkipJwtIssuerCheck:   opts.SkipJwtIssuerCheck,
 		jwtBearerVerifiers:   opts.jwtBearerVerifiers,
 		compiledRegex:        opts.CompiledRegex,
 		SetXAuthRequest:      opts.SetXAuthRequest,

--- a/options.go
+++ b/options.go
@@ -541,6 +541,7 @@ func parseJwtIssuers(issuers []string, msgs []string) ([]jwtIssuer, []string) {
 func newVerifierFromJwtIssuer(jwtIssuer jwtIssuer) (*oidc.IDTokenVerifier, error) {
 	config := &oidc.Config{
 		ClientID: jwtIssuer.audience,
+                SkipClientIDCheck: true,
 	}
 	// Try as an OpenID Connect Provider first
 	var verifier *oidc.IDTokenVerifier


### PR DESCRIPTION
## Description

As we run the proxy as a pass-through reverse proxy, it does not make sense right now to verify the client ID as those are generated on the fly in our OAuth provider. It would mean that for every new client we need to add a extra-jwt-issuer command to the proxy without adding more security as in the next hop in the network we verify if the particular user is able to access a particular resource. 

These commands allow the skipping of all 3 skip options as defined in the OIDC verify options struct as seen here: https://github.com/coreos/go-oidc/blob/v2/verify.go#L73

## Motivation and Context

It's required to allow skipping is the client id verification in a JWT when this extra security is not necessary. 

## How Has This Been Tested?

We run the proxy with the following extra commands

-extra-jwt-issuers=https://ouroauthproviderplatform.com=not-applicable
-skip-jwt-clientid-check=true

It does allow the following two options as well

-skip-jwt-expiry-check=true|false (Highly unrecommended, perhaps for very very limited testing purposes)
-skip-jwt-issuer-check=true|false (Highly unrecommended, you always want to make sure the source of the JWT is as expected)

## Checklist:

- [] My change requires a change to the documentation or CHANGELOG.
- [] I have updated the documentation/CHANGELOG accordingly.
- [X] I have created a feature (non-master) branch for my PR.

I updated the documentation but not the changelog yet. Awaiting feedback.