### PR TITLE
Feat: Configurable boolean options for each upstream, option to strip prefix from proxied requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - [#483](https://github.com/oauth2-proxy/oauth2-proxy/pull/483) Warn users when session cookies are split (@JoelSpeed)
 - [#488](https://github.com/oauth2-proxy/oauth2-proxy/pull/488) Set-Basic-Auth should default to false (@JoelSpeed)
 - [#494](https://github.com/oauth2-proxy/oauth2-proxy/pull/494) Upstream websockets TLS certificate validation now depends on ssl-upstream-insecure-skip-verify
+- [#495](https://github.com/oauth2-proxy/oauth2-proxy/pull/495) Configurable boolean options for each upstream, option to strip prefix from proxied requests
 
 # v5.1.0
 

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -117,7 +117,7 @@ An example [oauth2-proxy.cfg]({{ site.gitweb }}/contrib/oauth2-proxy.cfg.example
 | `-standard-logging-format` | string | Template for standard log lines | see [Logging Configuration](#logging-configuration) |
 | `-tls-cert-file` | string | path to certificate file | |
 | `-tls-key-file` | string | path to private key file | |
-| `-upstream` | string \| list | the http url(s) of the upstream endpoint, file:// paths for static files or `static://<status_code>` for static response. Routing is based on the path | |
+| `-upstream` | string \| list | the http url(s) of the upstream endpoint, file:// paths for static files or `static://<status_code>` for static response. Routing is based on the path. Options can be set for an upstream by providing an element before it with a prefix of `opts: and one or more of the options denoted in the [upstream options section](#upstream-options)  | |
 | `-validate-url` | string | Access token validation endpoint | |
 | `-version` | n/a | print version string | |
 | `-whitelist-domain` | string \| list | allowed domains for redirection after authentication. Prefix domain with a `.` to allow subdomains (eg `.example.com`) | |
@@ -133,6 +133,16 @@ See below for provider specific options
 Static file paths are configured as a file:// URL. `file:///var/www/static/` will serve the files from that directory at `http://[oauth2-proxy url]/var/www/static/`, which may not be what you want. You can provide the path to where the files should be available by adding a fragment to the configured URL. The value of the fragment will then be used to specify which path the files are available at. `file:///var/www/static/#/static/` will ie. make `/var/www/static/` available at `http://[oauth2-proxy url]/static/`.
 
 Multiple upstreams can either be configured by supplying a comma separated list to the `-upstream` parameter, supplying the parameter multiple times or provinding a list in the [config file](#config-file). When multiple upstreams are used routing to them will be based on the path they are set up with.
+
+#### Upstream Options
+
+Options can be configured for a specific upstream by providing an element before an upstream with a prefix of `opts:`. Each option should be separated by a `+`( there is only one supported option at the moment ). To specify false for an option prefix it with a `!`.
+
+Ex: `opts:StripPrefix,http://localhost:5678/thisprefix/` proxied requests will be made with  `/thisprefix/` stripped.
+
+| Option | Description | Default |
+| ------ | ----------- | ------- |
+| StripPrefix | Strips the path prefix from requests to this upstream path before proxying them to the backend  | false |
 
 ### Environment variables
 

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -174,7 +174,7 @@ func NewWebSocketOrRestReverseProxy(u *url.URL, opts *Options, auth hmacauth.Hma
 	}
 
 	if upstreamOptions.StripPath {
-		logger.Printf("stripping path %s from requests to %s", prefix, u.Host)
+		logger.Printf("stripping path %q from requests to %q", prefix, u.Host)
 		proxy = http.StripPrefix(prefix, proxy)
 	}
 

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -174,7 +174,7 @@ func NewWebSocketOrRestReverseProxy(u *url.URL, opts *Options, auth hmacauth.Hma
 	}
 
 	if upstreamOptions.StripPath {
-		fmt.Printf("stripping %s from requests\n", prefix)
+		logger.Printf("stripping path %s from requests to %s", prefix, u.Host)
 		proxy = http.StripPrefix(prefix, proxy)
 	}
 

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -176,7 +176,6 @@ func TestEncodedSlashes(t *testing.T) {
 
 	b, _ := url.Parse(backend.URL)
 	proxyHandler := NewReverseProxy(b, &Options{FlushInterval: time.Second})
-	setProxyDirector(proxyHandler)
 	frontend := httptest.NewServer(proxyHandler)
 	defer frontend.Close()
 

--- a/options.go
+++ b/options.go
@@ -163,14 +163,13 @@ func ParseUpstreamOptions(optionString string) *UpstreamOptions {
 	// struct
 	s := ps.Elem()
 	for _, opt := range strings.Split(optionString, "+") {
-		var field reflect.Value
 		var negate bool
 		if strings.HasPrefix(opt, "!") {
 			opt = opt[1:]
 			negate = true
 		}
 
-		field = s.FieldByName(opt)
+		field := s.FieldByName(opt)
 
 		if field.IsValid() {
 			field.SetBool(!negate)

--- a/options_test.go
+++ b/options_test.go
@@ -141,14 +141,14 @@ func TestRedirectURL(t *testing.T) {
 
 func TestProxyURLs(t *testing.T) {
 	o := testOptions()
-	o.Upstreams = append(o.Upstreams, "http://127.0.0.1:8081")
+	o.Upstreams = append(o.Upstreams, "opts:StripPath", "http://127.0.0.1:8081")
 	assert.Equal(t, nil, o.Validate())
-	expected := []*url.URL{
-		{Scheme: "http", Host: "127.0.0.1:8080", Path: "/"},
+	expected := []UpstreamConfig{
+		{URL: &url.URL{Scheme: "http", Host: "127.0.0.1:8080", Path: "/"}},
 		// note the '/' was added
-		{Scheme: "http", Host: "127.0.0.1:8081", Path: "/"},
+		{URL: &url.URL{Scheme: "http", Host: "127.0.0.1:8081", Path: "/"}, UpstreamOptions: UpstreamOptions{StripPath: true}},
 	}
-	assert.Equal(t, expected, o.proxyURLs)
+	assert.Equal(t, expected, o.upstreams)
 }
 
 func TestProxyURLsError(t *testing.T) {
@@ -325,4 +325,10 @@ func TestGCPHealthcheck(t *testing.T) {
 	o := testOptions()
 	o.GCPHealthChecks = true
 	assert.Equal(t, nil, o.Validate())
+}
+
+func TestNewUpstreamOptionsFromDefaults(t *testing.T) {
+	assert.NotPanics(t, func() {
+		NewUpstreamOptionsFromDefaults()
+	})
 }


### PR DESCRIPTION

## Description

Configurable boolean options for each upstream. Implemented a first option to strip prefix from proxied requests.

## Motivation and Context

This was required to enable adding an upstream that expects requests without a path prefix.

## How Has This Been Tested?

I added a few new tests for this change. I've also tested by creating two echo http servers as backends and adding them as upstreams. You can find my oauth2 proxy config and docker-compose file below: 

```cfg
upstreams = [
     "opts:StripPath",
     "http://localhost:5678/thispath/",
     "http://localhost:5679/dontstripthis/"
 ]
 client_id="abc"
 client_secret="iojoisjdff"
 skip_auth_regex="/thispath|/dontstripthis"
 cookie_secret="f640dfa7eb577ce4b27ecf47f2faf6f8"
```

```docker-compose.yaml
version: "3"
services:
    backend1:
        image: hashicorp/http-echo
        ports:
            - 5678:5678
        command:
            - "-text='hello world!'"
    backend2:
        image: hashicorp/http-echo
        ports:
            - 5679:5678
        command:
            - "-text='hello world!'"
```
Test that strip path works:
`curl http://localhost:4180/thispath/abc`
backend1 logs the request with requesturi  http://localhost:4180/abc
Test for regressions:
`curl http://localhost:4180/dontstripthis/abc`
backend2 logs the request with requesturi http://localhost:4180/dontstripthis/abc

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
