### PR TITLE
Add ability to skip authentication based on request headers

### DIFF
--- a/contrib/local-environment/Makefile
+++ b/contrib/local-environment/Makefile
@@ -6,6 +6,14 @@ up:
 %:
 	docker-compose $*
 
+.PHONY: alpha-config-up
+alpha-config-up:
+	docker-compose -f docker-compose.yaml -f docker-compose-alpha-config.yaml up -d
+
+.PHONY: alpha-config-%
+alpha-config-%:
+	docker-compose -f docker-compose.yaml -f docker-compose-nginx.yaml $*
+
 .PHONY: nginx-up
 nginx-up:
 	docker-compose -f docker-compose.yaml -f docker-compose-nginx.yaml up -d

--- a/contrib/local-environment/docker-compose-alpha-config.yaml
+++ b/contrib/local-environment/docker-compose-alpha-config.yaml
@@ -1,0 +1,19 @@
+# This docker-compose file can be used to bring up an example instance of oauth2-proxy
+# for manual testing and exploration of features.
+# Alongside OAuth2-Proxy, this file also starts Dex to act as the identity provider,
+# etcd for storage for Dex  and HTTPBin as an example upstream.
+# This file also uses alpha configuration when configuring OAuth2 Proxy.
+#
+# This file is an extension of the main compose file and must be used with it
+#    docker-compose -f docker-compose.yaml -f docker-compose-alpha-config.yaml <command>
+# Alternatively:
+#    make alpha-config-<command> (eg make nginx-up, make nginx-down)
+#
+# Access http://localhost:4180 to initiate a login cycle
+version: '3.0'
+services:
+  oauth2-proxy:
+    command: --config /oauth2-proxy.cfg --alpha-config /oauth2-proxy-alpha-config.yaml
+    volumes:
+      - "./oauth2-proxy-alpha-config.cfg:/oauth2-proxy.cfg"
+      - "./oauth2-proxy-alpha-config.yaml:/oauth2-proxy-alpha-config.yaml"

--- a/contrib/local-environment/oauth2-proxy-alpha-config.cfg
+++ b/contrib/local-environment/oauth2-proxy-alpha-config.cfg
@@ -1,0 +1,10 @@
+http_address="0.0.0.0:4180"
+cookie_secret="OQINaROshtE9TcZkNAm-5Zs2Pv3xaWytBmc5W7sPX7w="
+provider="oidc"
+email_domains="example.com"
+oidc_issuer_url="http://dex.localhost:4190/dex"
+client_secret="b2F1dGgyLXByb3h5LWNsaWVudC1zZWNyZXQK"
+client_id="oauth2-proxy"
+cookie_secure="false"
+
+redirect_url="http://localhost:4180/oauth2/callback"

--- a/contrib/local-environment/oauth2-proxy-alpha-config.cfg
+++ b/contrib/local-environment/oauth2-proxy-alpha-config.cfg
@@ -1,3 +1,4 @@
+upstreams=["http://httpbin"]
 http_address="0.0.0.0:4180"
 cookie_secret="OQINaROshtE9TcZkNAm-5Zs2Pv3xaWytBmc5W7sPX7w="
 provider="oidc"
@@ -8,3 +9,4 @@ client_id="oauth2-proxy"
 cookie_secure="false"
 
 redirect_url="http://localhost:4180/oauth2/callback"
+skip_auth_headers=["X-Secret-Header:^t?opSecret$"]

--- a/contrib/local-environment/oauth2-proxy-alpha-config.yaml
+++ b/contrib/local-environment/oauth2-proxy-alpha-config.yaml
@@ -1,0 +1,17 @@
+upstreams:
+  - id: httpbin
+    path: /
+    uri: http://httpbin
+injectRequestHeaders:
+- name: X-Forwarded-Groups
+  values:
+  - claim: groups
+- name: X-Forwarded-User
+  values:
+  -   claim: user
+- name: X-Forwarded-Email
+  values:
+  - claim: email
+- name: X-Forwarded-Preferred-Username
+  values:
+  - claim: preferred_username

--- a/contrib/local-environment/oauth2-proxy-alpha-config.yaml
+++ b/contrib/local-environment/oauth2-proxy-alpha-config.yaml
@@ -15,3 +15,7 @@ injectRequestHeaders:
 - name: X-Forwarded-Preferred-Username
   values:
   - claim: preferred_username
+skipAuthHeaders:
+- name: X-Secret-Header
+  values:
+  - claim: '^t?opSecret$'

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/frankban/quicktest v1.10.0 // indirect
 	github.com/fsnotify/fsnotify v1.4.9
+	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/go-redis/redis/v8 v8.2.3
 	github.com/justinas/alice v1.2.0
 	github.com/mbland/hmacauth v0.0.0-20170912233209-44256dfd4bfa

