### PR TITLE
Prevent browser caching during auth flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Important Notes
 
+- [#453](https://github.com/oauth2-proxy/oauth2-proxy/pull/453) Responses to endpoints with a proxy prefix will now return headers for preventing browser caching.
+
 ## Breaking Changes
 
 - Migration from Pusher to independent org may have introduced breaking changes for your environment.
@@ -12,6 +14,7 @@
 
 ## Changes since v5.1.0
 
+- [#453](https://github.com/oauth2-proxy/oauth2-proxy/pull/453) Prevent browser caching during auth flow (@johejo)
 - [#468](https://github.com/oauth2-proxy/oauth2-proxy/pull/468) Implement graceful shutdown and propagate request context (@johejo)
 - [#464](https://github.com/oauth2-proxy/oauth2-proxy/pull/464) Migrate to oauth2-proxy/oauth2-proxy (@JoelSpeed)
   - Project renamed from `pusher/oauth2_proxy` to `oauth2-proxy`

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -648,12 +648,8 @@ func prepareNoCache(w http.ResponseWriter) {
 	}
 }
 
-func hasProxyPrefix(path, prefix string) bool {
-	return strings.HasPrefix(path, prefix)
-}
-
 func (p *OAuthProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
-	if hasProxyPrefix(req.URL.Path, p.ProxyPrefix) {
+	if strings.HasPrefix(req.URL.Path, p.ProxyPrefix) {
 		prepareNoCache(rw)
 	}
 

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -453,6 +453,7 @@ func (p *OAuthProxy) ErrorPage(rw http.ResponseWriter, code int, title string, m
 
 // SignInPage writes the sing in template to the response
 func (p *OAuthProxy) SignInPage(rw http.ResponseWriter, req *http.Request, code int) {
+	prepareNoCache(rw)
 	p.ClearSessionCookie(rw, req)
 	rw.WriteHeader(code)
 
@@ -734,6 +735,7 @@ func (p *OAuthProxy) SignOut(rw http.ResponseWriter, req *http.Request) {
 
 // OAuthStart starts the OAuth2 authentication flow
 func (p *OAuthProxy) OAuthStart(rw http.ResponseWriter, req *http.Request) {
+	prepareNoCache(rw)
 	nonce, err := encryption.Nonce()
 	if err != nil {
 		logger.Printf("Error obtaining nonce: %s", err.Error())

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -1541,22 +1541,6 @@ func Test_prepareNoCache(t *testing.T) {
 	}
 }
 
-func Test_hasProxyPrefix(t *testing.T) {
-	tests := []struct {
-		path, prefix string
-		want         bool
-	}{
-		{"/oauth2/start", "/oauth2", true},
-		{"/other", "/oauth2", false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.path, func(t *testing.T) {
-			got := hasProxyPrefix(tt.path, tt.prefix)
-			assert.Equal(t, tt.want, got)
-		})
-	}
-}
-
 func Test_noCacheHeadersDoesNotExistsInResponseHeadersFromUpstream(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("upstream"))

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -1524,3 +1524,35 @@ func TestFindJwtBearerToken(t *testing.T) {
 
 	fmt.Printf("%s", token)
 }
+
+func Test_prepareNoCache(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		prepareNoCache(w)
+	})
+	mux := http.NewServeMux()
+	mux.Handle("/", handler)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	mux.ServeHTTP(rec, req)
+
+	for k, v := range noCacheHeaders {
+		assert.Equal(t, rec.Header().Get(k), v)
+	}
+}
+
+func Test_hasProxyPrefix(t *testing.T) {
+	tests := []struct {
+		path, prefix string
+		want         bool
+	}{
+		{"/oauth2/start", "/oauth2", true},
+		{"/other", "/oauth2", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			got := hasProxyPrefix(tt.path, tt.prefix)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add some headers to prevent browser caching during authentication flow.

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

Browser might cache `/oauth2/start` request etc. under certain conditions.

In my environment, Chrome will **not**  send `GET /oauth2/start` to the oauth2_proxy,  and the Chrome re-uses previous `GET /authorize?approval_prompt=force&client_id=xxx&redirect_uri=yyyy.......` request and send it to the provider.

Below are my steps for browser to reproduce.
1. Login as usual our site using oauth2_proxy. ( and open a blank page on the next tab for step 4 )
2. Clear all cookies (for our site and provider)
3. Close our site tab
4. Reopen tab (Right click on the top of the empty tab)
5. Login with Provider
6. oauth2_proxy returns 403

I think oauth2_proxy gets bad OIDC state param.
If my explanation is not enough, I would supplement more further.

The implementation using some headers to prevent caching referred from go-chi/chi.
https://github.com/go-chi/chi/blob/master/middleware/nocache.go

## How Has This Been Tested?

Added unit tests.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
