### PR TITLE
clarify the nginx auth_request_set/set problem with proxy_pass

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -317,7 +317,9 @@ server {
 }
 ```
 
-If you use ingress-nginx in Kubernetes (which includes the Lua module), you also can use the following configuration snippet for your Ingress:
+When you use ingress-nginx in Kubernetes , you MUST use `kubernetes/ingress-nginx` (which includes the Lua module) and the following configuration snippet for your `Ingress`.
+Variables set with `auth_request_set` are not `set`-able in plain nginx config when the location is processed via `proxy_pass` and then may only be processed by Lua.
+Note that `nginxinc/kubernetes-ingress` does not include the Lua module.
 
 ```yaml
 nginx.ingress.kubernetes.io/auth-response-headers: Authorization
@@ -332,6 +334,7 @@ nginx.ingress.kubernetes.io/configuration-snippet: |
     end
   }
 ```
+Alternatively, use `-session-store-type=redis` when expecting sessions / large OIDC tokens.
 
 You have to substitute *name* with the actual cookie name you configured via --cookie-name parameter. If you don't set a custom cookie name the variable  should be "$upstream_cookie__oauth2_proxy_1" instead of "$upstream_cookie_name_1" and the new cookie-name should be "_oauth2_proxy_1=" instead of "name_1=".
 

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -334,7 +334,7 @@ nginx.ingress.kubernetes.io/configuration-snippet: |
     end
   }
 ```
-Alternatively, use `-session-store-type=redis` when expecting sessions / large OIDC tokens.
+It is recommended to use `-session-store-type=redis` when expecting large sessions/OIDC tokens (_e.g._ with MS Azure).
 
 You have to substitute *name* with the actual cookie name you configured via --cookie-name parameter. If you don't set a custom cookie name the variable  should be "$upstream_cookie__oauth2_proxy_1" instead of "$upstream_cookie_name_1" and the new cookie-name should be "_oauth2_proxy_1=" instead of "name_1=".
 


### PR DESCRIPTION
First, thank you very much for developing oauth2_proxy and making it available to the general public.

## Description

How to use oauth2_proxy with the `auth_request` module and Lua appears as an option and does not clarify that the offered _plain_ nginx option does not work in the presence of `proxy_pass` statements.

## Motivation and Context

I was trying to use oauth2_proxy as an `auth_request` source for nexus with the flytreeleft/nexus3-keycloak-plugin. Refreshing OAuth2 never worked. `tcpdump`-ing showed the tokens passed around to be huge (8.5kB). I was using the `nginxinc/kubernetes-ingress` with the `auth_request_set` and `set` statements to split the cookie passed as `nginx.org/location-snippets`. I could not observe any effect.

Reading @marratj's investigation of #29 and kubernetes/ingress-nginx#3716 showed that effectively, large tokens from _plain_ nginx `auth_request_set` will not be processed correctly, so that the configuration involving Lua is the _only_ option. 

I assumed for a very long time that _both_ options documented for nginx and `auth_request` were viable and only very late did I understand that the first would never work with nginx _proxy_pass`. (@marratj : I'd be grateful if ypu could cross-check and perhaps amend my attempt at clarifying the issue.)

## How Has This Been Tested?

That is an change only involving the docs.

## Checklist:

- [ ] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
