### PR TITLE
WIP Add -user-id-claim to support phone_number in add. to email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Changes since v5.0.0
 
+- [#448](https://github.com/pusher/oauth2_proxy/pull/448) Add `-user-id-claim` to support phone_number in addition to email
 - [#450](https://github.com/pusher/oauth2_proxy/pull/450) Fix http.Cookie SameSite is not copied (@johejo)
 - [#445](https://github.com/pusher/oauth2_proxy/pull/445) Expose `acr_values` to all providers (@holyjak)
 - [#419](https://github.com/pusher/oauth2_proxy/pull/419) Support Go 1.14, upgrade dependencies, upgrade golangci-lint to 1.23.6 (@johejo)

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -117,6 +117,7 @@ An example [oauth2_proxy.cfg]({{ site.gitweb }}/contrib/oauth2_proxy.cfg.example
 | `-tls-cert-file` | string | path to certificate file | |
 | `-tls-key-file` | string | path to private key file | |
 | `-upstream` | string \| list | the http url(s) of the upstream endpoint, file:// paths for static files or `static://<status_code>` for static response. Routing is based on the path | |
+| `-user-id-claim` | string | which claim contains the user ID (may be given multiple times, the first one present gets used) | \["email"\] |
 | `-validate-url` | string | Access token validation endpoint | |
 | `-version` | n/a | print version string | |
 | `-whitelist-domain` | string \| list | allowed domains for redirection after authentication. Prefix domain with a `.` to allow subdomains (eg `.example.com`) | |

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ func main() {
 	googleGroups := StringArray{}
 	redisSentinelConnectionURLs := StringArray{}
 	redisClusterConnectionURLs := StringArray{}
+	userIDClaims := StringArray{}
 
 	config := flagSet.String("config", "", "path to config file")
 	showVersion := flagSet.Bool("version", false, "print version string")
@@ -142,6 +143,8 @@ func main() {
 	flagSet.String("pubjwk-url", "", "JWK pubkey access endpoint: required by login.gov")
 	flagSet.Bool("gcp-healthchecks", false, "Enable GCP/GKE healthcheck endpoints")
 
+	flagSet.Var(&userIDClaims, "user-id-claim", "which claim contains the user ID (may be given multiple times, the first one present gets used)")
+
 	flagSet.Parse(os.Args[1:])
 
 	if *showVersion {
@@ -160,6 +163,10 @@ func main() {
 	}
 	cfg.LoadEnvForStruct(opts)
 	options.Resolve(opts, flagSet, cfg)
+
+	if len(opts.UserIDClaims) == 0 {
+		opts.UserIDClaims = []string{"email"}
+	}
 
 	err := opts.Validate()
 	if err != nil {

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -970,7 +970,7 @@ func NewUserInfoEndpointTest() *ProcessCookieTest {
 	return pcTest
 }
 
-func TestUserInfoEndpointAccepted(t *testing.T) {
+func TestUserInfoEndpointAcceptedForEmailUserID(t *testing.T) {
 	test := NewUserInfoEndpointTest()
 	startSession := &sessions.SessionState{
 		UserID: "john.doe@example.com", AccessToken: "my_access_token"}
@@ -979,7 +979,19 @@ func TestUserInfoEndpointAccepted(t *testing.T) {
 	test.proxy.ServeHTTP(test.rw, test.req)
 	assert.Equal(t, http.StatusOK, test.rw.Code)
 	bodyBytes, _ := ioutil.ReadAll(test.rw.Body)
-	assert.Equal(t, "{\"email\":\"john.doe@example.com\"}\n", string(bodyBytes))
+	assert.Equal(t, "{\"userID\":\"john.doe@example.com\",\"userIDClaim\":\"email\",\"email\":\"john.doe@example.com\"}\n", string(bodyBytes))
+}
+
+func TestUserInfoEndpointAcceptedForCustomUserID(t *testing.T) {
+	test := NewUserInfoEndpointTest()
+	startSession := &sessions.SessionState{
+		UserID: "my-id", UserIDType: "my_claim", AccessToken: "my_access_token"}
+	test.SaveSession(startSession)
+
+	test.proxy.ServeHTTP(test.rw, test.req)
+	assert.Equal(t, http.StatusOK, test.rw.Code)
+	bodyBytes, _ := ioutil.ReadAll(test.rw.Body)
+	assert.Equal(t, "{\"userID\":\"my-id\",\"userIDClaim\":\"my_claim\"}\n", string(bodyBytes))
 }
 
 func TestUserInfoEndpointUnauthorizedOnNoCookieSetError(t *testing.T) {

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -477,7 +477,7 @@ func TestBasicAuthWithEmail(t *testing.T) {
 
 	session := &sessions.SessionState{
 		User:        userName,
-		Email:       emailAddress,
+		UserID:      emailAddress,
 		AccessToken: "oauth_token",
 		CreatedAt:   time.Now(),
 	}
@@ -518,7 +518,7 @@ func TestPassUserHeadersWithEmail(t *testing.T) {
 
 	session := &sessions.SessionState{
 		User:        userName,
-		Email:       emailAddress,
+		UserID:      emailAddress,
 		AccessToken: "oauth_token",
 		CreatedAt:   time.Now(),
 	}
@@ -895,12 +895,12 @@ func (p *ProcessCookieTest) LoadCookiedSession() (*sessions.SessionState, error)
 func TestLoadCookiedSession(t *testing.T) {
 	pcTest := NewProcessCookieTestWithDefaults()
 
-	startSession := &sessions.SessionState{Email: "john.doe@example.com", AccessToken: "my_access_token", CreatedAt: time.Now()}
+	startSession := &sessions.SessionState{UserID: "john.doe@example.com", AccessToken: "my_access_token", CreatedAt: time.Now()}
 	pcTest.SaveSession(startSession)
 
 	session, err := pcTest.LoadCookiedSession()
 	assert.Equal(t, nil, err)
-	assert.Equal(t, startSession.Email, session.Email)
+	assert.Equal(t, startSession.UserID, session.UserID)
 	assert.Equal(t, "john.doe@example.com", session.User)
 	assert.Equal(t, startSession.AccessToken, session.AccessToken)
 }
@@ -921,7 +921,7 @@ func TestProcessCookieRefreshNotSet(t *testing.T) {
 	})
 	reference := time.Now().Add(time.Duration(-2) * time.Hour)
 
-	startSession := &sessions.SessionState{Email: "michael.bland@gsa.gov", AccessToken: "my_access_token", CreatedAt: reference}
+	startSession := &sessions.SessionState{UserID: "michael.bland@gsa.gov", AccessToken: "my_access_token", CreatedAt: reference}
 	pcTest.SaveSession(startSession)
 
 	session, err := pcTest.LoadCookiedSession()
@@ -929,7 +929,7 @@ func TestProcessCookieRefreshNotSet(t *testing.T) {
 	if session.Age() < time.Duration(-2)*time.Hour {
 		t.Errorf("cookie too young %v", session.Age())
 	}
-	assert.Equal(t, startSession.Email, session.Email)
+	assert.Equal(t, startSession.UserID, session.UserID)
 }
 
 func TestProcessCookieFailIfCookieExpired(t *testing.T) {
@@ -937,7 +937,7 @@ func TestProcessCookieFailIfCookieExpired(t *testing.T) {
 		opts.CookieExpire = time.Duration(24) * time.Hour
 	})
 	reference := time.Now().Add(time.Duration(25) * time.Hour * -1)
-	startSession := &sessions.SessionState{Email: "michael.bland@gsa.gov", AccessToken: "my_access_token", CreatedAt: reference}
+	startSession := &sessions.SessionState{UserID: "michael.bland@gsa.gov", AccessToken: "my_access_token", CreatedAt: reference}
 	pcTest.SaveSession(startSession)
 
 	session, err := pcTest.LoadCookiedSession()
@@ -952,7 +952,7 @@ func TestProcessCookieFailIfRefreshSetAndCookieExpired(t *testing.T) {
 		opts.CookieExpire = time.Duration(24) * time.Hour
 	})
 	reference := time.Now().Add(time.Duration(25) * time.Hour * -1)
-	startSession := &sessions.SessionState{Email: "michael.bland@gsa.gov", AccessToken: "my_access_token", CreatedAt: reference}
+	startSession := &sessions.SessionState{UserID: "michael.bland@gsa.gov", AccessToken: "my_access_token", CreatedAt: reference}
 	pcTest.SaveSession(startSession)
 
 	pcTest.proxy.CookieRefresh = time.Hour
@@ -973,7 +973,7 @@ func NewUserInfoEndpointTest() *ProcessCookieTest {
 func TestUserInfoEndpointAccepted(t *testing.T) {
 	test := NewUserInfoEndpointTest()
 	startSession := &sessions.SessionState{
-		Email: "john.doe@example.com", AccessToken: "my_access_token"}
+		UserID: "john.doe@example.com", AccessToken: "my_access_token"}
 	test.SaveSession(startSession)
 
 	test.proxy.ServeHTTP(test.rw, test.req)
@@ -999,7 +999,7 @@ func NewAuthOnlyEndpointTest(modifiers ...OptionsModifier) *ProcessCookieTest {
 func TestAuthOnlyEndpointAccepted(t *testing.T) {
 	test := NewAuthOnlyEndpointTest()
 	startSession := &sessions.SessionState{
-		Email: "michael.bland@gsa.gov", AccessToken: "my_access_token", CreatedAt: time.Now()}
+		UserID: "michael.bland@gsa.gov", AccessToken: "my_access_token", CreatedAt: time.Now()}
 	test.SaveSession(startSession)
 
 	test.proxy.ServeHTTP(test.rw, test.req)
@@ -1023,7 +1023,7 @@ func TestAuthOnlyEndpointUnauthorizedOnExpiration(t *testing.T) {
 	})
 	reference := time.Now().Add(time.Duration(25) * time.Hour * -1)
 	startSession := &sessions.SessionState{
-		Email: "michael.bland@gsa.gov", AccessToken: "my_access_token", CreatedAt: reference}
+		UserID: "michael.bland@gsa.gov", AccessToken: "my_access_token", CreatedAt: reference}
 	test.SaveSession(startSession)
 
 	test.proxy.ServeHTTP(test.rw, test.req)
@@ -1035,7 +1035,7 @@ func TestAuthOnlyEndpointUnauthorizedOnExpiration(t *testing.T) {
 func TestAuthOnlyEndpointUnauthorizedOnEmailValidationFailure(t *testing.T) {
 	test := NewAuthOnlyEndpointTest()
 	startSession := &sessions.SessionState{
-		Email: "michael.bland@gsa.gov", AccessToken: "my_access_token", CreatedAt: time.Now()}
+		UserID: "michael.bland@gsa.gov", AccessToken: "my_access_token", CreatedAt: time.Now()}
 	test.SaveSession(startSession)
 	test.validateUser = false
 
@@ -1066,7 +1066,7 @@ func TestAuthOnlyEndpointSetXAuthRequestHeaders(t *testing.T) {
 		pcTest.opts.ProxyPrefix+"/auth", nil)
 
 	startSession := &sessions.SessionState{
-		User: "oauth_user", Email: "oauth_user@example.com", AccessToken: "oauth_token", CreatedAt: time.Now()}
+		User: "oauth_user", UserID: "oauth_user@example.com", AccessToken: "oauth_token", CreatedAt: time.Now()}
 	pcTest.SaveSession(startSession)
 
 	pcTest.proxy.ServeHTTP(pcTest.rw, pcTest.req)
@@ -1198,7 +1198,7 @@ func (st *SignatureTest) MakeRequestWithExpectedKey(method, body, key string) {
 	req.Header = st.header
 
 	state := &sessions.SessionState{
-		Email: "mbland@acm.org", AccessToken: "my_access_token"}
+		UserID: "mbland@acm.org", AccessToken: "my_access_token"}
 	err = proxy.SaveSession(st.rw, req, state)
 	if err != nil {
 		panic(err)
@@ -1443,7 +1443,7 @@ func TestGetJwtSession(t *testing.T) {
 	// Bearer
 	session, _ := test.proxy.GetJwtSession(test.req)
 	assert.Equal(t, session.User, "john@example.com")
-	assert.Equal(t, session.Email, "john@example.com")
+	assert.Equal(t, session.UserID, "john@example.com")
 	assert.Equal(t, session.ExpiresOn, time.Unix(1912151821, 0))
 	assert.Equal(t, session.IDToken, goodJwt)
 

--- a/options.go
+++ b/options.go
@@ -15,7 +15,7 @@ import (
 	"time"
 
 	oidc "github.com/coreos/go-oidc"
-	"github.com/dgrijalva/jwt-go"
+	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/mbland/hmacauth"
 	"github.com/pusher/oauth2_proxy/pkg/apis/options"
 	sessionsapi "github.com/pusher/oauth2_proxy/pkg/apis/sessions"

--- a/options.go
+++ b/options.go
@@ -105,26 +105,27 @@ type Options struct {
 	ApprovalPrompt                   string `flag:"approval-prompt" cfg:"approval_prompt" env:"OAUTH2_PROXY_APPROVAL_PROMPT"` // Deprecated by OIDC 1.0
 
 	// Configuration values for logging
-	LoggingFilename       string `flag:"logging-filename" cfg:"logging_filename" env:"OAUTH2_PROXY_LOGGING_FILENAME"`
-	LoggingMaxSize        int    `flag:"logging-max-size" cfg:"logging_max_size" env:"OAUTH2_PROXY_LOGGING_MAX_SIZE"`
-	LoggingMaxAge         int    `flag:"logging-max-age" cfg:"logging_max_age" env:"OAUTH2_PROXY_LOGGING_MAX_AGE"`
-	LoggingMaxBackups     int    `flag:"logging-max-backups" cfg:"logging_max_backups" env:"OAUTH2_PROXY_LOGGING_MAX_BACKUPS"`
-	LoggingLocalTime      bool   `flag:"logging-local-time" cfg:"logging_local_time" env:"OAUTH2_PROXY_LOGGING_LOCAL_TIME"`
-	LoggingCompress       bool   `flag:"logging-compress" cfg:"logging_compress" env:"OAUTH2_PROXY_LOGGING_COMPRESS"`
-	StandardLogging       bool   `flag:"standard-logging" cfg:"standard_logging" env:"OAUTH2_PROXY_STANDARD_LOGGING"`
-	StandardLoggingFormat string `flag:"standard-logging-format" cfg:"standard_logging_format" env:"OAUTH2_PROXY_STANDARD_LOGGING_FORMAT"`
-	RequestLogging        bool   `flag:"request-logging" cfg:"request_logging" env:"OAUTH2_PROXY_REQUEST_LOGGING"`
-	RequestLoggingFormat  string `flag:"request-logging-format" cfg:"request_logging_format" env:"OAUTH2_PROXY_REQUEST_LOGGING_FORMAT"`
-	ExcludeLoggingPaths   string `flag:"exclude-logging-paths" cfg:"exclude_logging_paths" env:"OAUTH2_PROXY_EXCLUDE_LOGGING_PATHS"`
-	SilencePingLogging    bool   `flag:"silence-ping-logging" cfg:"silence_ping_logging" env:"OAUTH2_PROXY_SILENCE_PING_LOGGING"`
-	AuthLogging           bool   `flag:"auth-logging" cfg:"auth_logging" env:"OAUTH2_PROXY_LOGGING_AUTH_LOGGING"`
-	AuthLoggingFormat     string `flag:"auth-logging-format" cfg:"auth_logging_format" env:"OAUTH2_PROXY_AUTH_LOGGING_FORMAT"`
-	SignatureKey          string `flag:"signature-key" cfg:"signature_key" env:"OAUTH2_PROXY_SIGNATURE_KEY"`
-	AcrValues             string `flag:"acr-values" cfg:"acr_values" env:"OAUTH2_PROXY_ACR_VALUES"`
-	JWTKey                string `flag:"jwt-key" cfg:"jwt_key" env:"OAUTH2_PROXY_JWT_KEY"`
-	JWTKeyFile            string `flag:"jwt-key-file" cfg:"jwt_key_file" env:"OAUTH2_PROXY_JWT_KEY_FILE"`
-	PubJWKURL             string `flag:"pubjwk-url" cfg:"pubjwk_url" env:"OAUTH2_PROXY_PUBJWK_URL"`
-	GCPHealthChecks       bool   `flag:"gcp-healthchecks" cfg:"gcp_healthchecks" env:"OAUTH2_PROXY_GCP_HEALTHCHECKS"`
+	LoggingFilename       string   `flag:"logging-filename" cfg:"logging_filename" env:"OAUTH2_PROXY_LOGGING_FILENAME"`
+	LoggingMaxSize        int      `flag:"logging-max-size" cfg:"logging_max_size" env:"OAUTH2_PROXY_LOGGING_MAX_SIZE"`
+	LoggingMaxAge         int      `flag:"logging-max-age" cfg:"logging_max_age" env:"OAUTH2_PROXY_LOGGING_MAX_AGE"`
+	LoggingMaxBackups     int      `flag:"logging-max-backups" cfg:"logging_max_backups" env:"OAUTH2_PROXY_LOGGING_MAX_BACKUPS"`
+	LoggingLocalTime      bool     `flag:"logging-local-time" cfg:"logging_local_time" env:"OAUTH2_PROXY_LOGGING_LOCAL_TIME"`
+	LoggingCompress       bool     `flag:"logging-compress" cfg:"logging_compress" env:"OAUTH2_PROXY_LOGGING_COMPRESS"`
+	StandardLogging       bool     `flag:"standard-logging" cfg:"standard_logging" env:"OAUTH2_PROXY_STANDARD_LOGGING"`
+	StandardLoggingFormat string   `flag:"standard-logging-format" cfg:"standard_logging_format" env:"OAUTH2_PROXY_STANDARD_LOGGING_FORMAT"`
+	RequestLogging        bool     `flag:"request-logging" cfg:"request_logging" env:"OAUTH2_PROXY_REQUEST_LOGGING"`
+	RequestLoggingFormat  string   `flag:"request-logging-format" cfg:"request_logging_format" env:"OAUTH2_PROXY_REQUEST_LOGGING_FORMAT"`
+	ExcludeLoggingPaths   string   `flag:"exclude-logging-paths" cfg:"exclude_logging_paths" env:"OAUTH2_PROXY_EXCLUDE_LOGGING_PATHS"`
+	SilencePingLogging    bool     `flag:"silence-ping-logging" cfg:"silence_ping_logging" env:"OAUTH2_PROXY_SILENCE_PING_LOGGING"`
+	AuthLogging           bool     `flag:"auth-logging" cfg:"auth_logging" env:"OAUTH2_PROXY_LOGGING_AUTH_LOGGING"`
+	AuthLoggingFormat     string   `flag:"auth-logging-format" cfg:"auth_logging_format" env:"OAUTH2_PROXY_AUTH_LOGGING_FORMAT"`
+	SignatureKey          string   `flag:"signature-key" cfg:"signature_key" env:"OAUTH2_PROXY_SIGNATURE_KEY"`
+	AcrValues             string   `flag:"acr-values" cfg:"acr_values" env:"OAUTH2_PROXY_ACR_VALUES"`
+	JWTKey                string   `flag:"jwt-key" cfg:"jwt_key" env:"OAUTH2_PROXY_JWT_KEY"`
+	JWTKeyFile            string   `flag:"jwt-key-file" cfg:"jwt_key_file" env:"OAUTH2_PROXY_JWT_KEY_FILE"`
+	PubJWKURL             string   `flag:"pubjwk-url" cfg:"pubjwk_url" env:"OAUTH2_PROXY_PUBJWK_URL"`
+	GCPHealthChecks       bool     `flag:"gcp-healthchecks" cfg:"gcp_healthchecks" env:"OAUTH2_PROXY_GCP_HEALTHCHECKS"`
+	UserIDClaims          []string `flag:"user-id-claim" cfg:"user_id_claims" env:"OAUTH2_PROXY_USER_ID_CLAIMS"`
 
 	// internal values that are set after config validation
 	redirectURL        *url.URL
@@ -190,6 +191,7 @@ func NewOptions() *Options {
 		RequestLoggingFormat:             logger.DefaultRequestLoggingFormat,
 		AuthLogging:                      true,
 		AuthLoggingFormat:                logger.DefaultAuthLoggingFormat,
+		UserIDClaims:                     StringArray{"email"},
 	}
 }
 
@@ -444,7 +446,8 @@ func parseProviderInfo(o *Options, msgs []string) []string {
 		p.SetTeam(o.BitbucketTeam)
 		p.SetRepository(o.BitbucketRepository)
 	case *providers.OIDCProvider:
-		p.AllowUnverifiedEmail = o.InsecureOIDCAllowUnverifiedEmail
+		p.AllowUnverifiedEmail = o.InsecureOIDCAllowUnverifiedEmail // TODO rename AllowUnverifiedUserId / have RequireUserIdVerified = [email,..]
+		p.UserIDClaims = o.UserIDClaims
 		if o.oidcVerifier == nil {
 			msgs = append(msgs, "oidc provider requires an oidc issuer URL")
 		} else {

--- a/pkg/apis/sessions/session_state.go
+++ b/pkg/apis/sessions/session_state.go
@@ -19,8 +19,8 @@ type SessionState struct {
 	CreatedAt    time.Time `json:"-"`
 	ExpiresOn    time.Time `json:"-"`
 	RefreshToken string    `json:",omitempty"`
-	// Existing stored session may still include the old 'email' field (renamed to UserID now);
-	// remove it in the next version
+	// Existing stored session may still include the old 'email' field (renamed to UserID now)
+	// so we read it into LegacyEmail to ingest; remove it in the next version
 	LegacyEmail       string `json:"Email,omitempty"`
 	UserID            string `json:",omitempty"`
 	UserIDType        string `json:",omitempty"` // "" == "email" (in older providers)
@@ -41,6 +41,11 @@ func (s *SessionState) IsExpired() bool {
 		return true
 	}
 	return false
+}
+
+// True if UserID is an email (and not some other of claim such as phone_number)
+func (s *SessionState) IsIdentifiedByEmail() bool {
+	return s.UserID != "" && (s.UserIDType == "" || s.UserIDType == UserIDTypeEmail) // "" because email is default for legacy reasons
 }
 
 // Age returns the age of a session

--- a/pkg/apis/sessions/session_state_test.go
+++ b/pkg/apis/sessions/session_state_test.go
@@ -19,7 +19,7 @@ func TestSessionStateSerialization(t *testing.T) {
 	c2, err := encryption.NewCipher([]byte(altSecret))
 	assert.Equal(t, nil, err)
 	s := &sessions.SessionState{
-		Email:             "user@domain.com",
+		UserID:            "user@domain.com",
 		PreferredUsername: "user",
 		AccessToken:       "token1234",
 		IDToken:           "rawtoken1234",
@@ -34,7 +34,7 @@ func TestSessionStateSerialization(t *testing.T) {
 	t.Logf("%#v", ss)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "user@domain.com", ss.User)
-	assert.Equal(t, s.Email, ss.Email)
+	assert.Equal(t, s.UserID, ss.UserID)
 	assert.Equal(t, s.PreferredUsername, ss.PreferredUsername)
 	assert.Equal(t, s.AccessToken, ss.AccessToken)
 	assert.Equal(t, s.IDToken, ss.IDToken)
@@ -47,7 +47,7 @@ func TestSessionStateSerialization(t *testing.T) {
 	t.Logf("%#v", ss)
 	assert.Equal(t, nil, err)
 	assert.NotEqual(t, "user@domain.com", ss.User)
-	assert.NotEqual(t, s.Email, ss.Email)
+	assert.NotEqual(t, s.UserID, ss.UserID)
 	assert.NotEqual(t, s.PreferredUsername, ss.PreferredUsername)
 	assert.Equal(t, s.CreatedAt.Unix(), ss.CreatedAt.Unix())
 	assert.Equal(t, s.ExpiresOn.Unix(), ss.ExpiresOn.Unix())
@@ -64,7 +64,7 @@ func TestSessionStateSerializationWithUser(t *testing.T) {
 	s := &sessions.SessionState{
 		User:              "just-user",
 		PreferredUsername: "ju",
-		Email:             "user@domain.com",
+		UserID:            "user@domain.com",
 		AccessToken:       "token1234",
 		CreatedAt:         time.Now(),
 		ExpiresOn:         time.Now().Add(time.Duration(1) * time.Hour),
@@ -77,7 +77,7 @@ func TestSessionStateSerializationWithUser(t *testing.T) {
 	t.Logf("%#v", ss)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, s.User, ss.User)
-	assert.Equal(t, s.Email, ss.Email)
+	assert.Equal(t, s.UserID, ss.UserID)
 	assert.Equal(t, s.PreferredUsername, ss.PreferredUsername)
 	assert.Equal(t, s.AccessToken, ss.AccessToken)
 	assert.Equal(t, s.CreatedAt.Unix(), ss.CreatedAt.Unix())
@@ -89,7 +89,7 @@ func TestSessionStateSerializationWithUser(t *testing.T) {
 	t.Logf("%#v", ss)
 	assert.Equal(t, nil, err)
 	assert.NotEqual(t, s.User, ss.User)
-	assert.NotEqual(t, s.Email, ss.Email)
+	assert.NotEqual(t, s.UserID, ss.UserID)
 	assert.NotEqual(t, s.PreferredUsername, ss.PreferredUsername)
 	assert.Equal(t, s.CreatedAt.Unix(), ss.CreatedAt.Unix())
 	assert.Equal(t, s.ExpiresOn.Unix(), ss.ExpiresOn.Unix())
@@ -99,7 +99,7 @@ func TestSessionStateSerializationWithUser(t *testing.T) {
 
 func TestSessionStateSerializationNoCipher(t *testing.T) {
 	s := &sessions.SessionState{
-		Email:             "user@domain.com",
+		UserID:            "user@domain.com",
 		PreferredUsername: "user",
 		AccessToken:       "token1234",
 		CreatedAt:         time.Now(),
@@ -113,7 +113,7 @@ func TestSessionStateSerializationNoCipher(t *testing.T) {
 	ss, err := sessions.DecodeSessionState(encoded, nil)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "user@domain.com", ss.User)
-	assert.Equal(t, s.Email, ss.Email)
+	assert.Equal(t, s.UserID, ss.UserID)
 	assert.Equal(t, s.PreferredUsername, ss.PreferredUsername)
 	assert.Equal(t, "", ss.AccessToken)
 	assert.Equal(t, "", ss.RefreshToken)
@@ -122,7 +122,7 @@ func TestSessionStateSerializationNoCipher(t *testing.T) {
 func TestSessionStateSerializationNoCipherWithUser(t *testing.T) {
 	s := &sessions.SessionState{
 		User:              "just-user",
-		Email:             "user@domain.com",
+		UserID:            "user@domain.com",
 		PreferredUsername: "user",
 		AccessToken:       "token1234",
 		CreatedAt:         time.Now(),
@@ -136,7 +136,7 @@ func TestSessionStateSerializationNoCipherWithUser(t *testing.T) {
 	ss, err := sessions.DecodeSessionState(encoded, nil)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, s.User, ss.User)
-	assert.Equal(t, s.Email, ss.Email)
+	assert.Equal(t, s.UserID, ss.UserID)
 	assert.Equal(t, s.PreferredUsername, ss.PreferredUsername)
 	assert.Equal(t, "", ss.AccessToken)
 	assert.Equal(t, "", ss.RefreshToken)
@@ -171,14 +171,14 @@ func TestEncodeSessionState(t *testing.T) {
 	testCases := []testCase{
 		{
 			SessionState: sessions.SessionState{
-				Email: "user@domain.com",
-				User:  "just-user",
+				UserID: "user@domain.com",
+				User:   "just-user",
 			},
-			Encoded: `{"Email":"user@domain.com","User":"just-user"}`,
+			Encoded: `{"UserID":"user@domain.com","User":"just-user"}`,
 		},
 		{
 			SessionState: sessions.SessionState{
-				Email:        "user@domain.com",
+				UserID:       "user@domain.com",
 				User:         "just-user",
 				AccessToken:  "token1234",
 				IDToken:      "rawtoken1234",
@@ -186,7 +186,7 @@ func TestEncodeSessionState(t *testing.T) {
 				ExpiresOn:    e,
 				RefreshToken: "refresh4321",
 			},
-			Encoded: `{"Email":"user@domain.com","User":"just-user"}`,
+			Encoded: `{"UserID":"user@domain.com","User":"just-user"}`,
 		},
 	}
 
@@ -219,17 +219,17 @@ func TestDecodeSessionState(t *testing.T) {
 	testCases := []testCase{
 		{
 			SessionState: sessions.SessionState{
-				Email: "user@domain.com",
-				User:  "just-user",
+				UserID: "user@domain.com",
+				User:   "just-user",
 			},
-			Encoded: `{"Email":"user@domain.com","User":"just-user"}`,
+			Encoded: `{"UserID":"user@domain.com","User":"just-user"}`,
 		},
 		{
 			SessionState: sessions.SessionState{
-				Email: "user@domain.com",
-				User:  "user@domain.com",
+				UserID: "user@domain.com",
+				User:   "user@domain.com",
 			},
-			Encoded: `{"Email":"user@domain.com"}`,
+			Encoded: `{"UserID":"user@domain.com"}`,
 		},
 		{
 			SessionState: sessions.SessionState{
@@ -239,14 +239,14 @@ func TestDecodeSessionState(t *testing.T) {
 		},
 		{
 			SessionState: sessions.SessionState{
-				Email: "user@domain.com",
-				User:  "just-user",
+				UserID: "user@domain.com",
+				User:   "just-user",
 			},
-			Encoded: fmt.Sprintf(`{"Email":"user@domain.com","User":"just-user","AccessToken":"I6s+ml+/MldBMgHIiC35BTKTh57skGX24w==","IDToken":"xojNdyyjB1HgYWh6XMtXY/Ph5eCVxa1cNsklJw==","RefreshToken":"qEX0x6RmASxo4dhlBG6YuRs9Syn/e9sHu/+K","CreatedAt":%s,"ExpiresOn":%s}`, createdString, eString),
+			Encoded: fmt.Sprintf(`{"UserID":"user@domain.com","User":"just-user","AccessToken":"I6s+ml+/MldBMgHIiC35BTKTh57skGX24w==","IDToken":"xojNdyyjB1HgYWh6XMtXY/Ph5eCVxa1cNsklJw==","RefreshToken":"qEX0x6RmASxo4dhlBG6YuRs9Syn/e9sHu/+K","CreatedAt":%s,"ExpiresOn":%s}`, createdString, eString),
 		},
 		{
 			SessionState: sessions.SessionState{
-				Email:        "user@domain.com",
+				UserID:       "user@domain.com",
 				User:         "just-user",
 				AccessToken:  "token1234",
 				IDToken:      "rawtoken1234",
@@ -254,31 +254,31 @@ func TestDecodeSessionState(t *testing.T) {
 				ExpiresOn:    e,
 				RefreshToken: "refresh4321",
 			},
-			Encoded: fmt.Sprintf(`{"Email":"FsKKYrTWZWrxSOAqA/fTNAUZS5QWCqOBjuAbBlbVOw==","User":"rT6JP3dxQhxUhkWrrd7yt6c1mDVyQCVVxw==","AccessToken":"I6s+ml+/MldBMgHIiC35BTKTh57skGX24w==","IDToken":"xojNdyyjB1HgYWh6XMtXY/Ph5eCVxa1cNsklJw==","RefreshToken":"qEX0x6RmASxo4dhlBG6YuRs9Syn/e9sHu/+K","CreatedAt":%s,"ExpiresOn":%s}`, createdString, eString),
+			Encoded: fmt.Sprintf(`{"UserID":"FsKKYrTWZWrxSOAqA/fTNAUZS5QWCqOBjuAbBlbVOw==","User":"rT6JP3dxQhxUhkWrrd7yt6c1mDVyQCVVxw==","AccessToken":"I6s+ml+/MldBMgHIiC35BTKTh57skGX24w==","IDToken":"xojNdyyjB1HgYWh6XMtXY/Ph5eCVxa1cNsklJw==","RefreshToken":"qEX0x6RmASxo4dhlBG6YuRs9Syn/e9sHu/+K","CreatedAt":%s,"ExpiresOn":%s}`, createdString, eString),
 			Cipher:  c,
 		},
 		{
 			SessionState: sessions.SessionState{
-				Email: "user@domain.com",
-				User:  "just-user",
+				UserID: "user@domain.com",
+				User:   "just-user",
 			},
-			Encoded: `{"Email":"EGTllJcOFC16b7LBYzLekaHAC5SMMSPdyUrg8hd25g==","User":"rT6JP3dxQhxUhkWrrd7yt6c1mDVyQCVVxw=="}`,
+			Encoded: `{"UserID":"EGTllJcOFC16b7LBYzLekaHAC5SMMSPdyUrg8hd25g==","User":"rT6JP3dxQhxUhkWrrd7yt6c1mDVyQCVVxw=="}`,
 			Cipher:  c,
 		},
 		{
-			Encoded: `{"Email":"user@domain.com","User":"just-user","AccessToken":"X"}`,
+			Encoded: `{"UserID":"user@domain.com","User":"just-user","AccessToken":"X"}`,
 			Cipher:  c,
 			Error:   true,
 		},
 		{
-			Encoded: `{"Email":"user@domain.com","User":"just-user","IDToken":"XXXX"}`,
+			Encoded: `{"UserID":"user@domain.com","User":"just-user","IDToken":"XXXX"}`,
 			Cipher:  c,
 			Error:   true,
 		},
 		{
 			SessionState: sessions.SessionState{
-				User:  "just-user",
-				Email: "user@domain.com",
+				User:   "just-user",
+				UserID: "user@domain.com",
 			},
 			Encoded: "email:user@domain.com user:just-user",
 		},
@@ -298,7 +298,7 @@ func TestDecodeSessionState(t *testing.T) {
 		},
 		{
 			SessionState: sessions.SessionState{
-				Email:        "user@domain.com",
+				UserID:       "user@domain.com",
 				User:         "just-user",
 				AccessToken:  "token1234",
 				ExpiresOn:    e,
@@ -309,7 +309,7 @@ func TestDecodeSessionState(t *testing.T) {
 		},
 		{
 			SessionState: sessions.SessionState{
-				Email:        "user@domain.com",
+				UserID:       "user@domain.com",
 				User:         "just-user",
 				AccessToken:  "token1234",
 				IDToken:      "rawtoken1234",
@@ -332,7 +332,7 @@ func TestDecodeSessionState(t *testing.T) {
 		assert.NoError(t, err)
 		if assert.NotNil(t, ss) {
 			assert.Equal(t, tc.User, ss.User)
-			assert.Equal(t, tc.Email, ss.Email)
+			assert.Equal(t, tc.UserID, ss.UserID)
 			assert.Equal(t, tc.AccessToken, ss.AccessToken)
 			assert.Equal(t, tc.RefreshToken, ss.RefreshToken)
 			assert.Equal(t, tc.IDToken, ss.IDToken)

--- a/pkg/sessions/session_store_test.go
+++ b/pkg/sessions/session_store_test.go
@@ -242,8 +242,8 @@ var _ = Describe("NewSessionStore", func() {
 
 				It("loads a session equal to the original session", func() {
 					if cookieOpts.CookieSecret == "" {
-						// Only Email and User stored in session when encrypted
-						Expect(loadedSession.Email).To(Equal(session.Email))
+						// Only UserID and User stored in session when encrypted
+						Expect(loadedSession.UserID).To(Equal(session.UserID))
 						Expect(loadedSession.User).To(Equal(session.User))
 					} else {
 						// All fields stored in session if encrypted
@@ -394,7 +394,8 @@ var _ = Describe("NewSessionStore", func() {
 			IDToken:      "IDToken",
 			ExpiresOn:    time.Now().Add(1 * time.Hour),
 			RefreshToken: "RefreshToken",
-			Email:        "john.doe@example.com",
+			UserID:       "john.doe@example.com",
+			UserIDType:   sessionsapi.UserIDTypeEmail,
 			User:         "john.doe",
 		}
 

--- a/providers/gitlab.go
+++ b/providers/gitlab.go
@@ -112,7 +112,7 @@ func (p *GitLabProvider) redeemRefreshToken(s *sessions.SessionState) (err error
 	s.RefreshToken = newSession.RefreshToken
 	s.CreatedAt = newSession.CreatedAt
 	s.ExpiresOn = newSession.ExpiresOn
-	s.Email = newSession.Email
+	s.UserID = newSession.UserID
 	return
 }
 

--- a/providers/google.go
+++ b/providers/google.go
@@ -156,7 +156,7 @@ func (p *GoogleProvider) Redeem(redirectURL, code string) (s *sessions.SessionSt
 		CreatedAt:    time.Now(),
 		ExpiresOn:    time.Now().Add(time.Duration(jsonResponse.ExpiresIn) * time.Second).Truncate(time.Second),
 		RefreshToken: jsonResponse.RefreshToken,
-		Email:        c.Email,
+		UserID:       c.Email,
 		User:         c.Subject,
 	}
 	return
@@ -251,8 +251,8 @@ func (p *GoogleProvider) RefreshSessionIfNeeded(s *sessions.SessionState) (bool,
 	}
 
 	// re-check that the user is in the proper google group(s)
-	if !p.ValidateGroup(s.Email) {
-		return false, fmt.Errorf("%s is no longer in the group(s)", s.Email)
+	if !p.ValidateGroup(s.UserID) {
+		return false, fmt.Errorf("%s is no longer in the group(s)", s.UserID)
 	}
 
 	origExpiration := s.ExpiresOn

--- a/providers/google_test.go
+++ b/providers/google_test.go
@@ -105,7 +105,7 @@ func TestGoogleProviderGetEmailAddress(t *testing.T) {
 	session, err := p.Redeem("http://redirect/", "code1234")
 	assert.Equal(t, nil, err)
 	assert.NotEqual(t, session, nil)
-	assert.Equal(t, "michael.bland@gsa.gov", session.Email)
+	assert.Equal(t, "michael.bland@gsa.gov", session.UserID)
 	assert.Equal(t, "a1234", session.AccessToken)
 	assert.Equal(t, "refresh12345", session.RefreshToken)
 }

--- a/providers/logingov.go
+++ b/providers/logingov.go
@@ -253,7 +253,7 @@ func (p *LoginGovProvider) Redeem(redirectURL, code string) (s *sessions.Session
 		IDToken:     jsonResponse.IDToken,
 		CreatedAt:   time.Now(),
 		ExpiresOn:   time.Now().Add(time.Duration(jsonResponse.ExpiresIn) * time.Second).Truncate(time.Second),
-		Email:       email,
+		UserID:      email,
 	}
 	return
 }

--- a/providers/logingov_test.go
+++ b/providers/logingov_test.go
@@ -192,7 +192,7 @@ func TestLoginGovProviderSessionData(t *testing.T) {
 	session, err := p.Redeem("http://redirect/", "code1234")
 	assert.NoError(t, err)
 	assert.NotEqual(t, session, nil)
-	assert.Equal(t, "timothy.spencer@gsa.gov", session.Email)
+	assert.Equal(t, "timothy.spencer@gsa.gov", session.UserID)
 	assert.Equal(t, "a1234", session.AccessToken)
 
 	// The test ought to run in under 2 seconds.  If not, you may need to bump this up.

--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -120,7 +120,8 @@ func (p *OIDCProvider) redeemRefreshToken(s *sessions.SessionState) (err error) 
 	// if it doesn't it's probably better to retain the old one
 	if newSession.IDToken != "" {
 		s.IDToken = newSession.IDToken
-		s.Email = newSession.Email
+		s.UserID = newSession.UserID
+		s.UserIDType = newSession.UserIDType
 		s.User = newSession.User
 		s.PreferredUsername = newSession.PreferredUsername
 	}
@@ -166,8 +167,8 @@ func (p *OIDCProvider) createSessionState(token *oauth2.Token, idToken *oidc.IDT
 
 			newSession.IDToken = token.Extra("id_token").(string)
 
-			newSession.Email = claims.UserID
-			//newSession.UserIDType = claims.UserIDType
+			newSession.UserID = claims.UserID
+			newSession.UserIDType = claims.UserIDType
 
 			newSession.User = claims.Subject
 			newSession.PreferredUsername = claims.PreferredUsername

--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -153,7 +153,6 @@ func (p *OIDCProvider) createSessionState(token *oauth2.Token, idToken *oidc.IDT
 	newSession := &sessions.SessionState{}
 
 	if idToken != nil {
-		fmt.Println("UserIDClaims=", p.UserIDClaims) // FIXME rm
 		claims, err := findClaimsFromIDToken(idToken, token.AccessToken, p.ProfileURL.String(), p.UserIDClaims)
 		if err != nil {
 			return nil, fmt.Errorf("couldn't extract claims from id_token (%e)", err)
@@ -230,8 +229,6 @@ func findClaimsFromIDToken(idToken *oidc.IDToken, accessToken string, profileURL
 		return nil, fmt.Errorf("id_token contained none of the user id claims %v", userIDClaims)
 	}
 
-	fmt.Println("DBG>>> ODIC: UserID=", claims.UserID) // FIXME rm
-
 	return claims, nil
 }
 
@@ -272,8 +269,8 @@ type OIDCClaims struct {
 	UserIDType          string `json:"-"` // Derived from other fields
 	Subject             string `json:"sub"`
 	Email               string `json:"email"`
+	Verified            *bool  `json:"email_verified"`
 	PhoneNumber         string `json:"phone_number"`
 	PhoneNumberVerified *bool  `json:"phone_number_verified"`
-	Verified            *bool  `json:"email_verified"`
 	PreferredUsername   string `json:"preferred_username"`
 }

--- a/providers/oidc_test.go
+++ b/providers/oidc_test.go
@@ -103,6 +103,7 @@ func newOIDCProvider(serverURL *url.URL) *OIDCProvider {
 			fakeKeySetStub{},
 			&oidc.Config{ClientID: clientID},
 		),
+		UserIDClaims: []string{"email"},
 	}
 
 	return p

--- a/providers/oidc_test.go
+++ b/providers/oidc_test.go
@@ -156,7 +156,7 @@ func TestOIDCProviderRedeem(t *testing.T) {
 
 	session, err := provider.Redeem(provider.RedeemURL.String(), "code1234")
 	assert.Equal(t, nil, err)
-	assert.Equal(t, defaultIDToken.Email, session.Email)
+	assert.Equal(t, defaultIDToken.Email, session.UserID)
 	assert.Equal(t, accessToken, session.AccessToken)
 	assert.Equal(t, idToken, session.IDToken)
 	assert.Equal(t, refreshToken, session.RefreshToken)
@@ -182,14 +182,14 @@ func TestOIDCProviderRefreshSessionIfNeededWithoutIdToken(t *testing.T) {
 		CreatedAt:    time.Time{},
 		ExpiresOn:    time.Time{},
 		RefreshToken: refreshToken,
-		Email:        "janedoe@example.com",
+		UserID:       "janedoe@example.com",
 		User:         "11223344",
 	}
 
 	refreshed, err := provider.RefreshSessionIfNeeded(existingSession)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, refreshed, true)
-	assert.Equal(t, "janedoe@example.com", existingSession.Email)
+	assert.Equal(t, "janedoe@example.com", existingSession.UserID)
 	assert.Equal(t, accessToken, existingSession.AccessToken)
 	assert.Equal(t, idToken, existingSession.IDToken)
 	assert.Equal(t, refreshToken, existingSession.RefreshToken)
@@ -216,13 +216,13 @@ func TestOIDCProviderRefreshSessionIfNeededWithIdToken(t *testing.T) {
 		CreatedAt:    time.Time{},
 		ExpiresOn:    time.Time{},
 		RefreshToken: refreshToken,
-		Email:        "changeit",
+		UserID:       "changeit",
 		User:         "changeit",
 	}
 	refreshed, err := provider.RefreshSessionIfNeeded(existingSession)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, refreshed, true)
-	assert.Equal(t, defaultIDToken.Email, existingSession.Email)
+	assert.Equal(t, defaultIDToken.Email, existingSession.UserID)
 	assert.Equal(t, defaultIDToken.Subject, existingSession.User)
 	assert.Equal(t, accessToken, existingSession.AccessToken)
 	assert.Equal(t, idToken, existingSession.IDToken)

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -1,6 +1,7 @@
 package providers
 
 import (
+	"github.com/coreos/go-oidc"
 	"github.com/pusher/oauth2_proxy/pkg/apis/sessions"
 	"github.com/pusher/oauth2_proxy/pkg/encryption"
 )
@@ -18,6 +19,7 @@ type Provider interface {
 	RefreshSessionIfNeeded(*sessions.SessionState) (bool, error)
 	SessionFromCookie(string, *encryption.Cipher) (*sessions.SessionState, error)
 	CookieForSession(*sessions.SessionState, *encryption.Cipher) (string, error)
+	CreateSessionStateFromBearerToken(rawIDToken string, idToken *oidc.IDToken) (*sessions.SessionState, error)
 }
 
 // New provides a new Provider based on the configured provider string


### PR DESCRIPTION
**This is work in progress - however any early feedback is welcomed!**

Fix #431 - make it possible to use the `phone_number` claim in addition to or instead of the default `email` as the user id that is required to be present in the claims.

Note: It would be cool to be able to support also custom claims but that would expand the scope too much. Once this is finished, we can look into adding that.

## Description

### Commits

NOTE: I split the change into multiple commits to make review easier but expect them to be squashed together upon merge. The commits are (oldest first):
1. "WIP Add -user-id-claim ..." - add the config option and change the oidc provider to use it
2. "Continued: Rename SessionState.Email to UserID" - a simple refactoring that touches many places. I also add `UserIDType` and set it as appropriate, add `LegacyEmail` and use it to decode sessions stored prior to this change.
3. "Fix uses of UserID x Email": Differentiate behavior (primarily verification) based of whether `UserIDType` is email or not
4. "Fix GetJwtSession to respect user-id-claim"

### Changes so far

1. Add a new list option, `-user-id-claim` (defaults to `["email"]`)
2. The OIDC provider uses it to extract the first present claim into the newly named `Session.UserID`, in order, and only fails if none of the requested user ID claims is present (note: I believe it is not useful for any other, more specialized provider)
3. `session_state.go` - `Email` renamed to `UserID`, added `UserIDType`, `IsIdentifiedByEmail`, and `LegacyEmail` (so that we can read pre-existing sessions that were created before the renaming). Adjusted reading/writing to use these fields correctly.
4. oauthproxy.go: fix uses of Email vs UserID - userinfo endpoint returns both, only validate email if IsIdentifiedByEmail, return new headers `X-Forwarded-User-Id[-Claim]` where we returned only `-Email` before (but keep email for backwards compatibility)
5. oauthproxy.go: Fixed `GetJwtSession` to respect the `-user-id-claim` - moved the core of the code to the default implementation of a new provider method, which is overridden by the OIDC provider to use the user id claim.

TODO: Rename SessionState.UserIDType to UserIDClaim for consistency with the CLI option.
TODO: Add unit tests, update docs w.r.t. the new headers / deprecating the old one

## Motivation and Context

See #431 - some of our users only have email, some only have phone_number (some have both).

## How Has This Been Tested?

**TODO: Add unit tests (session (de|en)coding, ...).**

### Setting `UserID` to the correct claim

(by printing the selected UserID, after authenticating with a user that has both):

1. no `-user-id-claim` CLI option => email used
2. `-user-id-claim phone_number` => phone_number used
3.  `-user-id-claim phone_number -user-id-claim email` => phone_number used
4.  `-user-id-claim email -user-id-claim phone_number` => email used

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
