### PR TITLE
Migrate cookie signing to SHA256 from SHA1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ## Changes since v5.1.1
 
+- [#524](https://github.com/oauth2-proxy/oauth2-proxy/pull/524) Sign cookies with SHA256 (@NickMeves)
 - [#487](https://github.com/oauth2-proxy/oauth2-proxy/pull/487) Switch flags to PFlag to remove StringArray (@JoelSpeed)
 - [#484](https://github.com/oauth2-proxy/oauth2-proxy/pull/484) Replace configuration loading with Viper (@JoelSpeed)
 - [#499](https://github.com/oauth2-proxy/oauth2-proxy/pull/499) Add `-user-id-claim` to support generic claims in addition to email (@holyjak)

--- a/pkg/encryption/cipher_test.go
+++ b/pkg/encryption/cipher_test.go
@@ -1,11 +1,30 @@
 package encryption
 
 import (
+	"crypto/sha1"
+	"crypto/sha256"
 	"encoding/base64"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestSignAndValidate(t *testing.T) {
+	seed := "0123456789abcdef"
+	key := "cookie-name"
+	value := base64.URLEncoding.EncodeToString([]byte("I am soooo encoded"))
+	epoch := "123456789"
+
+	sha256sig := cookieSignature(sha256.New, seed, key, value, epoch)
+	sha1sig := cookieSignature(sha1.New, seed, key, value, epoch)
+
+	assert.True(t, checkSignature(sha256sig, seed, key, value, epoch))
+	// This should be switched to False after fully deprecating SHA1
+	assert.True(t, checkSignature(sha1sig, seed, key, value, epoch))
+
+	assert.False(t, checkSignature(sha256sig, seed, key, "tampered", epoch))
+	assert.False(t, checkSignature(sha1sig, seed, key, "tampered", epoch))
+}
 
 func TestEncodeAndDecodeAccessToken(t *testing.T) {
 	const secret = "0123456789abcdefghijklmnopqrstuv"


### PR DESCRIPTION
This moves cookie signing from SHA1 to SHA256 in a backwards compatible way that still validates existing cookies with SHA1 signatures (to be removed later after a burn in period).

## Description

Sign cookies with SHA256

## Motivation and Context

Since SHA1 for signing now has multiple vulnerabilities & collision attack issues, this moves to the more cryptographically secure SHA256.

## How Has This Been Tested?

Ran locally:
Confirmed existing SHA1 signed cookie sessions still were valid with the proxy.
Confirmed new cookies were signed with SHA256

UPDATE: Unit tests added

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