--- a/go.sum
+++ b/go.sum
@@ -55,7 +55,10 @@ github.com/frankban/quicktest v1.10.0/go.mod h1:ui7WezCLWMWxVWr1GETZY3smRy0G4KWq
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32 h1:Mn26/9ZMNWSw9C9ERFA1PUxfmGpolnw2v0bKOREu5ew=
+github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/ghodss/yaml"
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/logger"
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/validation"
@@ -21,6 +22,7 @@ func main() {
 	configFlagSet := pflag.NewFlagSet("oauth2-proxy", pflag.ContinueOnError)
 	config := configFlagSet.String("config", "", "path to config file")
 	alphaConfig := configFlagSet.String("alpha-config", "", "path to alpha config file (use at your own risk - the structure in this config file may change between minor releases)")
+	convertConfig := configFlagSet.Bool("convert-config-to-alpha", false, "if true, the proxy will load configuration as normal and convert existing configuration to the alpha config structure, and print it to stdout")
 	showVersion := configFlagSet.Bool("version", false, "print version string")
 	configFlagSet.Parse(os.Args[1:])
 
@@ -29,10 +31,21 @@ func main() {
 		return
 	}
 
+	if *convertConfig && *alphaConfig != "" {
+		logger.Fatal("cannot use alpha-config and conver-config-to-alpha together")
+	}
+
 	opts, err := loadConfiguration(*config, *alphaConfig, configFlagSet)
 	if err != nil {
 		logger.Printf("ERROR: %v", err)
 		os.Exit(1)
+	}
+
+	if *convertConfig {
+		if err := printConvertedConfig(opts); err != nil {
+			logger.Fatalf("ERROR: could not convert config: %v", err)
+		}
+		return
 	}
 
 	err = validation.Validate(opts)
@@ -133,4 +146,22 @@ func loadOptions(config string, extraFlags *pflag.FlagSet) (*options.Options, er
 	}
 
 	return opts, nil
+}
+
+// printConvertedConfig extracts alpha options from the loaded configuration
+// and renders these to stdout in YAML format.
+func printConvertedConfig(opts *options.Options) error {
+	alphaConfig := &options.AlphaOptions{}
+	alphaConfig.ExtractFrom(opts)
+
+	data, err := yaml.Marshal(alphaConfig)
+	if err != nil {
+		return fmt.Errorf("unable to marshal config: %v", err)
+	}
+
+	if _, err := os.Stdout.Write(data); err != nil {
+		return fmt.Errorf("unable to write output: %v", err)
+	}
+
+	return nil
 }

--- a/main.go
+++ b/main.go
@@ -12,36 +12,26 @@ import (
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/logger"
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/validation"
+	"github.com/spf13/pflag"
 )
 
 func main() {
 	logger.SetFlags(logger.Lshortfile)
-	flagSet := options.NewFlagSet()
 
-	config := flagSet.String("config", "", "path to config file")
-	showVersion := flagSet.Bool("version", false, "print version string")
-
-	err := flagSet.Parse(os.Args[1:])
-	if err != nil {
-		logger.Printf("ERROR: Failed to parse flags: %v", err)
-		os.Exit(1)
-	}
+	configFlagSet := pflag.NewFlagSet("oauth2-proxy", pflag.ContinueOnError)
+	config := configFlagSet.String("config", "", "path to config file")
+	alphaConfig := configFlagSet.String("alpha-config", "", "path to alpha config file (use at your own risk - the structure in this config file may change between minor releases)")
+	showVersion := configFlagSet.Bool("version", false, "print version string")
+	configFlagSet.Parse(os.Args[1:])
 
 	if *showVersion {
 		fmt.Printf("oauth2-proxy %s (built with %s)\n", VERSION, runtime.Version())
 		return
 	}
 
-	legacyOpts := options.NewLegacyOptions()
-	err = options.Load(*config, flagSet, legacyOpts)
+	opts, err := loadConfiguration(*config, *alphaConfig, configFlagSet)
 	if err != nil {
-		logger.Errorf("ERROR: Failed to load config: %v", err)
-		os.Exit(1)
-	}
-
-	opts, err := legacyOpts.ToOptions()
-	if err != nil {
-		logger.Errorf("ERROR: Failed to convert config: %v", err)
+		logger.Printf("ERROR: %v", err)
 		os.Exit(1)
 	}
 
@@ -73,4 +63,74 @@ func main() {
 		s.stop <- struct{}{} // notify having caught signal
 	}()
 	s.ListenAndServe()
+}
+
+// loadConfiguration will load in the user's configuration.
+// It will either load the alpha configuration (if alphaConfig is given)
+// or the legacy configuration.
+func loadConfiguration(config, alphaConfig string, extraFlags *pflag.FlagSet) (*options.Options, error) {
+	if alphaConfig != "" {
+		logger.Printf("WARNING: You are using alpha configuration. The structure in this configuration file may change without notice. You MUST remove conflicting options from your existing configuration.")
+		return loadAlphaOptions(config, alphaConfig, extraFlags)
+	}
+	return loadLegacyOptions(config, extraFlags)
+}
+
+// loadLegacyOptions loads the old toml options using the legacy flagset
+// and legacy options struct.
+func loadLegacyOptions(config string, extraFlags *pflag.FlagSet) (*options.Options, error) {
+	optionsFlagSet := options.NewLegacyFlagSet()
+	optionsFlagSet.AddFlagSet(extraFlags)
+	if err := optionsFlagSet.Parse(os.Args[1:]); err != nil {
+		return nil, fmt.Errorf("failed to parse flags: %v", err)
+	}
+
+	legacyOpts := options.NewLegacyOptions()
+	if err := options.Load(config, optionsFlagSet, legacyOpts); err != nil {
+		return nil, fmt.Errorf("failed to load config: %v", err)
+	}
+
+	opts, err := legacyOpts.ToOptions()
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert config: %v", err)
+	}
+
+	return opts, nil
+}
+
+// loadAlphaOptions loads the old style config excluding options converted to
+// the new alpha format, then merges the alpha options, loaded from YAML,
+// into the core configuration.
+func loadAlphaOptions(config, alphaConfig string, extraFlags *pflag.FlagSet) (*options.Options, error) {
+	opts, err := loadOptions(config, extraFlags)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load core options: %v", err)
+	}
+
+	alphaOpts := &options.AlphaOptions{}
+	if err := options.LoadYAML(alphaConfig, alphaOpts); err != nil {
+		return nil, fmt.Errorf("failed to load alpha options: %v", err)
+	}
+
+	alphaOpts.MergeInto(opts)
+	return opts, nil
+}
+
+// loadOptions loads the configuration using the old style format into the
+// core options.Options struct.
+// This means that none of the options that have been converted to alpha config
+// will be loaded using this method.
+func loadOptions(config string, extraFlags *pflag.FlagSet) (*options.Options, error) {
+	optionsFlagSet := options.NewFlagSet()
+	optionsFlagSet.AddFlagSet(extraFlags)
+	if err := optionsFlagSet.Parse(os.Args[1:]); err != nil {
+		return nil, fmt.Errorf("failed to parse flags: %v", err)
+	}
+
+	opts := options.NewOptions()
+	if err := options.Load(config, optionsFlagSet, opts); err != nil {
+		return nil, fmt.Errorf("failed to load config: %v", err)
+	}
+
+	return opts, nil
 }

