### PR TITLE
Allow multiple cookie domains to be specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ## Changes since v5.1.0
 
+- [#474](https://github.com/oauth2-proxy/oauth2-proxy/pull/474) Always log hasMember request error object (@jbielick)
 - [#468](https://github.com/oauth2-proxy/oauth2-proxy/pull/468) Implement graceful shutdown and propagate request context (@johejo)
 - [#464](https://github.com/oauth2-proxy/oauth2-proxy/pull/464) Migrate to oauth2-proxy/oauth2-proxy (@JoelSpeed)
   - Project renamed from `pusher/oauth2_proxy` to `oauth2-proxy`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [#432](https://github.com/oauth2-proxy/oauth2-proxy/pull/432) Update ruby dependencies for documentation (@theobarberbany)
 - [#471](https://github.com/oauth2-proxy/oauth2-proxy/pull/471) Add logging in case of invalid redirects (@gargath)
 - [#462](https://github.com/oauth2-proxy/oauth2-proxy/pull/462) Allow HTML in banner message (@eritikass).
+- [#412](https://github.com/pusher/oauth2_proxy/pull/412) Allow multiple cookie domains to be specified (@edahlseng)
 
 # v5.1.0
 
@@ -54,7 +55,6 @@ N/A
 - [#355](https://github.com/oauth2-proxy/oauth2-proxy/pull/355) Add Client Secret File support for providers that rotate client secret via file system (@pasha-r)
 - [#401](https://github.com/oauth2-proxy/oauth2-proxy/pull/401) Give the option to pass email address in the Basic auth header instead of upstream usernames. (@Spindel)
 - [#405](https://github.com/oauth2-proxy/oauth2-proxy/pull/405) The `/sign_in` page now honors the `rd` query parameter, fixing the redirect after a successful authentication (@ti-mo)
-- [#412](https://github.com/pusher/oauth2_proxy/pull/412) Allow multiple cookie domains to be specified (@edahlseng)
 - [#434](https://github.com/oauth2-proxy/oauth2-proxy/pull/434) Give the option to prefer email address in the username header when using the -pass-user-headers option (@jordancrawfordnz)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ N/A
 - [#355](https://github.com/oauth2-proxy/oauth2-proxy/pull/355) Add Client Secret File support for providers that rotate client secret via file system (@pasha-r)
 - [#401](https://github.com/oauth2-proxy/oauth2-proxy/pull/401) Give the option to pass email address in the Basic auth header instead of upstream usernames. (@Spindel)
 - [#405](https://github.com/oauth2-proxy/oauth2-proxy/pull/405) The `/sign_in` page now honors the `rd` query parameter, fixing the redirect after a successful authentication (@ti-mo)
+- [#412](https://github.com/pusher/oauth2_proxy/pull/412) Allow multiple cookie domains to be specified (@edahlseng)
 - [#434](https://github.com/oauth2-proxy/oauth2-proxy/pull/434) Give the option to prefer email address in the username header when using the -pass-user-headers option (@jordancrawfordnz)
 
 

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -33,7 +33,7 @@ An example [oauth2-proxy.cfg]({{ site.gitweb }}/contrib/oauth2-proxy.cfg.example
 | `-client-secret` | string | the OAuth Client Secret | |
 | `-client-secret-file` | string | the file with OAuth Client Secret | |
 | `-config` | string | path to config file | |
-| `-cookie-domain` | string | an optional cookie domain to force cookies to (ie: `.yourcompany.com`) | |
+| `-cookie-domain` | string \| list | Optional cookie domains to force cookies to (ie: `.yourcompany.com`). The longest domain matching the request's host will be used (or the shortest cookie domain if there is no match). | |
 | `-cookie-expire` | duration | expire timeframe for cookie | 168h0m0s |
 | `-cookie-httponly` | bool | set HttpOnly cookie flag | true |
 | `-cookie-name` | string | the name of the cookie that the oauth_proxy creates | `"_oauth2_proxy"` |

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ func main() {
 	logger.SetFlags(logger.Lshortfile)
 	flagSet := flag.NewFlagSet("oauth2-proxy", flag.ExitOnError)
 
+	cookieDomains := StringArray{}
 	emailDomains := StringArray{}
 	whitelistDomains := StringArray{}
 	upstreams := StringArray{}
@@ -86,7 +87,7 @@ func main() {
 
 	flagSet.String("cookie-name", "_oauth2_proxy", "the name of the cookie that the oauth_proxy creates")
 	flagSet.String("cookie-secret", "", "the seed string for secure cookies (optionally base64 encoded)")
-	flagSet.String("cookie-domain", "", "an optional cookie domain to force cookies to (ie: .yourcompany.com)*")
+	flagSet.Var(&cookieDomains, "cookie-domain", "Optional cookie domains to force cookies to (ie: `.yourcompany.com`). The longest domain matching the request's host will be used (or the shortest cookie domain if there is no match).")
 	flagSet.String("cookie-path", "/", "an optional cookie path to force cookies to (ie: /poc/)*")
 	flagSet.Duration("cookie-expire", time.Duration(168)*time.Hour, "expire timeframe for cookie")
 	flagSet.Duration("cookie-refresh", time.Duration(0), "refresh the cookie after this duration; 0 to disable")

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -377,6 +377,10 @@ func (p *OAuthProxy) MakeCSRFCookie(req *http.Request, value string, expiration 
 
 func (p *OAuthProxy) makeCookie(req *http.Request, name string, value string, expiration time.Duration, now time.Time) *http.Cookie {
 	cookieDomain := ""
+	host := req.Header.Get("X-Forwarded-Host")
+	if host == "" {
+		host = req.Host
+	}
 
 	// Sort cookie domains by length, so that we try longer (and more specific)
 	// domains first
@@ -385,14 +389,14 @@ func (p *OAuthProxy) makeCookie(req *http.Request, name string, value string, ex
 		return len(sortedDomains[i]) > len(sortedDomains[j])
 	})
 	for _, domain := range sortedDomains {
-		if strings.HasSuffix(req.Host, domain) {
+		if strings.HasSuffix(host, domain) {
 			cookieDomain = domain
 			break
 		}
 	}
 
 	if cookieDomain != "" {
-		domain := req.Host
+		domain := host
 		if h, _, err := net.SplitHostPort(domain); err == nil {
 			domain = h
 		}

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -375,21 +375,10 @@ func (p *OAuthProxy) MakeCSRFCookie(req *http.Request, value string, expiration 
 }
 
 func (p *OAuthProxy) makeCookie(req *http.Request, name string, value string, expiration time.Duration, now time.Time) *http.Cookie {
-	cookieDomain := ""
-	host := req.Header.Get("X-Forwarded-Host")
-	if host == "" {
-		host = req.Host
-	}
-
-	for _, domain := range p.CookieDomains {
-		if strings.HasSuffix(host, domain) {
-			cookieDomain = domain
-			break
-		}
-	}
+	cookieDomain := cookies.GetCookieDomain(req, p.CookieDomains)
 
 	if cookieDomain != "" {
-		domain := host
+		domain := cookies.GetRequestHost(req)
 		if h, _, err := net.SplitHostPort(domain); err == nil {
 			domain = h
 		}

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -13,7 +13,6 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"regexp"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -382,13 +381,7 @@ func (p *OAuthProxy) makeCookie(req *http.Request, name string, value string, ex
 		host = req.Host
 	}
 
-	// Sort cookie domains by length, so that we try longer (and more specific)
-	// domains first
-	sortedDomains := p.CookieDomains
-	sort.Slice(sortedDomains, func(i, j int) bool {
-		return len(sortedDomains[i]) > len(sortedDomains[j])
-	})
-	for _, domain := range sortedDomains {
+	for _, domain := range p.CookieDomains {
 		if strings.HasSuffix(host, domain) {
 			cookieDomain = domain
 			break

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -13,6 +13,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -64,7 +65,7 @@ type OAuthProxy struct {
 	CookieSeed     string
 	CookieName     string
 	CSRFCookieName string
-	CookieDomain   string
+	CookieDomains  []string
 	CookiePath     string
 	CookieSecure   bool
 	CookieHTTPOnly bool
@@ -264,13 +265,13 @@ func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 		refresh = fmt.Sprintf("after %s", opts.CookieRefresh)
 	}
 
-	logger.Printf("Cookie settings: name:%s secure(https):%v httponly:%v expiry:%s domain:%s path:%s samesite:%s refresh:%s", opts.CookieName, opts.CookieSecure, opts.CookieHTTPOnly, opts.CookieExpire, opts.CookieDomain, opts.CookiePath, opts.CookieSameSite, refresh)
+	logger.Printf("Cookie settings: name:%s secure(https):%v httponly:%v expiry:%s domains:%s path:%s samesite:%s refresh:%s", opts.CookieName, opts.CookieSecure, opts.CookieHTTPOnly, opts.CookieExpire, strings.Join(opts.CookieDomains, ","), opts.CookiePath, opts.CookieSameSite, refresh)
 
 	return &OAuthProxy{
 		CookieName:     opts.CookieName,
 		CSRFCookieName: fmt.Sprintf("%v_%v", opts.CookieName, "csrf"),
 		CookieSeed:     opts.CookieSecret,
-		CookieDomain:   opts.CookieDomain,
+		CookieDomains:  opts.CookieDomains,
 		CookiePath:     opts.CookiePath,
 		CookieSecure:   opts.CookieSecure,
 		CookieHTTPOnly: opts.CookieHTTPOnly,
@@ -375,13 +376,28 @@ func (p *OAuthProxy) MakeCSRFCookie(req *http.Request, value string, expiration 
 }
 
 func (p *OAuthProxy) makeCookie(req *http.Request, name string, value string, expiration time.Duration, now time.Time) *http.Cookie {
-	if p.CookieDomain != "" {
+	cookieDomain := ""
+
+	// Sort cookie domains by length, so that we try longer (and more specific)
+	// domains first
+	sortedDomains := p.CookieDomains
+	sort.Slice(sortedDomains, func(i, j int) bool {
+		return len(sortedDomains[i]) > len(sortedDomains[j])
+	})
+	for _, domain := range sortedDomains {
+		if strings.HasSuffix(req.Host, domain) {
+			cookieDomain = domain
+			break
+		}
+	}
+
+	if cookieDomain != "" {
 		domain := req.Host
 		if h, _, err := net.SplitHostPort(domain); err == nil {
 			domain = h
 		}
-		if !strings.HasSuffix(domain, p.CookieDomain) {
-			logger.Printf("Warning: request host is %q but using configured cookie domain of %q", domain, p.CookieDomain)
+		if !strings.HasSuffix(domain, cookieDomain) {
+			logger.Printf("Warning: request host is %q but using configured cookie domain of %q", domain, cookieDomain)
 		}
 	}
 
@@ -389,7 +405,7 @@ func (p *OAuthProxy) makeCookie(req *http.Request, name string, value string, ex
 		Name:     name,
 		Value:    value,
 		Path:     p.CookiePath,
-		Domain:   p.CookieDomain,
+		Domain:   cookieDomain,
 		HttpOnly: p.CookieHTTPOnly,
 		Secure:   p.CookieSecure,
 		Expires:  now.Add(expiration),

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -1339,10 +1339,10 @@ func TestAjaxForbiddendRequest(t *testing.T) {
 func TestClearSplitCookie(t *testing.T) {
 	opts := NewOptions()
 	opts.CookieName = "oauth2"
-	opts.CookieDomain = "abc"
+	opts.CookieDomains = []string{"abc"}
 	store, err := cookie.NewCookieSessionStore(&opts.SessionOptions, &opts.CookieOptions)
 	assert.Equal(t, err, nil)
-	p := OAuthProxy{CookieName: opts.CookieName, CookieDomain: opts.CookieDomain, sessionStore: store}
+	p := OAuthProxy{CookieName: opts.CookieName, CookieDomains: opts.CookieDomains, sessionStore: store}
 	var rw = httptest.NewRecorder()
 	req := httptest.NewRequest("get", "/", nil)
 
@@ -1368,10 +1368,10 @@ func TestClearSplitCookie(t *testing.T) {
 func TestClearSingleCookie(t *testing.T) {
 	opts := NewOptions()
 	opts.CookieName = "oauth2"
-	opts.CookieDomain = "abc"
+	opts.CookieDomains = []string{"abc"}
 	store, err := cookie.NewCookieSessionStore(&opts.SessionOptions, &opts.CookieOptions)
 	assert.Equal(t, err, nil)
-	p := OAuthProxy{CookieName: opts.CookieName, CookieDomain: opts.CookieDomain, sessionStore: store}
+	p := OAuthProxy{CookieName: opts.CookieName, CookieDomains: opts.CookieDomains, sessionStore: store}
 	var rw = httptest.NewRecorder()
 	req := httptest.NewRequest("get", "/", nil)
 
@@ -1464,7 +1464,7 @@ func TestGetJwtSession(t *testing.T) {
 }
 
 func TestFindJwtBearerToken(t *testing.T) {
-	p := OAuthProxy{CookieName: "oauth2", CookieDomain: "abc"}
+	p := OAuthProxy{CookieName: "oauth2", CookieDomains: []string{"abc"}}
 	getReq := &http.Request{URL: &url.URL{Scheme: "http", Host: "example.com"}}
 
 	validToken := "eyJfoobar.eyJfoobar.12345asdf"

--- a/options.go
+++ b/options.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -395,6 +396,12 @@ func (o *Options) Validate() error {
 	default:
 		msgs = append(msgs, fmt.Sprintf("cookie_samesite (%s) must be one of ['', 'lax', 'strict', 'none']", o.CookieSameSite))
 	}
+
+	// Sort cookie domains by length, so that we try longer (and more specific)
+	// domains first
+	sort.Slice(o.CookieDomains, func(i, j int) bool {
+		return len(o.CookieDomains[i]) > len(o.CookieDomains[j])
+	})
 
 	msgs = parseSignatureKey(o, msgs)
 	msgs = validateCookieName(o, msgs)

--- a/pkg/apis/options/cookie.go
+++ b/pkg/apis/options/cookie.go
@@ -6,7 +6,7 @@ import "time"
 type CookieOptions struct {
 	CookieName     string        `flag:"cookie-name" cfg:"cookie_name" env:"OAUTH2_PROXY_COOKIE_NAME"`
 	CookieSecret   string        `flag:"cookie-secret" cfg:"cookie_secret" env:"OAUTH2_PROXY_COOKIE_SECRET"`
-	CookieDomain   string        `flag:"cookie-domain" cfg:"cookie_domain" env:"OAUTH2_PROXY_COOKIE_DOMAIN"`
+	CookieDomains  []string      `flag:"cookie-domain" cfg:"cookie_domain" env:"OAUTH2_PROXY_COOKIE_DOMAIN"`
 	CookiePath     string        `flag:"cookie-path" cfg:"cookie_path" env:"OAUTH2_PROXY_COOKIE_PATH"`
 	CookieExpire   time.Duration `flag:"cookie-expire" cfg:"cookie_expire" env:"OAUTH2_PROXY_COOKIE_EXPIRE"`
 	CookieRefresh  time.Duration `flag:"cookie-refresh" cfg:"cookie_refresh" env:"OAUTH2_PROXY_COOKIE_REFRESH"`

--- a/pkg/cookies/cookies.go
+++ b/pkg/cookies/cookies.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"sort"
 	"strings"
 	"time"
 
@@ -45,22 +44,16 @@ func MakeCookieFromOptions(req *http.Request, name string, value string, opts *o
 		host = req.Host
 	}
 
-	// Sort cookie domains by length, so that we try longer (and more specific)
-	// domains first
-	sortedDomains := opts.CookieDomains
-	sort.Slice(sortedDomains, func(i, j int) bool {
-		return len(sortedDomains[i]) > len(sortedDomains[j])
-	})
-	for _, domain := range sortedDomains {
+	for _, domain := range opts.CookieDomains {
 		if strings.HasSuffix(host, domain) {
 			return MakeCookie(req, name, value, opts.CookiePath, domain, opts.CookieHTTPOnly, opts.CookieSecure, expiration, now, ParseSameSite(opts.CookieSameSite))
 		}
 	}
 	// If nothing matches, create the cookie with the shortest domain
-	logger.Printf("Warning: request host %q did not match any of the specific cookie domains of %q", host, strings.Join(sortedDomains, ","))
+	logger.Printf("Warning: request host %q did not match any of the specific cookie domains of %q", host, strings.Join(opts.CookieDomains, ","))
 	defaultDomain := ""
-	if len(sortedDomains) > 0 {
-		defaultDomain = sortedDomains[len(sortedDomains)-1]
+	if len(opts.CookieDomains) > 0 {
+		defaultDomain = opts.CookieDomains[len(opts.CookieDomains)-1]
 	}
 	return MakeCookie(req, name, value, opts.CookiePath, defaultDomain, opts.CookieHTTPOnly, opts.CookieSecure, expiration, now, ParseSameSite(opts.CookieSameSite))
 }

--- a/pkg/cookies/cookies.go
+++ b/pkg/cookies/cookies.go
@@ -39,23 +39,43 @@ func MakeCookie(req *http.Request, name string, value string, path string, domai
 // MakeCookieFromOptions constructs a cookie based on the given *options.CookieOptions,
 // value and creation time
 func MakeCookieFromOptions(req *http.Request, name string, value string, opts *options.CookieOptions, expiration time.Duration, now time.Time) *http.Cookie {
-	host := req.Header.Get("X-Forwarded-Host")
-	if host == "" {
-		host = req.Host
-	}
+	domain := GetCookieDomain(req, opts.CookieDomains)
 
-	for _, domain := range opts.CookieDomains {
-		if strings.HasSuffix(host, domain) {
-			return MakeCookie(req, name, value, opts.CookiePath, domain, opts.CookieHTTPOnly, opts.CookieSecure, expiration, now, ParseSameSite(opts.CookieSameSite))
-		}
+	if domain != "" {
+		return MakeCookie(req, name, value, opts.CookiePath, domain, opts.CookieHTTPOnly, opts.CookieSecure, expiration, now, ParseSameSite(opts.CookieSameSite))
 	}
 	// If nothing matches, create the cookie with the shortest domain
-	logger.Printf("Warning: request host %q did not match any of the specific cookie domains of %q", host, strings.Join(opts.CookieDomains, ","))
+	logger.Printf("Warning: request host %q did not match any of the specific cookie domains of %q", GetRequestHost(req), strings.Join(opts.CookieDomains, ","))
 	defaultDomain := ""
 	if len(opts.CookieDomains) > 0 {
 		defaultDomain = opts.CookieDomains[len(opts.CookieDomains)-1]
 	}
 	return MakeCookie(req, name, value, opts.CookiePath, defaultDomain, opts.CookieHTTPOnly, opts.CookieSecure, expiration, now, ParseSameSite(opts.CookieSameSite))
+}
+
+// GetCookieDomain returns the correct cookie domain given a list of domains
+// by checking the X-Fowarded-Host and host header of an an http request
+func GetCookieDomain(req *http.Request, cookieDomains []string) string {
+	cookieDomain := ""
+
+	host := GetRequestHost(req)
+	for _, domain := range cookieDomains {
+		if strings.HasSuffix(host, domain) {
+			cookieDomain = domain
+			break
+		}
+	}
+	return cookieDomain
+
+}
+
+// GetRequestHost return the request host header or X-Forwarded-Host if present
+func GetRequestHost(req *http.Request) string {
+	host := req.Header.Get("X-Forwarded-Host")
+	if host == "" {
+		host = req.Host
+	}
+	return host
 }
 
 // Parse a valid http.SameSite value from a user supplied string for use of making cookies.

--- a/pkg/cookies/cookies.go
+++ b/pkg/cookies/cookies.go
@@ -40,6 +40,11 @@ func MakeCookie(req *http.Request, name string, value string, path string, domai
 // MakeCookieFromOptions constructs a cookie based on the given *options.CookieOptions,
 // value and creation time
 func MakeCookieFromOptions(req *http.Request, name string, value string, opts *options.CookieOptions, expiration time.Duration, now time.Time) *http.Cookie {
+	host := req.Header.Get("X-Forwarded-Host")
+	if host == "" {
+		host = req.Host
+	}
+
 	// Sort cookie domains by length, so that we try longer (and more specific)
 	// domains first
 	sortedDomains := opts.CookieDomains
@@ -47,12 +52,12 @@ func MakeCookieFromOptions(req *http.Request, name string, value string, opts *o
 		return len(sortedDomains[i]) > len(sortedDomains[j])
 	})
 	for _, domain := range sortedDomains {
-		if strings.HasSuffix(req.Host, domain) {
+		if strings.HasSuffix(host, domain) {
 			return MakeCookie(req, name, value, opts.CookiePath, domain, opts.CookieHTTPOnly, opts.CookieSecure, expiration, now, ParseSameSite(opts.CookieSameSite))
 		}
 	}
 	// If nothing matches, create the cookie with the shortest domain
-	logger.Printf("Warning: request host %q did not match any of the specific cookie domains of %q", req.Host, strings.Join(sortedDomains, ","))
+	logger.Printf("Warning: request host %q did not match any of the specific cookie domains of %q", host, strings.Join(sortedDomains, ","))
 	defaultDomain := ""
 	if len(sortedDomains) > 0 {
 		defaultDomain = sortedDomains[len(sortedDomains)-1]

--- a/pkg/sessions/session_store_test.go
+++ b/pkg/sessions/session_store_test.go
@@ -63,7 +63,11 @@ var _ = Describe("NewSessionStore", func() {
 
 			It("have the correct domain set", func() {
 				for _, cookie := range cookies {
-					Expect(cookie.Domain).To(Equal(cookieOpts.CookieDomain))
+					specifiedDomain := ""
+					if len(cookieOpts.CookieDomains) > 0 {
+						specifiedDomain = cookieOpts.CookieDomains[0]
+					}
+					Expect(cookie.Domain).To(Equal(specifiedDomain))
 				}
 			})
 
@@ -343,7 +347,7 @@ var _ = Describe("NewSessionStore", func() {
 					CookieRefresh:  time.Duration(2) * time.Hour,
 					CookieSecure:   false,
 					CookieHTTPOnly: false,
-					CookieDomain:   "example.com",
+					CookieDomains:  []string{"example.com"},
 					CookieSameSite: "strict",
 				}
 

--- a/providers/google.go
+++ b/providers/google.go
@@ -198,11 +198,11 @@ func userInGroup(service *admin.Service, groups []string, email string) bool {
 		req := service.Members.HasMember(group, email)
 		r, err := req.Do()
 		if err != nil {
-			err, ok := err.(*googleapi.Error)
+			gerr, ok := err.(*googleapi.Error)
 			switch {
-			case ok && err.Code == 404:
+			case ok && gerr.Code == 404:
 				logger.Printf("error checking membership in group %s: group does not exist", group)
-			case ok && err.Code == 400:
+			case ok && gerr.Code == 400:
 				// It is possible for Members.HasMember to return false even if the email is a group member.
 				// One case that can cause this is if the user email is from a different domain than the group,
 				// e.g. "member@otherdomain.com" in the group "group@mydomain.com" will result in a 400 error


### PR DESCRIPTION
This pull request allows multiple `--cookie-domain` arguments to be specified.

## Description

With the changes in this pull request, a user can specify multiple cookie domains by passing in the `--cookie-domain` argument more than once. When creating a cookie, the longest cookie domain that matches the request's host will be used.

For example, if the arguments `--cookie-domain=.example1.com --cookie-domain=.example2.com` were specified, and the OAuth2 proxy received a request via an `auth.example1.com` ingress, then `.example1.com` would be used for the cookie domain. On the other hand, if the same proxy pod received a request via an `auth.example2.com` ingress, then `.example2.com` would be used for the cookie domain.

## Motivation and Context

I have a Kubernetes cluster that uses OAuth authentication across multiple different domains, and unfortunately some of them don't share a common base domain. I'd like to be able to add multiple ingress rules to a single instance of this OAuth2 proxy in order to support these different domains, rather than deploying multiple instances of the OAuth2 proxy (reducing duplicate resources in the cluster). The `--whitelist-domain` parameter already supports multiple arguments, so all that was left to make this possible was extend support for multiple arguments to the `--cookie-domain` parameter.

## How Has This Been Tested?

I ran `make test` and updated the existing tests as necessary to make sure that all tests pass (there were some linting failures, but I confirmed that those errors existed on master before my changes – no new linting failures were created from these changes).

I also created a docker container (`edahlseng/oauth2_proxy` on Docker Hub, based off of the last v5.0.0 release), and deployed it to a Kubernetes cluster to use for ingress authentication. I added multiple ingresses across different domains and confirmed that the authentication flow worked as expected.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My change requires a change to the documentation or CHANGELOG.
- [X] I have updated the documentation/CHANGELOG accordingly.
  - I have updated the documentation, but not the CHANGELOG. Let me know if we want the CHANGELOG updated too!
- [X] I have created a feature (non-master) branch for my PR.
  - Should I use a different base branch for this PR?