### PR TITLE
Make sure websockets respect ssl-upstream-insecure-skip-verify setting.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - [#413](https://github.com/oauth2-proxy/oauth2-proxy/pull/413) Add -set-basic-auth param to set the Basic Authorization header for upstreams (@morarucostel).
 - [#483](https://github.com/oauth2-proxy/oauth2-proxy/pull/483) Warn users when session cookies are split (@JoelSpeed)
 - [#488](https://github.com/oauth2-proxy/oauth2-proxy/pull/488) Set-Basic-Auth should default to false (@JoelSpeed)
+- [#494](https://github.com/oauth2-proxy/oauth2-proxy/pull/494) Upstream websockets TLS certificate validation now depends on ssl-upstream-insecure-skip-verify
 
 # v5.1.0
 

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -191,6 +191,9 @@ func NewWebSocketOrRestReverseProxy(u *url.URL, opts *Options, auth hmacauth.Hma
 		wsScheme := "ws" + strings.TrimPrefix(u.Scheme, "http")
 		wsURL := &url.URL{Scheme: wsScheme, Host: u.Host}
 		wsProxy = wsutil.NewSingleHostReverseProxy(wsURL)
+		if opts.SSLUpstreamInsecureSkipVerify {
+			wsProxy.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		}
 	}
 	return &UpstreamProxy{
 		upstream:  u.Host,


### PR DESCRIPTION
## Description

This change makes websockets follow the same certificate validation behaviour as HTTPS.

## Motivation and Context

Without this change, websockets have to work over HTTP or always require valid TLS certificate even when ssl-upstream-insecure-skip-verify setting is set.
With this change, websockets TLS verification matches HTTPS.

## How Has This Been Tested?

Made a build, verified that websockets now follow same certificate validation rules as HTTPS.

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.

Signed-off-by: Yaroslav Rosomakho <yaroslavros@gmail.com>

Fixes #493 