### PR TITLE
Always encrypt sessions regardless of configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,11 @@
   - Multiple cookie domains may now be configured. The longest domain that matches will be used.
   - The config options `cookie_domain` is now `cookie_domains`
   - The environment variable `OAUTH2_PROXY_COOKIE_DOMAIN` is now `OAUTH2_PROXY_COOKIE_DOMAINS`
+- [#414](https://github.com/oauth2-proxy/oauth2-proxy/pull/414) Always encrypt sessions regardless of config
+  - Previously, sessions were encrypted only when certain options were configured.
+    This lead to confusion and misconfiguration as it was not obvious when a session should be encrypted.
+  - Cookie Secrets must now be 16, 24 or 32 bytes.
+  - If you need to change your secret, this will force users to reauthenticate.
 
 ## Changes since v5.1.1
 
@@ -86,6 +91,7 @@
 - [#488](https://github.com/oauth2-proxy/oauth2-proxy/pull/488) Set-Basic-Auth should default to false (@JoelSpeed)
 - [#494](https://github.com/oauth2-proxy/oauth2-proxy/pull/494) Upstream websockets TLS certificate validation now depends on ssl-upstream-insecure-skip-verify (@yaroslavros)
 - [#497](https://github.com/oauth2-proxy/oauth2-proxy/pull/497) Restrict access using Github collaborators (@jsclayton)
+- [#414](https://github.com/oauth2-proxy/oauth2-proxy/pull/414) Always encrypt sessions regardless of config (@ti-mo)
 
 # v5.1.1
 

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -29,6 +29,13 @@ import (
 	"golang.org/x/net/websocket"
 )
 
+const (
+	// The rawCookieSecret is 32 bytes and the base64CookieSecret is the base64
+	// encoded version of this.
+	rawCookieSecret    = "secretthirtytwobytes+abcdefghijk"
+	base64CookieSecret = "c2VjcmV0dGhpcnR5dHdvYnl0ZXMrYWJjZGVmZ2hpamsK"
+)
+
 func init() {
 	logger.SetFlags(logger.Lshortfile)
 
@@ -166,7 +173,7 @@ func TestRobotsTxt(t *testing.T) {
 	opts := options.NewOptions()
 	opts.ClientID = "asdlkjx"
 	opts.ClientSecret = "alkgks"
-	opts.Cookie.Secret = "asdkugkj"
+	opts.Cookie.Secret = rawCookieSecret
 	validation.Validate(opts)
 
 	proxy := NewOAuthProxy(opts, func(string) bool { return true })
@@ -181,7 +188,7 @@ func TestIsValidRedirect(t *testing.T) {
 	opts := options.NewOptions()
 	opts.ClientID = "skdlfj"
 	opts.ClientSecret = "fgkdsgj"
-	opts.Cookie.Secret = "ljgiogbj"
+	opts.Cookie.Secret = base64CookieSecret
 	// Should match domains that are exactly foo.bar and any subdomain of bar.foo
 	opts.WhitelistDomains = []string{
 		"foo.bar",
@@ -794,7 +801,7 @@ func NewSignInPageTest(skipProvider bool) *SignInPageTest {
 	var sipTest SignInPageTest
 
 	sipTest.opts = options.NewOptions()
-	sipTest.opts.Cookie.Secret = "adklsj2"
+	sipTest.opts.Cookie.Secret = rawCookieSecret
 	sipTest.opts.ClientID = "lkdgj"
 	sipTest.opts.ClientSecret = "sgiufgoi"
 	sipTest.opts.SkipProviderButton = skipProvider
@@ -1208,7 +1215,7 @@ func TestAuthSkippedForPreflightRequests(t *testing.T) {
 	opts.Upstreams = append(opts.Upstreams, upstream.URL)
 	opts.ClientID = "aljsal"
 	opts.ClientSecret = "jglkfsdgj"
-	opts.Cookie.Secret = "dkfjgdls"
+	opts.Cookie.Secret = base64CookieSecret
 	opts.SkipAuthPreflight = true
 	validation.Validate(opts)
 
@@ -1255,7 +1262,7 @@ type SignatureTest struct {
 
 func NewSignatureTest() *SignatureTest {
 	opts := options.NewOptions()
-	opts.Cookie.Secret = "cookie secret"
+	opts.Cookie.Secret = rawCookieSecret
 	opts.ClientID = "client ID"
 	opts.ClientSecret = "client secret"
 	opts.EmailDomains = []string{"acm.org"}
@@ -1402,7 +1409,7 @@ type ajaxRequestTest struct {
 func newAjaxRequestTest() *ajaxRequestTest {
 	test := &ajaxRequestTest{}
 	test.opts = options.NewOptions()
-	test.opts.Cookie.Secret = "sdflsw"
+	test.opts.Cookie.Secret = base64CookieSecret
 	test.opts.ClientID = "gkljfdl"
 	test.opts.ClientSecret = "sdflkjs"
 	validation.Validate(test.opts)

--- a/pkg/validation/options_test.go
+++ b/pkg/validation/options_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	cookieSecret = "foobar"
+	cookieSecret = "secretthirtytwobytes+abcdefghijk"
 	clientID     = "bazquux"
 	clientSecret = "xyzzyplugh"
 )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR instantiates a cipher with a given cookie_secret regardless of any other configuration options like `set_xauthrequest` or `set_authorization_header`.

## Description

<!--- Describe your changes in detail -->
In `Validate()`, a cookie decryption cipher is now always instantiated when `cookie_secret` is specified.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
When the user specifies a cookie secret, they expect the secret to be used to decrypt the cookie. This behaviour should not depend on config flags like `pass_access_token`, `set_authorization`, or anything else, really. If the secret it specified, it needs to be used, otherwise request processing will simply (silently) occur on an encrypted cookie.

This bug was introduced almost 4 years ago: https://github.com/pusher/oauth2_proxy/commit/829b442302f7db79929b679a01a6a3f41388bc4b. The `set-xauthrequest` flag was added, and `|| o.SetXAuthRequest` was not added to the list of conditions I removed in this PR. This causes the following surprising behaviour:

```
λ  ~  ./oauth2_proxy \
... oauth2 options ...
  --cookie-secret=my-cookie-secret \
  --set-xauthrequest=true \
  --set-authorization-header=true

λ  ~  curl http://localhost:4180/oauth2/auth -H"Cookie: _oauth2_proxy=eyJ...<my cookie>" -I
...
X-Auth-Request-Email: email@example.com
X-Auth-Request-User: 123123123
```
:point_up: decodes my cookie just fine.

However, running oauth2-proxy without `--set-auth-header` (figured I'd disable it, since we don't use it):
```
λ  ~  ./oauth2_proxy \
... oauth2 options ...
  --cookie-secret=my-cookie-secret \
  --set-xauthrequest=true
(without --set-auth-header=true)

λ  ~  curl http://localhost:4180/oauth2/auth -H"Cookie: _oauth2_proxy=eyJ...<my cookie>" -I
...
X-Auth-Request-Email: Xv6A+jI+gwLYqARBoki8TvquZJndX968DDh6AF3SzIDSZhDKLx0X
X-Auth-Request-User: xpCKJnbL9tgNvy8tlhvOYVouGxK72y3cpIaf5782ggKz/MQEAw==
```

:point_up: base64-decoding this, it looks like encrypted content.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

With this patch applied, running the scenario above both with and without `set-auth-header` works as expected.

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

In making this change, I broke some tests. I'm not sure to proceed with adapting them, as the code is 5 years old, a bit thorny, and things in `Validate()` look incredibly tightly coupled.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
