### PR TITLE
Add logging in case of invalid redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   - Release images moved to `quay.io/oauth2-proxy/oauth2-proxy`
   - Binaries renamed from `oauth2_proxy` to `oauth2-proxy`
 - [#432](https://github.com/oauth2-proxy/oauth2-proxy/pull/432) Update ruby dependencies for documentation (@theobarberbany)
+- [#471](https://github.com/oauth2-proxy/oauth2-proxy/pull/471) Add logging in case of invalid redirects (@gargath)
 
 # v5.1.0
 

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -576,6 +576,7 @@ func (p *OAuthProxy) IsValidRedirect(redirect string) bool {
 	case strings.HasPrefix(redirect, "http://") || strings.HasPrefix(redirect, "https://"):
 		redirectURL, err := url.Parse(redirect)
 		if err != nil {
+			logger.Printf("Rejecting invalid redirect %q: scheme unsupported or missing", redirect)
 			return false
 		}
 		redirectHostname := redirectURL.Hostname()
@@ -600,8 +601,10 @@ func (p *OAuthProxy) IsValidRedirect(redirect string) bool {
 			}
 		}
 
+		logger.Printf("Rejecting invalid redirect %q: domain / port not in whitelist", redirect)
 		return false
 	default:
+		logger.Printf("Rejecting invalid redirect %q: not an absolute or relative URL", redirect)
 		return false
 	}
 }


### PR DESCRIPTION
## Description

In cases where the oauth proxy rejects a requested redirect, it currently simply redirects to`/` instead with no information provided as to why this is happening.
This PR adds log statements for the different cases in which a requested redirect is rejected.

## Motivation and Context

A number of people, myself included, have been caught out by problems configuring redirects correctly. There are a number of past Issues on this repo around correctly configuring `whitelist-domains` and the `?rd=` query param.
Without understanding the codebase, it can be hard to diagnose why a redirect is not happening as expected if there is no log message reflecting the decision.

## How Has This Been Tested?

Replaced an existing deployment and re-created a known incorrect configuration to verify that logging happens.

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
