### PR TITLE
[provider/google] Always log hasMember request error object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ## Changes since v5.1.0
 
+- [#474](https://github.com/oauth2-proxy/oauth2-proxy/pull/474) Always log hasMember request error object (@jbielick)
 - [#468](https://github.com/oauth2-proxy/oauth2-proxy/pull/468) Implement graceful shutdown and propagate request context (@johejo)
 - [#464](https://github.com/oauth2-proxy/oauth2-proxy/pull/464) Migrate to oauth2-proxy/oauth2-proxy (@JoelSpeed)
   - Project renamed from `pusher/oauth2_proxy` to `oauth2-proxy`

--- a/providers/google.go
+++ b/providers/google.go
@@ -198,11 +198,11 @@ func userInGroup(service *admin.Service, groups []string, email string) bool {
 		req := service.Members.HasMember(group, email)
 		r, err := req.Do()
 		if err != nil {
-			err, ok := err.(*googleapi.Error)
+			gerr, ok := err.(*googleapi.Error)
 			switch {
-			case ok && err.Code == 404:
+			case ok && gerr.Code == 404:
 				logger.Printf("error checking membership in group %s: group does not exist", group)
-			case ok && err.Code == 400:
+			case ok && gerr.Code == 400:
 				// It is possible for Members.HasMember to return false even if the email is a group member.
 				// One case that can cause this is if the user email is from a different domain than the group,
 				// e.g. "member@otherdomain.com" in the group "group@mydomain.com" will result in a 400 error


### PR DESCRIPTION
## Description

Logs the original request error for group membership check to google

## Motivation and Context

When type asserting fails here, err is reassigned with nil and the default block of the switch prints out `<nil>` in the error message. This makes debugging a configuration or access token issue difficult.

### Before:

```
[2020/04/02 17:28:05] [google.go:224] error checking group membership: <nil>
```

### After:

```
[2020/04/02 17:28:05] [google.go:224] error checking group membership: Get "https://www.googleapis.com/admin/directory/v1/groups/group%40example.com/hasMember/josh%40example.com?alt=json&prettyPrint=false": oauth2: cannot fetch token: 401 Unauthorized
Response: {
  "error": "unauthorized_client",
  "error_description": "Client is unauthorized to retrieve access tokens using this method, or client not authorized for any of the scopes requested."
}
```

The issue seemed to be that ~I needed an additional OAuth scope, `https://www.googleapis.com/auth/admin.directory.group.member.readonly`, which I intend to add to the docs in another PR.~ The Admin SDK API was not enabled.

## How Has This Been Tested?

I'm currently trying to get this working with nginx-ingress-controller. I cloned this repo, made the change, ran the tests, built the image, pushed it, and used my custom image and got the error message in my logs.

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
