### PR TITLE
Preserve request URI when --skip-provider-button is set.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - [#483](https://github.com/oauth2-proxy/oauth2-proxy/pull/483) Warn users when session cookies are split (@JoelSpeed)
 - [#488](https://github.com/oauth2-proxy/oauth2-proxy/pull/488) Set-Basic-Auth should default to false (@JoelSpeed)
 - [#494](https://github.com/oauth2-proxy/oauth2-proxy/pull/494) Upstream websockets TLS certificate validation now depends on ssl-upstream-insecure-skip-verify
+- [#504](https://github.com/oauth2-proxy/oauth2-proxy/pull/504) Original request URL is preserved when skip-provider-button is used
 
 # v5.1.0
 

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -529,7 +529,7 @@ func (p *OAuthProxy) GetRedirect(req *http.Request) (redirect string, err error)
 		redirect = req.Form.Get("rd")
 	}
 	if !p.IsValidRedirect(redirect) {
-		redirect = req.URL.Path
+		redirect = req.RequestURI
 		if strings.HasPrefix(redirect, p.ProxyPrefix) {
 			redirect = "/"
 		}

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -519,11 +519,6 @@ func (p *OAuthProxy) ManualSignIn(rw http.ResponseWriter, req *http.Request) (st
 // GetRedirect reads the query parameter to get the URL to redirect clients to
 // once authenticated with the OAuthProxy
 func (p *OAuthProxy) GetRedirect(req *http.Request) (redirect string, err error) {
-	if p.SkipProviderButton {
-		redirect = req.RequestURI
-		return
-	}
-
 	err = req.ParseForm()
 	if err != nil {
 		return

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -519,6 +519,11 @@ func (p *OAuthProxy) ManualSignIn(rw http.ResponseWriter, req *http.Request) (st
 // GetRedirect reads the query parameter to get the URL to redirect clients to
 // once authenticated with the OAuthProxy
 func (p *OAuthProxy) GetRedirect(req *http.Request) (redirect string, err error) {
+	if p.SkipProviderButton {
+		redirect = req.RequestURI
+		return
+	}
+
 	err = req.ParseForm()
 	if err != nil {
 		return

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -530,7 +530,7 @@ func (p *OAuthProxy) GetRedirect(req *http.Request) (redirect string, err error)
 	}
 	if !p.IsValidRedirect(redirect) {
 		redirect = req.RequestURI
-		if strings.HasPrefix(redirect, p.ProxyPrefix) {
+		if redirect == "" || strings.HasPrefix(redirect, p.ProxyPrefix) {
 			redirect = "/"
 		}
 	}


### PR DESCRIPTION
## Description

Currently original request URI is not preserved if skip-provider-button is set and nobody is feeding X-Auth-Request-Redirect header. This behaviour breaks many applications.

This PR is a trivial fix of this issue.

## Motivation and Context

Preserving original request URL is important for many applications and skip-provider-button is a common option for users of a single authentication provider.
Original bug is https://github.com/oauth2-proxy/oauth2-proxy/issues/30

## How Has This Been Tested?

Without this change URL is not preserved and is always set to "/". With this change URL is preserved in the state.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My change requires a change to the documentation or CHANGELOG.
- [X] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