--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ func main() {
 		logger.Fatal("cannot use alpha-config and conver-config-to-alpha together")
 	}
 
-	opts, err := loadConfiguration(*config, *alphaConfig, configFlagSet)
+	opts, err := loadConfiguration(*config, *alphaConfig, configFlagSet, os.Args[1:])
 	if err != nil {
 		logger.Printf("ERROR: %v", err)
 		os.Exit(1)
@@ -81,20 +81,20 @@ func main() {
 // loadConfiguration will load in the user's configuration.
 // It will either load the alpha configuration (if alphaConfig is given)
 // or the legacy configuration.
-func loadConfiguration(config, alphaConfig string, extraFlags *pflag.FlagSet) (*options.Options, error) {
+func loadConfiguration(config, alphaConfig string, extraFlags *pflag.FlagSet, args []string) (*options.Options, error) {
 	if alphaConfig != "" {
 		logger.Printf("WARNING: You are using alpha configuration. The structure in this configuration file may change without notice. You MUST remove conflicting options from your existing configuration.")
-		return loadAlphaOptions(config, alphaConfig, extraFlags)
+		return loadAlphaOptions(config, alphaConfig, extraFlags, args)
 	}
-	return loadLegacyOptions(config, extraFlags)
+	return loadLegacyOptions(config, extraFlags, args)
 }
 
 // loadLegacyOptions loads the old toml options using the legacy flagset
 // and legacy options struct.
-func loadLegacyOptions(config string, extraFlags *pflag.FlagSet) (*options.Options, error) {
+func loadLegacyOptions(config string, extraFlags *pflag.FlagSet, args []string) (*options.Options, error) {
 	optionsFlagSet := options.NewLegacyFlagSet()
 	optionsFlagSet.AddFlagSet(extraFlags)
-	if err := optionsFlagSet.Parse(os.Args[1:]); err != nil {
+	if err := optionsFlagSet.Parse(args); err != nil {
 		return nil, fmt.Errorf("failed to parse flags: %v", err)
 	}
 
@@ -114,8 +114,8 @@ func loadLegacyOptions(config string, extraFlags *pflag.FlagSet) (*options.Optio
 // loadAlphaOptions loads the old style config excluding options converted to
 // the new alpha format, then merges the alpha options, loaded from YAML,
 // into the core configuration.
-func loadAlphaOptions(config, alphaConfig string, extraFlags *pflag.FlagSet) (*options.Options, error) {
-	opts, err := loadOptions(config, extraFlags)
+func loadAlphaOptions(config, alphaConfig string, extraFlags *pflag.FlagSet, args []string) (*options.Options, error) {
+	opts, err := loadOptions(config, extraFlags, args)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load core options: %v", err)
 	}
@@ -133,10 +133,10 @@ func loadAlphaOptions(config, alphaConfig string, extraFlags *pflag.FlagSet) (*o
 // core options.Options struct.
 // This means that none of the options that have been converted to alpha config
 // will be loaded using this method.
-func loadOptions(config string, extraFlags *pflag.FlagSet) (*options.Options, error) {
+func loadOptions(config string, extraFlags *pflag.FlagSet, args []string) (*options.Options, error) {
 	optionsFlagSet := options.NewFlagSet()
 	optionsFlagSet.AddFlagSet(extraFlags)
-	if err := optionsFlagSet.Parse(os.Args[1:]); err != nil {
+	if err := optionsFlagSet.Parse(args); err != nil {
 		return nil, fmt.Errorf("failed to parse flags: %v", err)
 	}
 

--- a/main_suite_test.go
+++ b/main_suite_test.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/logger"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestMainSuite(t *testing.T) {
+	logger.SetOutput(GinkgoWriter)
+
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Main Suite")
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,189 @@
+package main
+
+import (
+  "os"
+  "io/ioutil"
+  "time"
+
+  . "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo"
+  . "github.com/onsi/ginkgo/extensions/table"
+  "github.com/spf13/pflag"
+  "github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
+)
+
+var _ = Describe("Configuration Loading Suite", func() {
+  const testLegacyConfig = `
+upstreams="http://httpbin"
+set_basic_auth="true"
+basic_auth_password="super-secret-password"
+`
+
+const testAlphaConfig = `
+upstreams:
+  - id: httpbin
+    path: /
+    uri: http://httpbin
+injectRequestHeaders:
+- name: X-Forwarded-Groups
+  values:
+  - claim: groups
+- name: X-Forwarded-User
+  values:
+  - claim: user
+- name: X-Forwarded-Email
+  values:
+  - claim: email
+- name: X-Forwarded-Preferred-Username
+  values:
+  - claim: preferred_username
+injectResponseHeaders:
+- name: Authorization
+  values:
+  - claim: user
+    prefix: "Basic "
+    basicAuthPassword:
+      value: c3VwZXItc2VjcmV0LXBhc3N3b3Jk
+`
+
+const testCoreConfig = `
+http_address="0.0.0.0:4180"
+cookie_secret="OQINaROshtE9TcZkNAm-5Zs2Pv3xaWytBmc5W7sPX7w="
+provider="oidc"
+email_domains="example.com"
+oidc_issuer_url="http://dex.localhost:4190/dex"
+client_secret="b2F1dGgyLXByb3h5LWNsaWVudC1zZWNyZXQK"
+client_id="oauth2-proxy"
+cookie_secure="false"
+
+redirect_url="http://localhost:4180/oauth2/callback"
+`
+
+  boolPtr := func(b bool) *bool {
+    return &b
+  }
+
+  durationPtr := func(d time.Duration) *options.Duration {
+    du := options.Duration(d)
+    return &du
+  }
+
+  testExpectedOptions := func() *options.Options{
+    opts, err := options.NewLegacyOptions().ToOptions()
+    Expect(err).ToNot(HaveOccurred())
+
+    opts.HTTPAddress = "0.0.0.0:4180"
+    opts.Cookie.Secret = "OQINaROshtE9TcZkNAm-5Zs2Pv3xaWytBmc5W7sPX7w="
+    opts.ProviderType = "oidc"
+    opts.EmailDomains = []string{"example.com"}
+    opts.OIDCIssuerURL = "http://dex.localhost:4190/dex"
+    opts.ClientSecret = "b2F1dGgyLXByb3h5LWNsaWVudC1zZWNyZXQK"
+    opts.ClientID = "oauth2-proxy"
+    opts.Cookie.Secure = false
+    opts.RawRedirectURL = "http://localhost:4180/oauth2/callback"
+
+    opts.UpstreamServers = options.Upstreams{
+      {
+        ID: "/",
+        Path: "/",
+        URI: "http://httpbin",
+        FlushInterval: durationPtr(options.DefaultUpstreamFlushInterval),
+        PassHostHeader: boolPtr(true),
+        ProxyWebSockets: boolPtr(true),
+      },
+    }
+
+    authHeader := options.Header{
+      Name: "Authorization",
+      Values: []options.HeaderValue{
+        {
+          ClaimSource: &options.ClaimSource{
+            Claim: "user",
+            Prefix: "Basic ",
+            BasicAuthPassword: &options.SecretSource{
+              Value: []byte("super-secret-password"),
+            },
+          },
+        },
+      },
+    }
+
+    opts.InjectRequestHeaders = append([]options.Header{authHeader}, opts.InjectRequestHeaders...)
+    opts.InjectResponseHeaders = append(opts.InjectResponseHeaders, authHeader)
+    return opts
+  }
+
+
+  type loadConfigurationTableInput struct {
+    configContent string
+    alphaConfigContent string
+    args []string
+    extraFlags func() *pflag.FlagSet
+    expectedOptions func() *options.Options
+    expectedErr error
+  }
+
+  DescribeTable("LoadConfiguration",
+    func(in loadConfigurationTableInput) {
+      var configFileName, alphaConfigFileName string
+
+      defer func() {
+        if configFileName != "" {
+          Expect(os.Remove(configFileName)).To(Succeed())
+        }
+        if alphaConfigFileName != "" {
+          Expect(os.Remove(alphaConfigFileName)).To(Succeed())
+        }
+      }()
+
+      if in.configContent != "" {
+        By("Writing the config to a temporary file", func() {
+          file, err := ioutil.TempFile("", "oauth2-proxy-test-config-XXXX.cfg")
+          Expect(err).ToNot(HaveOccurred())
+          defer file.Close()
+
+          configFileName = file.Name()
+
+          _, err = file.WriteString(in.configContent)
+          Expect(err).ToNot(HaveOccurred())
+        })
+      }
+
+      if in.alphaConfigContent != "" {
+        By("Writing the config to a temporary file", func() {
+          file, err := ioutil.TempFile("", "oauth2-proxy-test-alpha-config-XXXX.yaml")
+          Expect(err).ToNot(HaveOccurred())
+          defer file.Close()
+
+          alphaConfigFileName = file.Name()
+
+          _, err = file.WriteString(in.alphaConfigContent)
+          Expect(err).ToNot(HaveOccurred())
+        })
+      }
+
+      extraFlags := pflag.NewFlagSet("test-flagset", pflag.ExitOnError)
+      if in.extraFlags != nil {
+        extraFlags = in.extraFlags()
+      }
+
+      opts, err := loadConfiguration(configFileName, alphaConfigFileName, extraFlags, in.args)
+      if in.expectedErr != nil {
+        Expect(err).To(MatchError(in.expectedErr.Error()))
+      } else {
+        Expect(err).ToNot(HaveOccurred())
+      }
+      Expect(in.expectedOptions).ToNot(BeNil())
+      Expect(opts).To(Equal(in.expectedOptions()))
+    },
+    Entry("with legacy configuration", loadConfigurationTableInput{
+      configContent: testCoreConfig + testLegacyConfig,
+      expectedOptions: testExpectedOptions,
+    }),
+    Entry("with alpha configuration", loadConfigurationTableInput{
+      configContent: testCoreConfig,
+      alphaConfigContent: testAlphaConfig,
+      expectedOptions: testExpectedOptions,
+    }),
+  )
+})

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -515,7 +515,7 @@ func TestBasicAuthPassword(t *testing.T) {
 					ClaimSource: &options.ClaimSource{
 						Claim: "email",
 						BasicAuthPassword: &options.SecretSource{
-							Value: []byte(base64.StdEncoding.EncodeToString([]byte(basicAuthPassword))),
+							Value: []byte(basicAuthPassword),
 						},
 					},
 				},
@@ -1361,7 +1361,7 @@ func TestAuthOnlyEndpointSetBasicAuthTrueRequestHeaders(t *testing.T) {
 					ClaimSource: &options.ClaimSource{
 						Claim: "user",
 						BasicAuthPassword: &options.SecretSource{
-							Value: []byte(base64.StdEncoding.EncodeToString([]byte("This is a secure password"))),
+							Value: []byte("This is a secure password"),
 						},
 					},
 				},

--- a/pkg/apis/options/alpha_options.go
+++ b/pkg/apis/options/alpha_options.go
@@ -29,3 +29,11 @@ type AlphaOptions struct {
 	// or from a static secret value.
 	InjectResponseHeaders []Header `json:"injectResponseHeaders,omitempty"`
 }
+
+// MergeInto replaces alpha options in the Options struct with the values
+// from the AlphaOptions
+func (a *AlphaOptions) MergeInto(opts *Options) {
+	opts.UpstreamServers = a.Upstreams
+	opts.InjectRequestHeaders = a.InjectRequestHeaders
+	opts.InjectResponseHeaders = a.InjectResponseHeaders
+}

--- a/pkg/apis/options/alpha_options.go
+++ b/pkg/apis/options/alpha_options.go
@@ -37,3 +37,11 @@ func (a *AlphaOptions) MergeInto(opts *Options) {
 	opts.InjectRequestHeaders = a.InjectRequestHeaders
 	opts.InjectResponseHeaders = a.InjectResponseHeaders
 }
+
+// ExtractFrom populates the fields in the AlphaOptions with the values from
+// the Options
+func (a *AlphaOptions) ExtractFrom(opts *Options) {
+	a.Upstreams = opts.UpstreamServers
+	a.InjectRequestHeaders = opts.InjectRequestHeaders
+	a.InjectResponseHeaders = opts.InjectResponseHeaders
+}

--- a/pkg/apis/options/alpha_options.go
+++ b/pkg/apis/options/alpha_options.go
@@ -28,6 +28,10 @@ type AlphaOptions struct {
 	// Headers may source values from either the authenticated user's session
 	// or from a static secret value.
 	InjectResponseHeaders []Header `json:"injectResponseHeaders,omitempty"`
+
+	// SkipAuthHeaders is used to configure headers that will cause the request to bypass authentication.
+	// Note that configured header values will be compared as regular expressions.
+	SkipAuthHeaders []Header `json:"skipAuthHeaders,omitempty"`
 }
 
 // MergeInto replaces alpha options in the Options struct with the values
@@ -36,6 +40,7 @@ func (a *AlphaOptions) MergeInto(opts *Options) {
 	opts.UpstreamServers = a.Upstreams
 	opts.InjectRequestHeaders = a.InjectRequestHeaders
 	opts.InjectResponseHeaders = a.InjectResponseHeaders
+	opts.SkipAuthHeaders = a.SkipAuthHeaders
 }
 
 // ExtractFrom populates the fields in the AlphaOptions with the values from
@@ -44,4 +49,5 @@ func (a *AlphaOptions) ExtractFrom(opts *Options) {
 	a.Upstreams = opts.UpstreamServers
 	a.InjectRequestHeaders = opts.InjectRequestHeaders
 	a.InjectResponseHeaders = opts.InjectResponseHeaders
+	a.SkipAuthHeaders = opts.SkipAuthHeaders
 }

--- a/pkg/apis/options/legacy_options.go
+++ b/pkg/apis/options/legacy_options.go
@@ -39,6 +39,15 @@ func NewLegacyOptions() *LegacyOptions {
 	}
 }
 
+func NewLegacyFlagSet() *pflag.FlagSet {
+	flagSet := NewFlagSet()
+
+	flagSet.AddFlagSet(legacyUpstreamsFlagSet())
+	flagSet.AddFlagSet(legacyHeadersFlagSet())
+
+	return flagSet
+}
+
 func (l *LegacyOptions) ToOptions() (*Options, error) {
 	upstreams, err := l.LegacyUpstreams.convert()
 	if err != nil {

--- a/pkg/apis/options/legacy_options.go
+++ b/pkg/apis/options/legacy_options.go
@@ -1,7 +1,6 @@
 package options
 
 import (
-	"encoding/base64"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -235,7 +234,7 @@ func getBasicAuthHeader(preferEmailToUser bool, basicAuthPassword string) Header
 					Claim:  claim,
 					Prefix: "Basic ",
 					BasicAuthPassword: &SecretSource{
-						Value: []byte(base64.StdEncoding.EncodeToString([]byte(basicAuthPassword))),
+						Value: []byte(basicAuthPassword),
 					},
 				},
 			},

--- a/pkg/apis/options/legacy_options_test.go
+++ b/pkg/apis/options/legacy_options_test.go
@@ -1,7 +1,6 @@
 package options
 
 import (
-	"encoding/base64"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -332,7 +331,7 @@ var _ = Describe("Legacy Options", func() {
 						Claim:  "user",
 						Prefix: "Basic ",
 						BasicAuthPassword: &SecretSource{
-							Value: []byte(base64.StdEncoding.EncodeToString([]byte(basicAuthSecret))),
+							Value: []byte(basicAuthSecret),
 						},
 					},
 				},
@@ -372,7 +371,7 @@ var _ = Describe("Legacy Options", func() {
 						Claim:  "email",
 						Prefix: "Basic ",
 						BasicAuthPassword: &SecretSource{
-							Value: []byte(base64.StdEncoding.EncodeToString([]byte(basicAuthSecret))),
+							Value: []byte(basicAuthSecret),
 						},
 					},
 				},

--- a/pkg/apis/options/options.go
+++ b/pkg/apis/options/options.go
@@ -246,8 +246,6 @@ func NewFlagSet() *pflag.FlagSet {
 
 	flagSet.AddFlagSet(cookieFlagSet())
 	flagSet.AddFlagSet(loggingFlagSet())
-	flagSet.AddFlagSet(legacyUpstreamsFlagSet())
-	flagSet.AddFlagSet(legacyHeadersFlagSet())
 
 	return flagSet
 }

--- a/pkg/apis/options/options.go
+++ b/pkg/apis/options/options.go
@@ -67,9 +67,11 @@ type Options struct {
 
 	InjectRequestHeaders  []Header `cfg:",internal"`
 	InjectResponseHeaders []Header `cfg:",internal"`
+	SkipAuthHeaders       []Header `cfg:",internal"`
 
 	SkipAuthRegex         []string `flag:"skip-auth-regex" cfg:"skip_auth_regex"`
 	SkipAuthRoutes        []string `flag:"skip-auth-route" cfg:"skip_auth_routes"`
+	LegacySkipAuthHeaders []string `flag:"skip-auth-header" cfg:"skip_auth_headers"`
 	SkipJwtBearerTokens   bool     `flag:"skip-jwt-bearer-tokens" cfg:"skip_jwt_bearer_tokens"`
 	ExtraJwtIssuers       []string `flag:"extra-jwt-issuers" cfg:"extra_jwt_issuers"`
 	SkipProviderButton    bool     `flag:"skip-provider-button" cfg:"skip_provider_button"`
@@ -170,6 +172,7 @@ func NewFlagSet() *pflag.FlagSet {
 	flagSet.String("redirect-url", "", "the OAuth Redirect URL. ie: \"https://internalapp.yourcompany.com/oauth2/callback\"")
 	flagSet.StringSlice("skip-auth-regex", []string{}, "(DEPRECATED for --skip-auth-route) bypass authentication for requests path's that match (may be given multiple times)")
 	flagSet.StringSlice("skip-auth-route", []string{}, "bypass authentication for requests that match the method & path. Format: method=path_regex OR path_regex alone for all methods")
+	flagSet.StringSlice("skip-auth-header", []string{}, "bypass authentication if header matches (regular expression, e.g. X-Real-IP:^192\\\\..+$) (may be given multiple times)")
 	flagSet.Bool("skip-provider-button", false, "will skip sign-in-page to directly reach the next step: oauth/start")
 	flagSet.Bool("skip-auth-preflight", false, "will skip authentication for OPTIONS requests")
 	flagSet.Bool("ssl-insecure-skip-verify", false, "skip validation of certificates presented when using HTTPS providers")

--- a/pkg/apis/options/util/util.go
+++ b/pkg/apis/options/util/util.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	"encoding/base64"
 	"errors"
 	"io/ioutil"
 	"os"
@@ -13,9 +12,7 @@ import (
 func GetSecretValue(source *options.SecretSource) ([]byte, error) {
 	switch {
 	case len(source.Value) > 0 && source.FromEnv == "" && source.FromFile == "":
-		value := make([]byte, base64.StdEncoding.DecodedLen(len(source.Value)))
-		decoded, err := base64.StdEncoding.Decode(value, source.Value)
-		return value[:decoded], err
+		return source.Value, nil
 	case len(source.Value) == 0 && source.FromEnv != "" && source.FromFile == "":
 		return []byte(os.Getenv(source.FromEnv)), nil
 	case len(source.Value) == 0 && source.FromEnv == "" && source.FromFile != "":

--- a/pkg/apis/options/util/util_test.go
+++ b/pkg/apis/options/util/util_test.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	"encoding/base64"
 	"io/ioutil"
 	"os"
 	"path"
@@ -31,20 +30,12 @@ var _ = Describe("GetSecretValue", func() {
 		os.RemoveAll(fileDir)
 	})
 
-	It("returns the correct value from base64", func() {
-		originalValue := []byte("secret-value-1")
-		b64Value := base64.StdEncoding.EncodeToString((originalValue))
-
-		// Once encoded, the originalValue could have a decoded length longer than
-		// its actual length, ensure we trim this.
-		// This assertion ensures we are testing the triming
-		Expect(len(originalValue)).To(BeNumerically("<", base64.StdEncoding.DecodedLen(len(b64Value))))
-
+	It("returns the correct value from the string value", func() {
 		value, err := GetSecretValue(&options.SecretSource{
-			Value: []byte(b64Value),
+			Value: []byte("secret-value-1"),
 		})
 		Expect(err).ToNot(HaveOccurred())
-		Expect(value).To(Equal(originalValue))
+		Expect(string(value)).To(Equal("secret-value-1"))
 	})
 
 	It("returns the correct value from the environment", func() {

--- a/pkg/header/injector_test.go
+++ b/pkg/header/injector_test.go
@@ -49,14 +49,14 @@ var _ = Describe("Injector Suite", func() {
 				},
 				expectedErr: nil,
 			}),
-			Entry("with a static valued header from base64", newInjectorTableInput{
+			Entry("with a static valued header from string", newInjectorTableInput{
 				headers: []options.Header{
 					{
 						Name: "Secret",
 						Values: []options.HeaderValue{
 							{
 								SecretSource: &options.SecretSource{
-									Value: []byte(base64.StdEncoding.EncodeToString([]byte("super-secret"))),
+									Value: []byte("super-secret"),
 								},
 							},
 						},
@@ -200,7 +200,7 @@ var _ = Describe("Injector Suite", func() {
 								ClaimSource: &options.ClaimSource{
 									Claim: "user",
 									BasicAuthPassword: &options.SecretSource{
-										Value: []byte(base64.StdEncoding.EncodeToString([]byte("basic-password"))),
+										Value: []byte("basic-password"),
 									},
 								},
 							},
@@ -349,7 +349,7 @@ var _ = Describe("Injector Suite", func() {
 								ClaimSource: &options.ClaimSource{
 									Claim: "user",
 									BasicAuthPassword: &options.SecretSource{
-										Value: []byte(base64.StdEncoding.EncodeToString([]byte("basic-password"))),
+										Value: []byte("basic-password"),
 									},
 								},
 							},
@@ -380,17 +380,17 @@ var _ = Describe("Injector Suite", func() {
 						Values: []options.HeaderValue{
 							{
 								SecretSource: &options.SecretSource{
-									Value: []byte(base64.StdEncoding.EncodeToString([]byte("major=1"))),
+									Value: []byte("major=1"),
 								},
 							},
 							{
 								SecretSource: &options.SecretSource{
-									Value: []byte(base64.StdEncoding.EncodeToString([]byte("minor=2"))),
+									Value: []byte("minor=2"),
 								},
 							},
 							{
 								SecretSource: &options.SecretSource{
-									Value: []byte(base64.StdEncoding.EncodeToString([]byte("patch=3"))),
+									Value: []byte("patch=3"),
 								},
 							},
 						},

--- a/pkg/validation/common.go
+++ b/pkg/validation/common.go
@@ -1,7 +1,6 @@
 package validation
 
 import (
-	"encoding/base64"
 	"fmt"
 	"os"
 
@@ -13,7 +12,7 @@ const multipleValuesForSecretSource = "multiple values specified for secret sour
 func validateSecretSource(source options.SecretSource) string {
 	switch {
 	case len(source.Value) > 0 && source.FromEnv == "" && source.FromFile == "":
-		return validateSecretSourceValue(source.Value)
+		return ""
 	case len(source.Value) == 0 && source.FromEnv != "" && source.FromFile == "":
 		return validateSecretSourceEnv(source.FromEnv)
 	case len(source.Value) == 0 && source.FromEnv == "" && source.FromFile != "":
@@ -21,14 +20,6 @@ func validateSecretSource(source options.SecretSource) string {
 	default:
 		return multipleValuesForSecretSource
 	}
-}
-
-func validateSecretSourceValue(value []byte) string {
-	dst := make([]byte, len(value))
-	if _, err := base64.StdEncoding.Decode(dst, value); err != nil {
-		return fmt.Sprintf("error decoding secret value: %v", err)
-	}
-	return ""
 }
 
 func validateSecretSourceEnv(key string) string {

--- a/pkg/validation/common_test.go
+++ b/pkg/validation/common_test.go
@@ -1,7 +1,6 @@
 package validation
 
 import (
-	"encoding/base64"
 	"io/ioutil"
 	"os"
 
@@ -17,7 +16,7 @@ var _ = Describe("Common", func() {
 	var validSecretSourceFile string
 
 	BeforeEach(func() {
-		validSecretSourceValue = []byte(base64.StdEncoding.EncodeToString([]byte("This is a secret source value")))
+		validSecretSourceValue = []byte("This is a secret source value")
 		Expect(os.Setenv(validSecretSourceEnv, "This is a secret source env")).To(Succeed())
 		tmp, err := ioutil.TempFile("", "oauth2-proxy-secret-source-test")
 		Expect(err).ToNot(HaveOccurred())
@@ -109,14 +108,6 @@ var _ = Describe("Common", func() {
 				}
 			},
 			expectedMsg: "",
-		}),
-		Entry("with an invalid Value", validateSecretSourceTableInput{
-			source: func() options.SecretSource {
-				return options.SecretSource{
-					Value: []byte("Invalid Base64 Value"),
-				}
-			},
-			expectedMsg: "error decoding secret value: illegal base64 data at input byte 7",
 		}),
 		Entry("with an invalid FromEnv", validateSecretSourceTableInput{
 			source: func() options.SecretSource {

--- a/pkg/validation/header_test.go
+++ b/pkg/validation/header_test.go
@@ -148,7 +148,7 @@ var _ = Describe("Headers", func() {
 							ClaimSource: &options.ClaimSource{
 								Claim: "user",
 								BasicAuthPassword: &options.SecretSource{
-									Value: []byte("secret"),
+									FromEnv: "UNKNOWN_ENV",
 								},
 							},
 						},
@@ -157,7 +157,7 @@ var _ = Describe("Headers", func() {
 				validHeader1,
 			},
 			expectedMsgs: []string{
-				"invalid header \"With-Invalid-Basic-Auth\": invalid values: invalid basicAuthPassword: error decoding secret value: illegal base64 data at input byte 4",
+				"invalid header \"With-Invalid-Basic-Auth\": invalid values: invalid basicAuthPassword: error loading secret from environent: no value for for key \"UNKNOWN_ENV\"",
 			},
 		}),
 	)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This adds the ability to skip authentication based on request headers. Request headers are compared to a list of regular expressions provided in the configuration. If any header matches any of the provided regular expressions, oauth2proxy will grant access.

## Motivation and Context

We're using an internal fork of the bitly/oauth2_proxy project and like to switch to pusher/oauth2_proxy. We have several use cases for this, for example:

- `Host`: Some applications use different domains for different services. You might want to skip access control for some of them.
- `X-Real-IP`: If oauth2proxy is running behind a reverse proxy, this can be used to skip access control for certain IP ranges.
- `User-Agent`: This can be used to skip access control for bots.

## How Has This Been Tested?

- If the option is not used, there is no change in behavior.
- If the command line option `--skip-auth-header '(?i)^User-Agent:.*curl.*'` or config file option `skip_auth_header = ["(?i)^User-Agent:.*curl.*'"]` is set, the site can be accessed via curl but not via Chrome.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
