### PR TITLE
Implement Gitea Provider with Username filter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ## Breaking Changes
 
 ## Changes since v5.0.0
-
+- [#410](https://github.com/pusher/oauth2_proxy/pull/410) Implement Gitea Provider with optional user filter (@igzsergiofernandez)
 - [#385](https://github.com/pusher/oauth2_proxy/pull/385) Use the `Authorization` header instead of `access_token` for refreshing GitHub Provider sessions (@ibuclaw)
 - [#372](https://github.com/pusher/oauth2_proxy/pull/372) Allow fallback to secondary verified email address in GitHub provider (@dmnemec)
 - [#335](https://github.com/pusher/oauth2_proxy/pull/335) OIDC Provider support for empty id_tokens in the access token refresh response (@howzat)

--- a/docs/2_auth.md
+++ b/docs/2_auth.md
@@ -15,6 +15,7 @@ Valid providers are :
 - [Azure](#azure-auth-provider)
 - [Facebook](#facebook-auth-provider)
 - [GitHub](#github-auth-provider)
+- [Gitea](#gitea-auth-provider)
 - [Keycloak](#keycloak-auth-provider)
 - [GitLab](#gitlab-auth-provider)
 - [LinkedIn](#linkedin-auth-provider)
@@ -105,6 +106,25 @@ If you are using GitHub enterprise, make sure you set the following to the appro
     -login-url="http(s)://<enterprise github host>/login/oauth/authorize"
     -redeem-url="http(s)://<enterprise github host>/login/oauth/access_token"
     -validate-url="http(s)://<enterprise github host>/api/v3"
+
+### Gitea Auth Provider
+
+1.  Create a new application: https://gitea.com/user/settings/applications
+2.  Under `Create a new OAuth2 Application` enter the correct `Redirect URI` ie `https://internal.yourcompany.com/oauth2/callback`
+
+The Gitea auth provider supports an additional parameter to restrict authentication access by username:
+
+    -gitea-user="<your gitea username>": restrict logins to a specific gitea username
+
+If you are using a private Gitea installation, make sure you set the following to the appropriate url:
+
+    -login-url="http(s)://<custom gitea host>/login/oauth/authorize"
+    -redeem-url="http(s)://<custom gitea host>/login/oauth/access_token"
+    -profile-url="http(s)://<custom gitea host>/api/v1/user"
+
+./oauth2_proxy -http-address=http://localhost:4000 -provider=gitea 
+ -redirect-url=http://localhost:4000/oauth2/callback   -profile-url=http://192.168.1.142:3000/api/v1/user -gitea-user=sergio
+
 
 ### Keycloak Auth Provider
 

--- a/main.go
+++ b/main.go
@@ -64,6 +64,7 @@ func main() {
 	flagSet.String("bitbucket-repository", "", "restrict logins to user with access to this repository")
 	flagSet.String("github-org", "", "restrict logins to members of this organisation")
 	flagSet.String("github-team", "", "restrict logins to members of this team")
+	flagSet.String("gitea-user", "", "restrict logins to a specific gitea username")
 	flagSet.String("gitlab-group", "", "restrict logins to members of this group")
 	flagSet.Var(&googleGroups, "google-group", "restrict logins to members of this google group (may be given multiple times).")
 	flagSet.String("google-admin-email", "", "the google admin to impersonate for api calls")

--- a/options.go
+++ b/options.go
@@ -52,6 +52,7 @@ type Options struct {
 	WhitelistDomains         []string `flag:"whitelist-domain" cfg:"whitelist_domains" env:"OAUTH2_PROXY_WHITELIST_DOMAINS"`
 	GitHubOrg                string   `flag:"github-org" cfg:"github_org" env:"OAUTH2_PROXY_GITHUB_ORG"`
 	GitHubTeam               string   `flag:"github-team" cfg:"github_team" env:"OAUTH2_PROXY_GITHUB_TEAM"`
+	GiteaUser                string   `flag:"gitea-user" cfg:"gitea-user" env:"OAUTH2_PROXY_GITEA_USER"`
 	GitLabGroup              string   `flag:"gitlab-group" cfg:"gitlab_group" env:"OAUTH2_PROXY_GITLAB_GROUP"`
 	GoogleGroups             []string `flag:"google-group" cfg:"google_group" env:"OAUTH2_PROXY_GOOGLE_GROUPS"`
 	GoogleAdminEmail         string   `flag:"google-admin-email" cfg:"google_admin_email" env:"OAUTH2_PROXY_GOOGLE_ADMIN_EMAIL"`
@@ -421,6 +422,10 @@ func parseProviderInfo(o *Options, msgs []string) []string {
 		p.SetOrgTeam(o.GitHubOrg, o.GitHubTeam)
 	case *providers.KeycloakProvider:
 		p.SetGroup(o.KeycloakGroup)
+	case *providers.GiteaProvider:
+		if o.GiteaUser != "" {
+			p.SetUser(o.GiteaUser)
+		}
 	case *providers.GoogleProvider:
 		if o.GoogleServiceAccountJSON != "" {
 			file, err := os.Open(o.GoogleServiceAccountJSON)

--- a/providers/gitea.go
+++ b/providers/gitea.go
@@ -1,0 +1,115 @@
+package providers
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/pusher/oauth2_proxy/pkg/apis/sessions"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+)
+
+// GiteaProvider represents an Gitea based Identity Provider
+type GiteaProvider struct {
+	*ProviderData
+	user string
+}
+
+// NewGiteaProvider initiates a new GiteaProvider
+func NewGiteaProvider(p *ProviderData) *GiteaProvider {
+	p.ProviderName = "Gitea"
+	if p.LoginURL == nil || p.LoginURL.String() == "" {
+		p.LoginURL = &url.URL{
+			Scheme: "https",
+			Host:   "gitea.com",
+			Path:   "/login/oauth/authorize",
+		}
+	}
+	if p.RedeemURL == nil || p.RedeemURL.String() == "" {
+		p.RedeemURL = &url.URL{
+			Scheme: "https",
+			Host:   "gitea.com",
+			Path:   "/login/oauth/access_token",
+		}
+	}
+	// ValidationURL is the API Base URL
+	if p.ValidateURL == nil || p.ValidateURL.String() == "" {
+		p.ValidateURL = &url.URL{
+			Scheme: "https",
+			Host:   "api.gitea.com",
+			Path:   "/",
+		}
+	}
+
+	if p.Scope == "" {
+		p.Scope = "user:email"
+	}
+
+	return &GiteaProvider{ProviderData: p}
+}
+
+func (p *GiteaProvider) SetUser(user string) {
+	p.user = user
+}
+
+type giteaUserInfo struct {
+	Username string `json:"username"`
+	Email    string `json:"email"`
+}
+
+func (p *GiteaProvider) getUserInfo(s *sessions.SessionState) (*giteaUserInfo, error) {
+
+	if s.AccessToken == "" {
+		return nil, errors.New("missing access token")
+	}
+
+	// Build user info url from login url of Gitea instance
+	userInfoURL := *p.LoginURL
+	userInfoURL.Path = "/api/v1/user"
+
+	req, err := http.NewRequest("GET", userInfoURL.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create user info request: %v", err)
+	}
+
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", s.AccessToken))
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to perform user info request: %v", err)
+	}
+	var body []byte
+	body, err = ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read user info response: %v", err)
+	}
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("got %d during user info request: %s", resp.StatusCode, body)
+	}
+
+	var userInfo giteaUserInfo
+	err = json.Unmarshal(body, &userInfo)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse user info: %v", err)
+	}
+
+	if p.user != "" && p.user != userInfo.Username {
+		return nil, fmt.Errorf("invalid username %s for this request", userInfo.Username)
+	}
+
+	return &userInfo, nil
+}
+
+func (p *GiteaProvider) GetEmailAddress(s *sessions.SessionState) (string, error) {
+
+	userInfo, err := p.getUserInfo(s)
+	if err != nil {
+		return "", err
+	}
+
+	return userInfo.Email, nil
+}

--- a/providers/gitea_test.go
+++ b/providers/gitea_test.go
@@ -1,0 +1,126 @@
+package providers
+
+import (
+	"github.com/pusher/oauth2_proxy/pkg/apis/sessions"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func testGiteaProvider(hostname string) *GiteaProvider {
+	p := NewGiteaProvider(
+		&ProviderData{
+			ProviderName: "",
+			LoginURL:     &url.URL{},
+			RedeemURL:    &url.URL{},
+			ProfileURL:   &url.URL{},
+			ValidateURL:  &url.URL{},
+			Scope:        ""})
+	if hostname != "" {
+		updateURL(p.Data().LoginURL, hostname)
+		updateURL(p.Data().RedeemURL, hostname)
+		updateURL(p.Data().ProfileURL, hostname)
+		updateURL(p.Data().ValidateURL, hostname)
+	}
+	return p
+}
+
+func testGiteaBackend(payload []string) *httptest.Server {
+	pathToQueryMap := map[string][]string{
+		"/api/v1/user": {""},
+	}
+
+	return httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			query, ok := pathToQueryMap[r.URL.Path]
+			validQuery := false
+			index := 0
+			for i, q := range query {
+				if q == r.URL.RawQuery {
+					validQuery = true
+					index = i
+				}
+			}
+			if !ok {
+				w.WriteHeader(404)
+			} else if !validQuery {
+				w.WriteHeader(404)
+			} else {
+				w.WriteHeader(200)
+				w.Write([]byte(payload[index]))
+			}
+		}))
+}
+
+func TestGiteaProviderDefaults(t *testing.T) {
+	p := testGiteaProvider("")
+	assert.NotEqual(t, nil, p)
+	assert.Equal(t, "Gitea", p.Data().ProviderName)
+	assert.Equal(t, "https://gitea.com/login/oauth/authorize",
+		p.Data().LoginURL.String())
+	assert.Equal(t, "https://gitea.com/login/oauth/access_token",
+		p.Data().RedeemURL.String())
+	assert.Equal(t, "https://api.gitea.com/",
+		p.Data().ValidateURL.String())
+	assert.Equal(t, "user:email", p.Data().Scope)
+}
+
+func TestGiteaProviderOverrides(t *testing.T) {
+	p := NewGiteaProvider(
+		&ProviderData{
+			LoginURL: &url.URL{
+				Scheme: "https",
+				Host:   "example.com",
+				Path:   "/login/oauth/authorize"},
+			RedeemURL: &url.URL{
+				Scheme: "https",
+				Host:   "example.com",
+				Path:   "/login/oauth/access_token"},
+			ValidateURL: &url.URL{
+				Scheme: "https",
+				Host:   "api.example.com",
+				Path:   "/"},
+			Scope: "profile"})
+	assert.NotEqual(t, nil, p)
+	assert.Equal(t, "Gitea", p.Data().ProviderName)
+	assert.Equal(t, "https://example.com/login/oauth/authorize",
+		p.Data().LoginURL.String())
+	assert.Equal(t, "https://example.com/login/oauth/access_token",
+		p.Data().RedeemURL.String())
+	assert.Equal(t, "https://api.example.com/",
+		p.Data().ValidateURL.String())
+	assert.Equal(t, "profile", p.Data().Scope)
+}
+
+func TestGiteaProviderGetEmailAddress(t *testing.T) {
+	b := testGiteaBackend([]string{`{"email": "michael.bland@gsa.gov", "username": "mbland"}`})
+	defer b.Close()
+
+	bURL, _ := url.Parse(b.URL)
+	p := testGiteaProvider(bURL.Host)
+
+	session := CreateAuthorizedSession()
+	email, err := p.GetEmailAddress(session)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "michael.bland@gsa.gov", email)
+}
+
+// Note that trying to trigger the "failed building request" case is not
+// practical, since the only way it can fail is if the URL fails to parse.
+func TestGiteaProviderGetEmailAddressFailedRequest(t *testing.T) {
+	b := testGiteaBackend([]string{"unused payload"})
+	defer b.Close()
+
+	bURL, _ := url.Parse(b.URL)
+	p := testGiteaProvider(bURL.Host)
+
+	// We'll trigger a request failure by using an unexpected access
+	// token. Alternatively, we could allow the parsing of the payload as
+	// JSON to fail.
+	session := &sessions.SessionState{AccessToken: "unexpected_access_token"}
+	email, err := p.GetEmailAddress(session)
+	assert.NotEqual(t, nil, err)
+	assert.Equal(t, "", email)
+}

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -28,6 +28,8 @@ func New(provider string, p *ProviderData) Provider {
 		return NewFacebookProvider(p)
 	case "github":
 		return NewGitHubProvider(p)
+	case "gitea":
+		return NewGiteaProvider(p)
 	case "keycloak":
 		return NewKeycloakProvider(p)
 	case "azure":


### PR DESCRIPTION
Implement Gitea Provider as a new provider with a new parameter to allow filter by username

## Description

* Add Gitea generic providers.go
* Add custom param to allow only one user

## Motivation and Context

We needed to add our Gitea server as an OAuth2 provider.
Also, we need to control access per user, so we've added a new **optional** CLI parameter to restrict access to a single user

This is related to issue #217 

## How Has This Been Tested?

We tested it with gitea.com and our own on-premise installation. Also, we added unit tests on Gitea provider.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
