### PR TITLE
Encryption efficiency improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 
 ## Changes since v5.1.1
 
+- [#539](https://github.com/oauth2-proxy/oauth2-proxy/pull/539) Refactor encryption ciphers and add AES-GCM support (@NickMeves)
 - [#601](https://github.com/oauth2-proxy/oauth2-proxy/pull/601) Ensure decrypted user/email are valid UTF8 (@JoelSpeed)
 - [#560](https://github.com/oauth2-proxy/oauth2-proxy/pull/560) Fallback to UserInfo is User ID claim not present (@JoelSpeed)
 - [#598](https://github.com/oauth2-proxy/oauth2-proxy/pull/598) acr_values no longer sent to IdP when empty (@ScottGuymer)

--- a/pkg/apis/options/sessions.go
+++ b/pkg/apis/options/sessions.go
@@ -5,7 +5,7 @@ import "github.com/oauth2-proxy/oauth2-proxy/pkg/encryption"
 // SessionOptions contains configuration options for the SessionStore providers.
 type SessionOptions struct {
 	Type   string             `flag:"session-store-type" cfg:"session_store_type"`
-	Cipher *encryption.Cipher `cfg:",internal"`
+	Cipher encryption.Cipher `cfg:",internal"`
 	Redis  RedisStoreOptions  `cfg:",squash"`
 }
 

--- a/pkg/apis/options/sessions.go
+++ b/pkg/apis/options/sessions.go
@@ -4,9 +4,9 @@ import "github.com/oauth2-proxy/oauth2-proxy/pkg/encryption"
 
 // SessionOptions contains configuration options for the SessionStore providers.
 type SessionOptions struct {
-	Type   string             `flag:"session-store-type" cfg:"session_store_type"`
+	Type   string            `flag:"session-store-type" cfg:"session_store_type"`
 	Cipher encryption.Cipher `cfg:",internal"`
-	Redis  RedisStoreOptions  `cfg:",squash"`
+	Redis  RedisStoreOptions `cfg:",squash"`
 }
 
 // CookieSessionStoreType is used to indicate the CookieSessionStore should be

--- a/pkg/apis/sessions/session_state_test.go
+++ b/pkg/apis/sessions/session_state_test.go
@@ -17,10 +17,14 @@ func timePtr(t time.Time) *time.Time {
 	return &t
 }
 
+func NewCipher(secret []byte) (encryption.Cipher, error) {
+	return encryption.NewBase64Cipher(encryption.NewCFBCipher, secret)
+}
+
 func TestSessionStateSerialization(t *testing.T) {
-	c, err := encryption.NewCipher([]byte(secret))
+	c, err := NewCipher([]byte(secret))
 	assert.Equal(t, nil, err)
-	c2, err := encryption.NewCipher([]byte(altSecret))
+	c2, err := NewCipher([]byte(altSecret))
 	assert.Equal(t, nil, err)
 	s := &sessions.SessionState{
 		Email:             "user@domain.com",
@@ -53,9 +57,9 @@ func TestSessionStateSerialization(t *testing.T) {
 }
 
 func TestSessionStateSerializationWithUser(t *testing.T) {
-	c, err := encryption.NewCipher([]byte(secret))
+	c, err := NewCipher([]byte(secret))
 	assert.Equal(t, nil, err)
-	c2, err := encryption.NewCipher([]byte(altSecret))
+	c2, err := NewCipher([]byte(altSecret))
 	assert.Equal(t, nil, err)
 	s := &sessions.SessionState{
 		User:              "just-user",
@@ -201,7 +205,7 @@ func TestDecodeSessionState(t *testing.T) {
 	eJSON, _ := e.MarshalJSON()
 	eString := string(eJSON)
 
-	c, err := encryption.NewCipher([]byte(secret))
+	c, err := NewCipher([]byte(secret))
 	assert.NoError(t, err)
 
 	testCases := []testCase{

--- a/pkg/apis/sessions/session_state_test.go
+++ b/pkg/apis/sessions/session_state_test.go
@@ -1,11 +1,13 @@
-package sessions_test
+package sessions
 
 import (
+	"crypto/rand"
 	"fmt"
+	"io"
+	mathrand "math/rand"
 	"testing"
 	"time"
 
-	"github.com/oauth2-proxy/oauth2-proxy/pkg/apis/sessions"
 	"github.com/oauth2-proxy/oauth2-proxy/pkg/encryption"
 	"github.com/stretchr/testify/assert"
 )
@@ -26,7 +28,7 @@ func TestSessionStateSerialization(t *testing.T) {
 	assert.Equal(t, nil, err)
 	c2, err := newTestCipher([]byte(altSecret))
 	assert.Equal(t, nil, err)
-	s := &sessions.SessionState{
+	s := &SessionState{
 		Email:             "user@domain.com",
 		PreferredUsername: "user",
 		AccessToken:       "token1234",
@@ -38,7 +40,7 @@ func TestSessionStateSerialization(t *testing.T) {
 	encoded, err := s.EncodeSessionState(c)
 	assert.Equal(t, nil, err)
 
-	ss, err := sessions.DecodeSessionState(encoded, c)
+	ss, err := DecodeSessionState(encoded, c)
 	t.Logf("%#v", ss)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "", ss.User)
@@ -51,7 +53,7 @@ func TestSessionStateSerialization(t *testing.T) {
 	assert.Equal(t, s.RefreshToken, ss.RefreshToken)
 
 	// ensure a different cipher can't decode properly (ie: it gets gibberish)
-	ss, err = sessions.DecodeSessionState(encoded, c2)
+	ss, err = DecodeSessionState(encoded, c2)
 	t.Logf("%#v", ss)
 	assert.NotEqual(t, nil, err)
 }
@@ -61,7 +63,7 @@ func TestSessionStateSerializationWithUser(t *testing.T) {
 	assert.Equal(t, nil, err)
 	c2, err := newTestCipher([]byte(altSecret))
 	assert.Equal(t, nil, err)
-	s := &sessions.SessionState{
+	s := &SessionState{
 		User:              "just-user",
 		PreferredUsername: "ju",
 		Email:             "user@domain.com",
@@ -73,7 +75,7 @@ func TestSessionStateSerializationWithUser(t *testing.T) {
 	encoded, err := s.EncodeSessionState(c)
 	assert.Equal(t, nil, err)
 
-	ss, err := sessions.DecodeSessionState(encoded, c)
+	ss, err := DecodeSessionState(encoded, c)
 	t.Logf("%#v", ss)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, s.User, ss.User)
@@ -85,13 +87,13 @@ func TestSessionStateSerializationWithUser(t *testing.T) {
 	assert.Equal(t, s.RefreshToken, ss.RefreshToken)
 
 	// ensure a different cipher can't decode properly (ie: it gets gibberish)
-	ss, err = sessions.DecodeSessionState(encoded, c2)
+	ss, err = DecodeSessionState(encoded, c2)
 	t.Logf("%#v", ss)
 	assert.NotEqual(t, nil, err)
 }
 
 func TestSessionStateSerializationNoCipher(t *testing.T) {
-	s := &sessions.SessionState{
+	s := &SessionState{
 		Email:             "user@domain.com",
 		PreferredUsername: "user",
 		AccessToken:       "token1234",
@@ -103,7 +105,7 @@ func TestSessionStateSerializationNoCipher(t *testing.T) {
 	assert.Equal(t, nil, err)
 
 	// only email should have been serialized
-	ss, err := sessions.DecodeSessionState(encoded, nil)
+	ss, err := DecodeSessionState(encoded, nil)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "", ss.User)
 	assert.Equal(t, s.Email, ss.Email)
@@ -113,7 +115,7 @@ func TestSessionStateSerializationNoCipher(t *testing.T) {
 }
 
 func TestSessionStateSerializationNoCipherWithUser(t *testing.T) {
-	s := &sessions.SessionState{
+	s := &SessionState{
 		User:              "just-user",
 		Email:             "user@domain.com",
 		PreferredUsername: "user",
@@ -126,7 +128,7 @@ func TestSessionStateSerializationNoCipherWithUser(t *testing.T) {
 	assert.Equal(t, nil, err)
 
 	// only email should have been serialized
-	ss, err := sessions.DecodeSessionState(encoded, nil)
+	ss, err := DecodeSessionState(encoded, nil)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, s.User, ss.User)
 	assert.Equal(t, s.Email, ss.Email)
@@ -136,18 +138,18 @@ func TestSessionStateSerializationNoCipherWithUser(t *testing.T) {
 }
 
 func TestExpired(t *testing.T) {
-	s := &sessions.SessionState{ExpiresOn: timePtr(time.Now().Add(time.Duration(-1) * time.Minute))}
+	s := &SessionState{ExpiresOn: timePtr(time.Now().Add(time.Duration(-1) * time.Minute))}
 	assert.Equal(t, true, s.IsExpired())
 
-	s = &sessions.SessionState{ExpiresOn: timePtr(time.Now().Add(time.Duration(1) * time.Minute))}
+	s = &SessionState{ExpiresOn: timePtr(time.Now().Add(time.Duration(1) * time.Minute))}
 	assert.Equal(t, false, s.IsExpired())
 
-	s = &sessions.SessionState{}
+	s = &SessionState{}
 	assert.Equal(t, false, s.IsExpired())
 }
 
 type testCase struct {
-	sessions.SessionState
+	SessionState
 	Encoded string
 	Cipher  encryption.Cipher
 	Error   bool
@@ -163,14 +165,14 @@ func TestEncodeSessionState(t *testing.T) {
 
 	testCases := []testCase{
 		{
-			SessionState: sessions.SessionState{
+			SessionState: SessionState{
 				Email: "user@domain.com",
 				User:  "just-user",
 			},
 			Encoded: `{"Email":"user@domain.com","User":"just-user"}`,
 		},
 		{
-			SessionState: sessions.SessionState{
+			SessionState: SessionState{
 				Email:        "user@domain.com",
 				User:         "just-user",
 				AccessToken:  "token1234",
@@ -185,7 +187,7 @@ func TestEncodeSessionState(t *testing.T) {
 
 	for i, tc := range testCases {
 		encoded, err := tc.EncodeSessionState(tc.Cipher)
-		t.Logf("i:%d Encoded:%#vsessions.SessionState:%#v Error:%#v", i, encoded, tc.SessionState, err)
+		t.Logf("i:%d Encoded:%#vSessionState:%#v Error:%#v", i, encoded, tc.SessionState, err)
 		if tc.Error {
 			assert.Error(t, err)
 			assert.Empty(t, encoded)
@@ -210,34 +212,34 @@ func TestDecodeSessionState(t *testing.T) {
 
 	testCases := []testCase{
 		{
-			SessionState: sessions.SessionState{
+			SessionState: SessionState{
 				Email: "user@domain.com",
 				User:  "just-user",
 			},
 			Encoded: `{"Email":"user@domain.com","User":"just-user"}`,
 		},
 		{
-			SessionState: sessions.SessionState{
+			SessionState: SessionState{
 				Email: "user@domain.com",
 				User:  "",
 			},
 			Encoded: `{"Email":"user@domain.com"}`,
 		},
 		{
-			SessionState: sessions.SessionState{
+			SessionState: SessionState{
 				User: "just-user",
 			},
 			Encoded: `{"User":"just-user"}`,
 		},
 		{
-			SessionState: sessions.SessionState{
+			SessionState: SessionState{
 				Email: "user@domain.com",
 				User:  "just-user",
 			},
 			Encoded: fmt.Sprintf(`{"Email":"user@domain.com","User":"just-user","AccessToken":"I6s+ml+/MldBMgHIiC35BTKTh57skGX24w==","IDToken":"xojNdyyjB1HgYWh6XMtXY/Ph5eCVxa1cNsklJw==","RefreshToken":"qEX0x6RmASxo4dhlBG6YuRs9Syn/e9sHu/+K","CreatedAt":%s,"ExpiresOn":%s}`, createdString, eString),
 		},
 		{
-			SessionState: sessions.SessionState{
+			SessionState: SessionState{
 				Email:        "user@domain.com",
 				User:         "just-user",
 				AccessToken:  "token1234",
@@ -250,7 +252,7 @@ func TestDecodeSessionState(t *testing.T) {
 			Cipher:  c,
 		},
 		{
-			SessionState: sessions.SessionState{
+			SessionState: SessionState{
 				Email: "user@domain.com",
 				User:  "just-user",
 			},
@@ -268,7 +270,7 @@ func TestDecodeSessionState(t *testing.T) {
 			Error:   true,
 		},
 		{
-			SessionState: sessions.SessionState{
+			SessionState: SessionState{
 				Email: "user@domain.com",
 				User:  "YmFzZTY0LWVuY29kZWQtdXNlcgo=", // Base64 encoding of base64-encoded-user
 			},
@@ -278,8 +280,8 @@ func TestDecodeSessionState(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		ss, err := sessions.DecodeSessionState(tc.Encoded, tc.Cipher)
-		t.Logf("i:%d Encoded:%#vsessions.SessionState:%#v Error:%#v", i, tc.Encoded, ss, err)
+		ss, err := DecodeSessionState(tc.Encoded, tc.Cipher)
+		t.Logf("i:%d Encoded:%#vSessionState:%#v Error:%#v", i, tc.Encoded, ss, err)
 		if tc.Error {
 			assert.Error(t, err)
 			assert.Nil(t, ss)
@@ -301,7 +303,7 @@ func TestDecodeSessionState(t *testing.T) {
 }
 
 func TestSessionStateAge(t *testing.T) {
-	ss := &sessions.SessionState{}
+	ss := &SessionState{}
 
 	// Created at unset so should be 0
 	assert.Equal(t, time.Duration(0), ss.Age())
@@ -309,4 +311,45 @@ func TestSessionStateAge(t *testing.T) {
 	// Set CreatedAt to 1 hour ago
 	ss.CreatedAt = timePtr(time.Now().Add(-1 * time.Hour))
 	assert.Equal(t, time.Hour, ss.Age().Round(time.Minute))
+}
+
+func TestIntoEncryptAndIntoDecrypt(t *testing.T) {
+	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+	// Test all 3 valid AES sizes
+	for _, secretSize := range []int{16, 24, 32} {
+		t.Run(fmt.Sprintf("%d", secretSize), func(t *testing.T) {
+			secret := make([]byte, secretSize)
+			_, err := io.ReadFull(rand.Reader, secret)
+			assert.Equal(t, nil, err)
+
+			c, err := newTestCipher(secret)
+			assert.NoError(t, err)
+
+			// Check no errors with empty or nil strings
+			empty := ""
+			assert.Equal(t, nil, into(&empty, c.Encrypt))
+			assert.Equal(t, nil, into(&empty, c.Decrypt))
+			assert.Equal(t, nil, into(nil, c.Encrypt))
+			assert.Equal(t, nil, into(nil, c.Decrypt))
+
+			// Test various sizes tokens might be
+			for _, dataSize := range []int{10, 100, 1000, 5000, 10000} {
+				t.Run(fmt.Sprintf("%d", dataSize), func(t *testing.T) {
+					b := make([]byte, dataSize)
+					for i := range b {
+						b[i] = charset[mathrand.Intn(len(charset))]
+					}
+					data := string(b)
+					originalData := data
+
+					assert.Equal(t, nil, into(&data, c.Encrypt))
+					assert.NotEqual(t, originalData, data)
+
+					assert.Equal(t, nil, into(&data, c.Decrypt))
+					assert.Equal(t, originalData, data)
+				})
+			}
+		})
+	}
 }

--- a/pkg/apis/sessions/session_state_test.go
+++ b/pkg/apis/sessions/session_state_test.go
@@ -17,14 +17,14 @@ func timePtr(t time.Time) *time.Time {
 	return &t
 }
 
-func NewCipher(secret []byte) (encryption.Cipher, error) {
+func newTestCipher(secret []byte) (encryption.Cipher, error) {
 	return encryption.NewBase64Cipher(encryption.NewCFBCipher, secret)
 }
 
 func TestSessionStateSerialization(t *testing.T) {
-	c, err := NewCipher([]byte(secret))
+	c, err := newTestCipher([]byte(secret))
 	assert.Equal(t, nil, err)
-	c2, err := NewCipher([]byte(altSecret))
+	c2, err := newTestCipher([]byte(altSecret))
 	assert.Equal(t, nil, err)
 	s := &sessions.SessionState{
 		Email:             "user@domain.com",
@@ -57,9 +57,9 @@ func TestSessionStateSerialization(t *testing.T) {
 }
 
 func TestSessionStateSerializationWithUser(t *testing.T) {
-	c, err := NewCipher([]byte(secret))
+	c, err := newTestCipher([]byte(secret))
 	assert.Equal(t, nil, err)
-	c2, err := NewCipher([]byte(altSecret))
+	c2, err := newTestCipher([]byte(altSecret))
 	assert.Equal(t, nil, err)
 	s := &sessions.SessionState{
 		User:              "just-user",
@@ -205,7 +205,7 @@ func TestDecodeSessionState(t *testing.T) {
 	eJSON, _ := e.MarshalJSON()
 	eString := string(eJSON)
 
-	c, err := NewCipher([]byte(secret))
+	c, err := newTestCipher([]byte(secret))
 	assert.NoError(t, err)
 
 	testCases := []testCase{

--- a/pkg/apis/sessions/session_state_test.go
+++ b/pkg/apis/sessions/session_state_test.go
@@ -145,7 +145,7 @@ func TestExpired(t *testing.T) {
 type testCase struct {
 	sessions.SessionState
 	Encoded string
-	Cipher  *encryption.Cipher
+	Cipher  encryption.Cipher
 	Error   bool
 }
 

--- a/pkg/encryption/cipher.go
+++ b/pkg/encryption/cipher.go
@@ -13,11 +13,9 @@ import (
 type Cipher interface {
 	Encrypt(value []byte) ([]byte, error)
 	Decrypt(ciphertext []byte) ([]byte, error)
-	EncryptInto(s *string) error
-	DecryptInto(s *string) error
 }
 
-type Base64Cipher struct {
+type base64Cipher struct {
 	Cipher Cipher
 }
 
@@ -28,11 +26,11 @@ func NewBase64Cipher(initCipher func([]byte) (Cipher, error), secret []byte) (Ci
 	if err != nil {
 		return nil, err
 	}
-	return &Base64Cipher{Cipher: c}, nil
+	return &base64Cipher{Cipher: c}, nil
 }
 
 // Encrypt encrypts a value with the embedded Cipher & Base64 encodes it
-func (c *Base64Cipher) Encrypt(value []byte) ([]byte, error) {
+func (c *base64Cipher) Encrypt(value []byte) ([]byte, error) {
 	encrypted, err := c.Cipher.Encrypt(value)
 	if err != nil {
 		return nil, err
@@ -42,7 +40,7 @@ func (c *Base64Cipher) Encrypt(value []byte) ([]byte, error) {
 }
 
 // Decrypt Base64 decodes a value & decrypts it with the embedded Cipher
-func (c *Base64Cipher) Decrypt(ciphertext []byte) ([]byte, error) {
+func (c *base64Cipher) Decrypt(ciphertext []byte) ([]byte, error) {
 	encrypted, err := base64.StdEncoding.DecodeString(string(ciphertext))
 	if err != nil {
 		return nil, fmt.Errorf("failed to base64 decode value %s", err)
@@ -51,17 +49,7 @@ func (c *Base64Cipher) Decrypt(ciphertext []byte) ([]byte, error) {
 	return c.Cipher.Decrypt(encrypted)
 }
 
-// EncryptInto encrypts the value and stores it back in the string pointer
-func (c *Base64Cipher) EncryptInto(s *string) error {
-	return into(c.Encrypt, s)
-}
-
-// DecryptInto decrypts the value and stores it back in the string pointer
-func (c *Base64Cipher) DecryptInto(s *string) error {
-	return into(c.Decrypt, s)
-}
-
-type CFBCipher struct {
+type cfbCipher struct {
 	cipher.Block
 }
 
@@ -71,11 +59,11 @@ func NewCFBCipher(secret []byte) (Cipher, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &CFBCipher{Block: c}, err
+	return &cfbCipher{Block: c}, err
 }
 
 // Encrypt with AES CFB
-func (c *CFBCipher) Encrypt(value []byte) ([]byte, error) {
+func (c *cfbCipher) Encrypt(value []byte) ([]byte, error) {
 	ciphertext := make([]byte, aes.BlockSize+len(value))
 	iv := ciphertext[:aes.BlockSize]
 	if _, err := io.ReadFull(rand.Reader, iv); err != nil {
@@ -88,7 +76,7 @@ func (c *CFBCipher) Encrypt(value []byte) ([]byte, error) {
 }
 
 // Decrypt an AES CFB ciphertext
-func (c *CFBCipher) Decrypt(ciphertext []byte) ([]byte, error) {
+func (c *cfbCipher) Decrypt(ciphertext []byte) ([]byte, error) {
 	if len(ciphertext) < aes.BlockSize {
 		return nil, fmt.Errorf("encrypted value should be at least %d bytes, but is only %d bytes", aes.BlockSize, len(ciphertext))
 	}
@@ -101,17 +89,7 @@ func (c *CFBCipher) Decrypt(ciphertext []byte) ([]byte, error) {
 	return plaintext, nil
 }
 
-// EncryptInto returns an error since the encrypted data is a []byte that isn't string cast-able
-func (c *CFBCipher) EncryptInto(s *string) error {
-	return fmt.Errorf("CFBCipher is not a string->string compatible cipher")
-}
-
-// EncryptInto returns an error since the encrypted data needs to be a []byte
-func (c *CFBCipher) DecryptInto(s *string) error {
-	return fmt.Errorf("CFBCipher is not a string->string compatible cipher")
-}
-
-type GCMCipher struct {
+type gcmCipher struct {
 	cipher.Block
 }
 
@@ -121,11 +99,11 @@ func NewGCMCipher(secret []byte) (Cipher, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &GCMCipher{Block: c}, err
+	return &gcmCipher{Block: c}, err
 }
 
 // Encrypt with AES GCM on raw bytes
-func (c *GCMCipher) Encrypt(value []byte) ([]byte, error) {
+func (c *gcmCipher) Encrypt(value []byte) ([]byte, error) {
 	gcm, err := cipher.NewGCM(c.Block)
 	if err != nil {
 		return nil, err
@@ -141,7 +119,7 @@ func (c *GCMCipher) Encrypt(value []byte) ([]byte, error) {
 }
 
 // Decrypt an AES GCM ciphertext
-func (c *GCMCipher) Decrypt(ciphertext []byte) ([]byte, error) {
+func (c *gcmCipher) Decrypt(ciphertext []byte) ([]byte, error) {
 	gcm, err := cipher.NewGCM(c.Block)
 	if err != nil {
 		return nil, err
@@ -155,31 +133,4 @@ func (c *GCMCipher) Decrypt(ciphertext []byte) ([]byte, error) {
 		return nil, err
 	}
 	return plaintext, nil
-}
-
-// EncryptInto returns an error since the encrypted data is a []byte that isn't string cast-able
-func (c *GCMCipher) EncryptInto(s *string) error {
-	return fmt.Errorf("CFBCipher is not a string->string compatible cipher")
-}
-
-// EncryptInto returns an error since the encrypted data needs to be a []byte
-func (c *GCMCipher) DecryptInto(s *string) error {
-	return fmt.Errorf("CFBCipher is not a string->string compatible cipher")
-}
-
-// codecFunc is a function that takes a string and encodes/decodes it
-type codecFunc func([]byte) ([]byte, error)
-
-func into(f codecFunc, s *string) error {
-	// Do not encrypt/decrypt nil or empty strings
-	if s == nil || *s == "" {
-		return nil
-	}
-
-	d, err := f([]byte(*s))
-	if err != nil {
-		return err
-	}
-	*s = string(d)
-	return nil
 }

--- a/pkg/encryption/cipher.go
+++ b/pkg/encryption/cipher.go
@@ -3,111 +3,11 @@ package encryption
 import (
 	"crypto/aes"
 	"crypto/cipher"
-	"crypto/hmac"
 	"crypto/rand"
-	"crypto/sha1"
-	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
-	"hash"
 	"io"
-	"net/http"
-	"strconv"
-	"strings"
-	"time"
 )
-
-// SecretBytes attempts to base64 decode the secret, if that fails it treats the secret as binary
-func SecretBytes(secret string) []byte {
-	b, err := base64.RawURLEncoding.DecodeString(strings.TrimRight(secret, "="))
-	if err == nil {
-		// Only return decoded form if a valid AES length
-		// Don't want unintentional decoding resulting in invalid lengths confusing a user
-		// that thought they used a 16, 24, 32 length string
-		for _, i := range []int{16, 24, 32} {
-			if len(b) == i {
-				return b
-			}
-		}
-	}
-	// If decoding didn't work or resulted in non-AES compliant length,
-	// assume the raw string was the intended secret
-	return []byte(secret)
-}
-
-// cookies are stored in a 3 part (value + timestamp + signature) to enforce that the values are as originally set.
-// additionally, the 'value' is encrypted so it's opaque to the browser
-
-// Validate ensures a cookie is properly signed
-func Validate(cookie *http.Cookie, seed string, expiration time.Duration) (value []byte, t time.Time, ok bool) {
-	// value, timestamp, sig
-	parts := strings.Split(cookie.Value, "|")
-	if len(parts) != 3 {
-		return
-	}
-	if checkSignature(parts[2], seed, cookie.Name, parts[0], parts[1]) {
-		ts, err := strconv.Atoi(parts[1])
-		if err != nil {
-			return
-		}
-		// The expiration timestamp set when the cookie was created
-		// isn't sent back by the browser. Hence, we check whether the
-		// creation timestamp stored in the cookie falls within the
-		// window defined by (Now()-expiration, Now()].
-		t = time.Unix(int64(ts), 0)
-		if t.After(time.Now().Add(expiration*-1)) && t.Before(time.Now().Add(time.Minute*5)) {
-			// it's a valid cookie. now get the contents
-			rawValue, err := base64.URLEncoding.DecodeString(parts[0])
-			if err == nil {
-				value = rawValue
-				ok = true
-				return
-			}
-		}
-	}
-	return
-}
-
-// SignedValue returns a cookie that is signed and can later be checked with Validate
-func SignedValue(seed string, key string, value []byte, now time.Time) string {
-	encodedValue := base64.URLEncoding.EncodeToString(value)
-	timeStr := fmt.Sprintf("%d", now.Unix())
-	sig := cookieSignature(sha256.New, seed, key, encodedValue, timeStr)
-	cookieVal := fmt.Sprintf("%s|%s|%s", encodedValue, timeStr, sig)
-	return cookieVal
-}
-
-func cookieSignature(signer func() hash.Hash, args ...string) string {
-	h := hmac.New(signer, []byte(args[0]))
-	for _, arg := range args[1:] {
-		h.Write([]byte(arg))
-	}
-	var b []byte
-	b = h.Sum(b)
-	return base64.URLEncoding.EncodeToString(b)
-}
-
-func checkSignature(signature string, args ...string) bool {
-	checkSig := cookieSignature(sha256.New, args...)
-	if checkHmac(signature, checkSig) {
-		return true
-	}
-
-	// TODO: After appropriate rollout window, remove support for SHA1
-	legacySig := cookieSignature(sha1.New, args...)
-	return checkHmac(signature, legacySig)
-}
-
-func checkHmac(input, expected string) bool {
-	inputMAC, err1 := base64.URLEncoding.DecodeString(input)
-	if err1 == nil {
-		expectedMAC, err2 := base64.URLEncoding.DecodeString(expected)
-		if err2 == nil {
-			return hmac.Equal(inputMAC, expectedMAC)
-		}
-	}
-	return false
-}
 
 // Cipher provides methods to encrypt and decrypt
 type Cipher interface {

--- a/pkg/encryption/cipher.go
+++ b/pkg/encryption/cipher.go
@@ -50,7 +50,7 @@ func NewBase64Cipher(initCipher func([]byte) (Cipher, error), secret []byte) (Ci
 	return &Base64Cipher{Cipher: c}, nil
 }
 
-// Encrypt encrypts a value with AES CFB & base64 encodes it
+// Encrypt encrypts a value with AES CFB & Base64 encodes it
 func (c *Base64Cipher) Encrypt(value []byte) ([]byte, error) {
 	encrypted, err := c.Cipher.Encrypt([]byte(value))
 	if err != nil {

--- a/pkg/encryption/cipher.go
+++ b/pkg/encryption/cipher.go
@@ -39,7 +39,7 @@ func SecretBytes(secret string) []byte {
 // additionally, the 'value' is encrypted so it's opaque to the browser
 
 // Validate ensures a cookie is properly signed
-func Validate(cookie *http.Cookie, seed string, expiration time.Duration) (value string, t time.Time, ok bool) {
+func Validate(cookie *http.Cookie, seed string, expiration time.Duration) (value []byte, t time.Time, ok bool) {
 	// value, timestamp, sig
 	parts := strings.Split(cookie.Value, "|")
 	if len(parts) != 3 {
@@ -59,7 +59,7 @@ func Validate(cookie *http.Cookie, seed string, expiration time.Duration) (value
 			// it's a valid cookie. now get the contents
 			rawValue, err := base64.URLEncoding.DecodeString(parts[0])
 			if err == nil {
-				value = string(rawValue)
+				value = rawValue
 				ok = true
 				return
 			}
@@ -69,8 +69,8 @@ func Validate(cookie *http.Cookie, seed string, expiration time.Duration) (value
 }
 
 // SignedValue returns a cookie that is signed and can later be checked with Validate
-func SignedValue(seed string, key string, value string, now time.Time) string {
-	encodedValue := base64.URLEncoding.EncodeToString([]byte(value))
+func SignedValue(seed string, key string, value []byte, now time.Time) string {
+	encodedValue := base64.URLEncoding.EncodeToString(value)
 	timeStr := fmt.Sprintf("%d", now.Unix())
 	sig := cookieSignature(sha256.New, seed, key, encodedValue, timeStr)
 	cookieVal := fmt.Sprintf("%s|%s|%s", encodedValue, timeStr, sig)

--- a/pkg/encryption/cipher_test.go
+++ b/pkg/encryption/cipher_test.go
@@ -134,17 +134,96 @@ func TestEncodeAndDecodeAccessTokenB64(t *testing.T) {
 	assert.Equal(t, []byte(token), decoded)
 }
 
-func TestEncryptAndDecryptBase64(t *testing.T) {
+func TestEncryptAndDecrypt(t *testing.T) {
 	var err error
 
+	// Test our 3 cipher types
+	for _, initCipher := range []func([]byte) (Cipher, error){NewCipher, NewCFBCipher, NewGCMCipher} {
+		// Test all 3 valid AES sizes
+		for _, secretSize := range []int{16, 24, 32} {
+			secret := make([]byte, secretSize)
+			_, err = io.ReadFull(rand.Reader, secret)
+			assert.Equal(t, nil, err)
+
+			c, err := initCipher(secret)
+			assert.Equal(t, nil, err)
+
+			// Test various sizes sessions might be
+			for _, dataSize := range []int{10, 100, 1000, 5000, 10000} {
+				data := make([]byte, dataSize)
+				_, err := io.ReadFull(rand.Reader, data)
+				assert.Equal(t, nil, err)
+
+				encrypted, err := c.Encrypt(data)
+				assert.Equal(t, nil, err)
+				assert.NotEqual(t, encrypted, data)
+
+				decrypted, err := c.Decrypt(encrypted)
+				assert.Equal(t, nil, err)
+				assert.Equal(t, data, decrypted)
+				assert.NotEqual(t, encrypted, decrypted)
+			}
+		}
+	}
+}
+
+func TestDecryptWrongSecret(t *testing.T) {
+	secret1 := []byte("0123456789abcdefghijklmnopqrstuv")
+	secret2 := []byte("9876543210abcdefghijklmnopqrstuv")
+
+	// Test CFB & Base64 (GCM is authenticated, it errors differently)
+	for _, initCipher := range []func([]byte) (Cipher, error){NewCipher, NewCFBCipher} {
+		c1, err := initCipher(secret1)
+		assert.Equal(t, nil, err)
+
+		c2, err := initCipher(secret2)
+		assert.Equal(t, nil, err)
+
+		data := []byte("f3928pufm982374dj02y485dsl34890u2t9nd4028s94dm58y2394087dhmsyt29h8df")
+
+		ciphertext, err := c1.Encrypt(data)
+		assert.Equal(t, nil, err)
+
+		wrongData, err := c2.Decrypt(ciphertext)
+		assert.Equal(t, nil, err)
+		assert.NotEqual(t, data, wrongData)
+	}
+}
+
+func TestDecryptGCMWrongSecret(t *testing.T) {
+	secret1 := []byte("0123456789abcdefghijklmnopqrstuv")
+	secret2 := []byte("9876543210abcdefghijklmnopqrstuv")
+
+	c1, err := NewGCMCipher(secret1)
+	assert.Equal(t, nil, err)
+
+	c2, err := NewGCMCipher(secret2)
+	assert.Equal(t, nil, err)
+
+	data := []byte("f3928pufm982374dj02y485dsl34890u2t9nd4028s94dm58y2394087dhmsyt29h8df")
+
+	ciphertext, err := c1.Encrypt(data)
+	assert.Equal(t, nil, err)
+
+	// GCM is authenticated - this should lead to message authentication failed
+	_, err = c2.Decrypt(ciphertext)
+	assert.Error(t, err)
+}
+
+func TestIntermixCiphersErrors(t *testing.T) {
+	var err error
+
+	// Encrypt with GCM, Decrypt with CFB: Results in Garbage data
 	// Test all 3 valid AES sizes
 	for _, secretSize := range []int{16, 24, 32} {
 		secret := make([]byte, secretSize)
 		_, err = io.ReadFull(rand.Reader, secret)
 		assert.Equal(t, nil, err)
 
-		// NewCipher creates a Base64 wrapper of CFBCipher
-		c, err := NewCipher(secret)
+		gcm, err := NewGCMCipher(secret)
+		assert.Equal(t, nil, err)
+
+		cfb, err := NewCFBCipher(secret)
 		assert.Equal(t, nil, err)
 
 		// Test various sizes sessions might be
@@ -153,48 +232,29 @@ func TestEncryptAndDecryptBase64(t *testing.T) {
 			_, err := io.ReadFull(rand.Reader, data)
 			assert.Equal(t, nil, err)
 
-			encrypted, err := c.Encrypt(data)
+			encrypted, err := gcm.Encrypt(data)
 			assert.Equal(t, nil, err)
+			assert.NotEqual(t, encrypted, data)
 
-			decrypted, err := c.Decrypt(encrypted)
+			decrypted, err := cfb.Decrypt(encrypted)
 			assert.Equal(t, nil, err)
-			assert.Equal(t, data, decrypted)
+			// Data is mangled
+			assert.NotEqual(t, data, decrypted)
+			assert.NotEqual(t, encrypted, decrypted)
 		}
 	}
-}
 
-func TestDecryptBase64WrongSecret(t *testing.T) {
-	var err error
-
-	secret1 := []byte("0123456789abcdefghijklmnopqrstuv")
-	secret2 := []byte("9876543210abcdefghijklmnopqrstuv")
-
-	c1, err := NewCipher(secret1)
-	assert.Equal(t, nil, err)
-
-	c2, err := NewCipher(secret2)
-	assert.Equal(t, nil, err)
-
-	data := []byte("f3928pufm982374dj02y485dsl34890u2t9nd4028s94dm58y2394087dhmsyt29h8df")
-
-	ciphertext, err := c1.Encrypt(data)
-	assert.Equal(t, nil, err)
-
-	wrongData, err := c2.Decrypt(ciphertext)
-	assert.Equal(t, nil, err)
-	assert.NotEqual(t, data, wrongData)
-}
-
-func TestEncryptAndDecryptCFB(t *testing.T) {
-	var err error
-
+	// Encrypt with CFB, Decrypt with GCM: Results in errors
 	// Test all 3 valid AES sizes
 	for _, secretSize := range []int{16, 24, 32} {
 		secret := make([]byte, secretSize)
 		_, err = io.ReadFull(rand.Reader, secret)
 		assert.Equal(t, nil, err)
 
-		c, err := NewCFBCipher(secret)
+		gcm, err := NewGCMCipher(secret)
+		assert.Equal(t, nil, err)
+
+		cfb, err := NewCFBCipher(secret)
 		assert.Equal(t, nil, err)
 
 		// Test various sizes sessions might be
@@ -203,36 +263,15 @@ func TestEncryptAndDecryptCFB(t *testing.T) {
 			_, err := io.ReadFull(rand.Reader, data)
 			assert.Equal(t, nil, err)
 
-			encrypted, err := c.Encrypt(data)
+			encrypted, err := cfb.Encrypt(data)
 			assert.Equal(t, nil, err)
+			assert.NotEqual(t, encrypted, data)
 
-			decrypted, err := c.Decrypt(encrypted)
-			assert.Equal(t, nil, err)
-			assert.Equal(t, data, decrypted)
+			// GCM is authenticated - this should lead to message authentication failed
+			_, err = gcm.Decrypt(encrypted)
+			assert.Error(t, err)
 		}
 	}
-}
-
-func TestDecryptCFBWrongSecret(t *testing.T) {
-	var err error
-
-	secret1 := []byte("0123456789abcdefghijklmnopqrstuv")
-	secret2 := []byte("9876543210abcdefghijklmnopqrstuv")
-
-	c1, err := NewCFBCipher(secret1)
-	assert.Equal(t, nil, err)
-
-	c2, err := NewCFBCipher(secret2)
-	assert.Equal(t, nil, err)
-
-	data := []byte("f3928pufm982374dj02y485dsl34890u2t9nd4028s94dm58y2394087dhmsyt29h8df")
-
-	ciphertext, err := c1.Encrypt(data)
-	assert.Equal(t, nil, err)
-
-	wrongData, err := c2.Decrypt(ciphertext)
-	assert.Equal(t, nil, err)
-	assert.NotEqual(t, data, wrongData)
 }
 
 func TestEncodeIntoAndDecodeIntoAccessToken(t *testing.T) {

--- a/pkg/encryption/cipher_test.go
+++ b/pkg/encryption/cipher_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	mathrand "math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -116,80 +115,6 @@ func runEncryptAndDecrypt(t *testing.T, c Cipher, dataSize int) {
 	assert.Equal(t, encrypted, immutableEnc)
 	// Encrypt/Decrypt actually did something
 	assert.NotEqual(t, encrypted, decrypted)
-}
-
-func TestEncryptIntoAndDecryptInto(t *testing.T) {
-	// Test our 2 cipher types
-	cipherInits := map[string]func([]byte) (Cipher, error){
-		"CFB": NewCFBCipher,
-		"GCM": NewGCMCipher,
-	}
-	for name, initCipher := range cipherInits {
-		t.Run(name, func(t *testing.T) {
-			// Test all 3 valid AES sizes
-			for _, secretSize := range []int{16, 24, 32} {
-				t.Run(fmt.Sprintf("%d", secretSize), func(t *testing.T) {
-					secret := make([]byte, secretSize)
-					_, err := io.ReadFull(rand.Reader, secret)
-					assert.Equal(t, nil, err)
-
-					// Test Standard & Base64 wrapped
-					cstd, err := initCipher(secret)
-					assert.Equal(t, nil, err)
-
-					cb64, err := NewBase64Cipher(initCipher, secret)
-					assert.Equal(t, nil, err)
-
-					ciphers := map[string]Cipher{
-						"Standard": cstd,
-						"Base64":   cb64,
-					}
-
-					for cName, c := range ciphers {
-						// Check no errors with empty or nil strings
-						if cName == "Base64" {
-							empty := ""
-							assert.Equal(t, nil, c.EncryptInto(&empty))
-							assert.Equal(t, nil, c.DecryptInto(&empty))
-							assert.Equal(t, nil, c.EncryptInto(nil))
-							assert.Equal(t, nil, c.DecryptInto(nil))
-						}
-
-						t.Run(cName, func(t *testing.T) {
-							// Test various sizes sessions might be
-							for _, dataSize := range []int{10, 100, 1000, 5000, 10000} {
-								t.Run(fmt.Sprintf("%d", dataSize), func(t *testing.T) {
-									runEncryptIntoAndDecryptInto(t, c, cName, dataSize)
-								})
-							}
-						})
-					}
-				})
-			}
-		})
-	}
-}
-
-func runEncryptIntoAndDecryptInto(t *testing.T, c Cipher, cipherType string, dataSize int) {
-	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-	b := make([]byte, dataSize)
-	for i := range b {
-		b[i] = charset[mathrand.Intn(len(charset))]
-	}
-	data := string(b)
-	originalData := data
-
-	// Base64 is the only cipher that supports string->string Encrypt/Decrypt Into methods
-	if cipherType == "Base64" {
-		assert.Equal(t, nil, c.EncryptInto(&data))
-		assert.NotEqual(t, originalData, data)
-
-		assert.Equal(t, nil, c.DecryptInto(&data))
-		assert.Equal(t, originalData, data)
-	} else {
-		assert.NotEqual(t, nil, c.EncryptInto(&data))
-		assert.NotEqual(t, nil, c.DecryptInto(&data))
-	}
 }
 
 func TestDecryptCFBWrongSecret(t *testing.T) {

--- a/pkg/encryption/cipher_test.go
+++ b/pkg/encryption/cipher_test.go
@@ -80,20 +80,26 @@ func TestEncryptAndDecrypt(t *testing.T) {
 									_, err := io.ReadFull(rand.Reader, data)
 									assert.Equal(t, nil, err)
 
+									// Ensure our Encrypt function doesn't encrypt in place
+									immutableData := make([]byte, len(data))
+									copy(immutableData, data)
+
 									encrypted, err := c.Encrypt(data)
 									assert.Equal(t, nil, err)
 									assert.NotEqual(t, encrypted, data)
+									// Encrypt didn't operate in-place on []byte
+									assert.Equal(t, data, immutableData)
 
 									// Ensure our Decrypt function doesn't decrypt in place
-									immutable := make([]byte, len(encrypted))
-									copy(immutable, encrypted)
+									immutableEnc := make([]byte, len(encrypted))
+									copy(immutableEnc, encrypted)
 
 									decrypted, err := c.Decrypt(encrypted)
 									assert.Equal(t, nil, err)
 									// Original data back
 									assert.Equal(t, data, decrypted)
 									// Decrypt didn't operate in-place on []byte
-									assert.Equal(t, encrypted, immutable)
+									assert.Equal(t, encrypted, immutableEnc)
 									// Encrypt/Decrypt actually did something
 									assert.NotEqual(t, encrypted, decrypted)
 								})

--- a/pkg/encryption/cipher_test.go
+++ b/pkg/encryption/cipher_test.go
@@ -84,9 +84,17 @@ func TestEncryptAndDecrypt(t *testing.T) {
 									assert.Equal(t, nil, err)
 									assert.NotEqual(t, encrypted, data)
 
+									// Ensure our Decrypt function doesn't decrypt in place
+									immutable := make([]byte, len(encrypted))
+									copy(immutable, encrypted)
+
 									decrypted, err := c.Decrypt(encrypted)
 									assert.Equal(t, nil, err)
+									// Original data back
 									assert.Equal(t, data, decrypted)
+									// Decrypt didn't operate in-place on []byte
+									assert.Equal(t, encrypted, immutable)
+									// Encrypt/Decrypt actually did something
 									assert.NotEqual(t, encrypted, decrypted)
 								})
 							}

--- a/pkg/encryption/cipher_test.go
+++ b/pkg/encryption/cipher_test.go
@@ -3,6 +3,7 @@ package encryption
 import (
 	"crypto/rand"
 	"encoding/base64"
+	"fmt"
 	"io"
 	"testing"
 
@@ -54,7 +55,7 @@ func TestEncryptAndDecrypt(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			// Test all 3 valid AES sizes
 			for _, secretSize := range []int{16, 24, 32} {
-				t.Run(string(secretSize), func(t *testing.T) {
+				t.Run(fmt.Sprintf("%d", secretSize), func(t *testing.T) {
 					secret := make([]byte, secretSize)
 					_, err := io.ReadFull(rand.Reader, secret)
 					assert.Equal(t, nil, err)
@@ -75,33 +76,8 @@ func TestEncryptAndDecrypt(t *testing.T) {
 						t.Run(cName, func(t *testing.T) {
 							// Test various sizes sessions might be
 							for _, dataSize := range []int{10, 100, 1000, 5000, 10000} {
-								t.Run(string(dataSize), func(t *testing.T) {
-									data := make([]byte, dataSize)
-									_, err := io.ReadFull(rand.Reader, data)
-									assert.Equal(t, nil, err)
-
-									// Ensure our Encrypt function doesn't encrypt in place
-									immutableData := make([]byte, len(data))
-									copy(immutableData, data)
-
-									encrypted, err := c.Encrypt(data)
-									assert.Equal(t, nil, err)
-									assert.NotEqual(t, encrypted, data)
-									// Encrypt didn't operate in-place on []byte
-									assert.Equal(t, data, immutableData)
-
-									// Ensure our Decrypt function doesn't decrypt in place
-									immutableEnc := make([]byte, len(encrypted))
-									copy(immutableEnc, encrypted)
-
-									decrypted, err := c.Decrypt(encrypted)
-									assert.Equal(t, nil, err)
-									// Original data back
-									assert.Equal(t, data, decrypted)
-									// Decrypt didn't operate in-place on []byte
-									assert.Equal(t, encrypted, immutableEnc)
-									// Encrypt/Decrypt actually did something
-									assert.NotEqual(t, encrypted, decrypted)
+								t.Run(fmt.Sprintf("%d", dataSize), func(t *testing.T) {
+									runEncryptAndDecrypt(t, c, dataSize)
 								})
 							}
 						})
@@ -110,6 +86,35 @@ func TestEncryptAndDecrypt(t *testing.T) {
 			}
 		})
 	}
+}
+
+func runEncryptAndDecrypt(t *testing.T, c Cipher, dataSize int) {
+	data := make([]byte, dataSize)
+	_, err := io.ReadFull(rand.Reader, data)
+	assert.Equal(t, nil, err)
+
+	// Ensure our Encrypt function doesn't encrypt in place
+	immutableData := make([]byte, len(data))
+	copy(immutableData, data)
+
+	encrypted, err := c.Encrypt(data)
+	assert.Equal(t, nil, err)
+	assert.NotEqual(t, encrypted, data)
+	// Encrypt didn't operate in-place on []byte
+	assert.Equal(t, data, immutableData)
+
+	// Ensure our Decrypt function doesn't decrypt in place
+	immutableEnc := make([]byte, len(encrypted))
+	copy(immutableEnc, encrypted)
+
+	decrypted, err := c.Decrypt(encrypted)
+	assert.Equal(t, nil, err)
+	// Original data back
+	assert.Equal(t, data, decrypted)
+	// Decrypt didn't operate in-place on []byte
+	assert.Equal(t, encrypted, immutableEnc)
+	// Encrypt/Decrypt actually did something
+	assert.NotEqual(t, encrypted, decrypted)
 }
 
 func TestDecryptCFBWrongSecret(t *testing.T) {
@@ -156,7 +161,7 @@ func TestDecryptGCMWrongSecret(t *testing.T) {
 func TestGCMtoCFBErrors(t *testing.T) {
 	// Test all 3 valid AES sizes
 	for _, secretSize := range []int{16, 24, 32} {
-		t.Run(string(secretSize), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%d", secretSize), func(t *testing.T) {
 			secret := make([]byte, secretSize)
 			_, err := io.ReadFull(rand.Reader, secret)
 			assert.Equal(t, nil, err)
@@ -169,7 +174,7 @@ func TestGCMtoCFBErrors(t *testing.T) {
 
 			// Test various sizes sessions might be
 			for _, dataSize := range []int{10, 100, 1000, 5000, 10000} {
-				t.Run(string(dataSize), func(t *testing.T) {
+				t.Run(fmt.Sprintf("%d", dataSize), func(t *testing.T) {
 					data := make([]byte, dataSize)
 					_, err := io.ReadFull(rand.Reader, data)
 					assert.Equal(t, nil, err)
@@ -193,7 +198,7 @@ func TestGCMtoCFBErrors(t *testing.T) {
 func TestCFBtoGCMErrors(t *testing.T) {
 	// Test all 3 valid AES sizes
 	for _, secretSize := range []int{16, 24, 32} {
-		t.Run(string(secretSize), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%d", secretSize), func(t *testing.T) {
 			secret := make([]byte, secretSize)
 			_, err := io.ReadFull(rand.Reader, secret)
 			assert.Equal(t, nil, err)
@@ -206,7 +211,7 @@ func TestCFBtoGCMErrors(t *testing.T) {
 
 			// Test various sizes sessions might be
 			for _, dataSize := range []int{10, 100, 1000, 5000, 10000} {
-				t.Run(string(dataSize), func(t *testing.T) {
+				t.Run(fmt.Sprintf("%d", dataSize), func(t *testing.T) {
 					data := make([]byte, dataSize)
 					_, err := io.ReadFull(rand.Reader, data)
 					assert.Equal(t, nil, err)

--- a/pkg/encryption/cipher_test.go
+++ b/pkg/encryption/cipher_test.go
@@ -2,102 +2,12 @@ package encryption
 
 import (
 	"crypto/rand"
-	"crypto/sha1"
-	"crypto/sha256"
 	"encoding/base64"
-	"fmt"
 	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
-
-func TestSecretBytesEncoded(t *testing.T) {
-	for _, secretSize := range []int{16, 24, 32} {
-		t.Run(fmt.Sprintf("%d", secretSize), func(t *testing.T) {
-			secret := make([]byte, secretSize)
-			_, err := io.ReadFull(rand.Reader, secret)
-			assert.Equal(t, nil, err)
-
-			// We test both padded & raw Base64 to ensure we handle both
-			// potential user input routes for Base64
-			base64Padded := base64.URLEncoding.EncodeToString(secret)
-			sb := SecretBytes(base64Padded)
-			assert.Equal(t, secret, sb)
-			assert.Equal(t, len(sb), secretSize)
-
-			base64Raw := base64.RawURLEncoding.EncodeToString(secret)
-			sb = SecretBytes(base64Raw)
-			assert.Equal(t, secret, sb)
-			assert.Equal(t, len(sb), secretSize)
-		})
-	}
-}
-
-// A string that isn't intended as Base64 and still decodes (but to unintended length)
-// will return the original secret as bytes
-func TestSecretBytesEncodedWrongSize(t *testing.T) {
-	for _, secretSize := range []int{15, 20, 28, 33, 44} {
-		t.Run(fmt.Sprintf("%d", secretSize), func(t *testing.T) {
-			secret := make([]byte, secretSize)
-			_, err := io.ReadFull(rand.Reader, secret)
-			assert.Equal(t, nil, err)
-
-			// We test both padded & raw Base64 to ensure we handle both
-			// potential user input routes for Base64
-			base64Padded := base64.URLEncoding.EncodeToString(secret)
-			sb := SecretBytes(base64Padded)
-			assert.NotEqual(t, secret, sb)
-			assert.NotEqual(t, len(sb), secretSize)
-			// The given secret is returned as []byte
-			assert.Equal(t, base64Padded, string(sb))
-
-			base64Raw := base64.RawURLEncoding.EncodeToString(secret)
-			sb = SecretBytes(base64Raw)
-			assert.NotEqual(t, secret, sb)
-			assert.NotEqual(t, len(sb), secretSize)
-			// The given secret is returned as []byte
-			assert.Equal(t, base64Raw, string(sb))
-		})
-	}
-}
-
-func TestSecretBytesNonBase64(t *testing.T) {
-	trailer := "equals=========="
-	assert.Equal(t, trailer, string(SecretBytes(trailer)))
-
-	raw16 := "asdflkjhqwer)(*&"
-	sb16 := SecretBytes(raw16)
-	assert.Equal(t, raw16, string(sb16))
-	assert.Equal(t, 16, len(sb16))
-
-	raw24 := "asdflkjhqwer)(*&CJEN#$%^"
-	sb24 := SecretBytes(raw24)
-	assert.Equal(t, raw24, string(sb24))
-	assert.Equal(t, 24, len(sb24))
-
-	raw32 := "asdflkjhqwer)(*&1234lkjhqwer)(*&"
-	sb32 := SecretBytes(raw32)
-	assert.Equal(t, raw32, string(sb32))
-	assert.Equal(t, 32, len(sb32))
-}
-
-func TestSignAndValidate(t *testing.T) {
-	seed := "0123456789abcdef"
-	key := "cookie-name"
-	value := base64.URLEncoding.EncodeToString([]byte("I am soooo encoded"))
-	epoch := "123456789"
-
-	sha256sig := cookieSignature(sha256.New, seed, key, value, epoch)
-	sha1sig := cookieSignature(sha1.New, seed, key, value, epoch)
-
-	assert.True(t, checkSignature(sha256sig, seed, key, value, epoch))
-	// This should be switched to False after fully deprecating SHA1
-	assert.True(t, checkSignature(sha1sig, seed, key, value, epoch))
-
-	assert.False(t, checkSignature(sha256sig, seed, key, "tampered", epoch))
-	assert.False(t, checkSignature(sha1sig, seed, key, "tampered", epoch))
-}
 
 func TestEncodeAndDecodeAccessToken(t *testing.T) {
 	const secret = "0123456789abcdefghijklmnopqrstuv"

--- a/pkg/encryption/cipher_test.go
+++ b/pkg/encryption/cipher_test.go
@@ -105,14 +105,14 @@ func TestEncodeAndDecodeAccessToken(t *testing.T) {
 	c, err := NewCipher([]byte(secret))
 	assert.Equal(t, nil, err)
 
-	encoded, err := c.Encrypt(token)
+	encoded, err := c.Encrypt([]byte(token))
 	assert.Equal(t, nil, err)
 
 	decoded, err := c.Decrypt(encoded)
 	assert.Equal(t, nil, err)
 
-	assert.NotEqual(t, token, encoded)
-	assert.Equal(t, token, decoded)
+	assert.NotEqual(t, []byte(token), encoded)
+	assert.Equal(t, []byte(token), decoded)
 }
 
 func TestEncodeAndDecodeAccessTokenB64(t *testing.T) {
@@ -124,14 +124,115 @@ func TestEncodeAndDecodeAccessTokenB64(t *testing.T) {
 	c, err := NewCipher([]byte(secret))
 	assert.Equal(t, nil, err)
 
-	encoded, err := c.Encrypt(token)
+	encoded, err := c.Encrypt([]byte(token))
 	assert.Equal(t, nil, err)
 
 	decoded, err := c.Decrypt(encoded)
 	assert.Equal(t, nil, err)
 
-	assert.NotEqual(t, token, encoded)
-	assert.Equal(t, token, decoded)
+	assert.NotEqual(t, []byte(token), encoded)
+	assert.Equal(t, []byte(token), decoded)
+}
+
+func TestEncryptAndDecryptBase64(t *testing.T) {
+	var err error
+
+	// Test all 3 valid AES sizes
+	for _, secretSize := range []int{16, 24, 32} {
+		secret := make([]byte, secretSize)
+		_, err = io.ReadFull(rand.Reader, secret)
+		assert.Equal(t, nil, err)
+
+		// NewCipher creates a Base64 wrapper of CFBCipher
+		c, err := NewCipher(secret)
+		assert.Equal(t, nil, err)
+
+		// Test various sizes sessions might be
+		for _, dataSize := range []int{10, 100, 1000, 5000, 10000} {
+			data := make([]byte, dataSize)
+			_, err := io.ReadFull(rand.Reader, data)
+			assert.Equal(t, nil, err)
+
+			encrypted, err := c.Encrypt(data)
+			assert.Equal(t, nil, err)
+
+			decrypted, err := c.Decrypt(encrypted)
+			assert.Equal(t, nil, err)
+			assert.Equal(t, data, decrypted)
+		}
+	}
+}
+
+func TestDecryptBase64WrongSecret(t *testing.T) {
+	var err error
+
+	secret1 := []byte("0123456789abcdefghijklmnopqrstuv")
+	secret2 := []byte("9876543210abcdefghijklmnopqrstuv")
+
+	c1, err := NewCipher(secret1)
+	assert.Equal(t, nil, err)
+
+	c2, err := NewCipher(secret2)
+	assert.Equal(t, nil, err)
+
+	data := []byte("f3928pufm982374dj02y485dsl34890u2t9nd4028s94dm58y2394087dhmsyt29h8df")
+
+	ciphertext, err := c1.Encrypt(data)
+	assert.Equal(t, nil, err)
+
+	wrongData, err := c2.Decrypt(ciphertext)
+	assert.Equal(t, nil, err)
+	assert.NotEqual(t, data, wrongData)
+}
+
+func TestEncryptAndDecryptCFB(t *testing.T) {
+	var err error
+
+	// Test all 3 valid AES sizes
+	for _, secretSize := range []int{16, 24, 32} {
+		secret := make([]byte, secretSize)
+		_, err = io.ReadFull(rand.Reader, secret)
+		assert.Equal(t, nil, err)
+
+		c, err := NewCFBCipher(secret)
+		assert.Equal(t, nil, err)
+
+		// Test various sizes sessions might be
+		for _, dataSize := range []int{10, 100, 1000, 5000, 10000} {
+			data := make([]byte, dataSize)
+			_, err := io.ReadFull(rand.Reader, data)
+			assert.Equal(t, nil, err)
+
+			encrypted, err := c.Encrypt(data)
+			assert.Equal(t, nil, err)
+
+			decrypted, err := c.Decrypt(encrypted)
+			assert.Equal(t, nil, err)
+			assert.Equal(t, data, decrypted)
+		}
+	}
+}
+
+func TestDecryptCFBWrongSecret(t *testing.T) {
+	var err error
+
+	secret1 := []byte("0123456789abcdefghijklmnopqrstuv")
+	secret2 := []byte("9876543210abcdefghijklmnopqrstuv")
+
+	c1, err := NewCFBCipher(secret1)
+	assert.Equal(t, nil, err)
+
+	c2, err := NewCFBCipher(secret2)
+	assert.Equal(t, nil, err)
+
+	data := []byte("f3928pufm982374dj02y485dsl34890u2t9nd4028s94dm58y2394087dhmsyt29h8df")
+
+	ciphertext, err := c1.Encrypt(data)
+	assert.Equal(t, nil, err)
+
+	wrongData, err := c2.Decrypt(ciphertext)
+	assert.Equal(t, nil, err)
+	assert.NotEqual(t, data, wrongData)
 }
 
 func TestEncodeIntoAndDecodeIntoAccessToken(t *testing.T) {

--- a/pkg/encryption/utils.go
+++ b/pkg/encryption/utils.go
@@ -1,0 +1,107 @@
+package encryption
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"hash"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// SecretBytes attempts to base64 decode the secret, if that fails it treats the secret as binary
+func SecretBytes(secret string) []byte {
+	b, err := base64.RawURLEncoding.DecodeString(strings.TrimRight(secret, "="))
+	if err == nil {
+		// Only return decoded form if a valid AES length
+		// Don't want unintentional decoding resulting in invalid lengths confusing a user
+		// that thought they used a 16, 24, 32 length string
+		for _, i := range []int{16, 24, 32} {
+			if len(b) == i {
+				return b
+			}
+		}
+	}
+	// If decoding didn't work or resulted in non-AES compliant length,
+	// assume the raw string was the intended secret
+	return []byte(secret)
+}
+
+// cookies are stored in a 3 part (value + timestamp + signature) to enforce that the values are as originally set.
+// additionally, the 'value' is encrypted so it's opaque to the browser
+
+// Validate ensures a cookie is properly signed
+func Validate(cookie *http.Cookie, seed string, expiration time.Duration) (value []byte, t time.Time, ok bool) {
+	// value, timestamp, sig
+	parts := strings.Split(cookie.Value, "|")
+	if len(parts) != 3 {
+		return
+	}
+	if checkSignature(parts[2], seed, cookie.Name, parts[0], parts[1]) {
+		ts, err := strconv.Atoi(parts[1])
+		if err != nil {
+			return
+		}
+		// The expiration timestamp set when the cookie was created
+		// isn't sent back by the browser. Hence, we check whether the
+		// creation timestamp stored in the cookie falls within the
+		// window defined by (Now()-expiration, Now()].
+		t = time.Unix(int64(ts), 0)
+		if t.After(time.Now().Add(expiration*-1)) && t.Before(time.Now().Add(time.Minute*5)) {
+			// it's a valid cookie. now get the contents
+			rawValue, err := base64.URLEncoding.DecodeString(parts[0])
+			if err == nil {
+				value = rawValue
+				ok = true
+				return
+			}
+		}
+	}
+	return
+}
+
+// SignedValue returns a cookie that is signed and can later be checked with Validate
+func SignedValue(seed string, key string, value []byte, now time.Time) string {
+	encodedValue := base64.URLEncoding.EncodeToString(value)
+	timeStr := fmt.Sprintf("%d", now.Unix())
+	sig := cookieSignature(sha256.New, seed, key, encodedValue, timeStr)
+	cookieVal := fmt.Sprintf("%s|%s|%s", encodedValue, timeStr, sig)
+	return cookieVal
+}
+
+func cookieSignature(signer func() hash.Hash, args ...string) string {
+	h := hmac.New(signer, []byte(args[0]))
+	for _, arg := range args[1:] {
+		h.Write([]byte(arg))
+	}
+	var b []byte
+	b = h.Sum(b)
+	return base64.URLEncoding.EncodeToString(b)
+}
+
+func checkSignature(signature string, args ...string) bool {
+	checkSig := cookieSignature(sha256.New, args...)
+	if checkHmac(signature, checkSig) {
+		return true
+	}
+
+	// TODO: After appropriate rollout window, remove support for SHA1
+	legacySig := cookieSignature(sha1.New, args...)
+	return checkHmac(signature, legacySig)
+}
+
+func checkHmac(input, expected string) bool {
+	inputMAC, err1 := base64.URLEncoding.DecodeString(input)
+	if err1 == nil {
+		expectedMAC, err2 := base64.URLEncoding.DecodeString(expected)
+		if err2 == nil {
+			return hmac.Equal(inputMAC, expectedMAC)
+		}
+	}
+	return false
+}
+

--- a/pkg/encryption/utils.go
+++ b/pkg/encryption/utils.go
@@ -104,4 +104,3 @@ func checkHmac(input, expected string) bool {
 	}
 	return false
 }
-

--- a/pkg/encryption/utils_test.go
+++ b/pkg/encryption/utils_test.go
@@ -1,0 +1,100 @@
+package encryption
+
+import (
+	"crypto/rand"
+	"crypto/sha1"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSecretBytesEncoded(t *testing.T) {
+	for _, secretSize := range []int{16, 24, 32} {
+		t.Run(fmt.Sprintf("%d", secretSize), func(t *testing.T) {
+			secret := make([]byte, secretSize)
+			_, err := io.ReadFull(rand.Reader, secret)
+			assert.Equal(t, nil, err)
+
+			// We test both padded & raw Base64 to ensure we handle both
+			// potential user input routes for Base64
+			base64Padded := base64.URLEncoding.EncodeToString(secret)
+			sb := SecretBytes(base64Padded)
+			assert.Equal(t, secret, sb)
+			assert.Equal(t, len(sb), secretSize)
+
+			base64Raw := base64.RawURLEncoding.EncodeToString(secret)
+			sb = SecretBytes(base64Raw)
+			assert.Equal(t, secret, sb)
+			assert.Equal(t, len(sb), secretSize)
+		})
+	}
+}
+
+// A string that isn't intended as Base64 and still decodes (but to unintended length)
+// will return the original secret as bytes
+func TestSecretBytesEncodedWrongSize(t *testing.T) {
+	for _, secretSize := range []int{15, 20, 28, 33, 44} {
+		t.Run(fmt.Sprintf("%d", secretSize), func(t *testing.T) {
+			secret := make([]byte, secretSize)
+			_, err := io.ReadFull(rand.Reader, secret)
+			assert.Equal(t, nil, err)
+
+			// We test both padded & raw Base64 to ensure we handle both
+			// potential user input routes for Base64
+			base64Padded := base64.URLEncoding.EncodeToString(secret)
+			sb := SecretBytes(base64Padded)
+			assert.NotEqual(t, secret, sb)
+			assert.NotEqual(t, len(sb), secretSize)
+			// The given secret is returned as []byte
+			assert.Equal(t, base64Padded, string(sb))
+
+			base64Raw := base64.RawURLEncoding.EncodeToString(secret)
+			sb = SecretBytes(base64Raw)
+			assert.NotEqual(t, secret, sb)
+			assert.NotEqual(t, len(sb), secretSize)
+			// The given secret is returned as []byte
+			assert.Equal(t, base64Raw, string(sb))
+		})
+	}
+}
+
+func TestSecretBytesNonBase64(t *testing.T) {
+	trailer := "equals=========="
+	assert.Equal(t, trailer, string(SecretBytes(trailer)))
+
+	raw16 := "asdflkjhqwer)(*&"
+	sb16 := SecretBytes(raw16)
+	assert.Equal(t, raw16, string(sb16))
+	assert.Equal(t, 16, len(sb16))
+
+	raw24 := "asdflkjhqwer)(*&CJEN#$%^"
+	sb24 := SecretBytes(raw24)
+	assert.Equal(t, raw24, string(sb24))
+	assert.Equal(t, 24, len(sb24))
+
+	raw32 := "asdflkjhqwer)(*&1234lkjhqwer)(*&"
+	sb32 := SecretBytes(raw32)
+	assert.Equal(t, raw32, string(sb32))
+	assert.Equal(t, 32, len(sb32))
+}
+
+func TestSignAndValidate(t *testing.T) {
+	seed := "0123456789abcdef"
+	key := "cookie-name"
+	value := base64.URLEncoding.EncodeToString([]byte("I am soooo encoded"))
+	epoch := "123456789"
+
+	sha256sig := cookieSignature(sha256.New, seed, key, value, epoch)
+	sha1sig := cookieSignature(sha1.New, seed, key, value, epoch)
+
+	assert.True(t, checkSignature(sha256sig, seed, key, value, epoch))
+	// This should be switched to False after fully deprecating SHA1
+	assert.True(t, checkSignature(sha1sig, seed, key, value, epoch))
+
+	assert.False(t, checkSignature(sha256sig, seed, key, "tampered", epoch))
+	assert.False(t, checkSignature(sha1sig, seed, key, "tampered", epoch))
+}

--- a/pkg/sessions/cookie/session_store.go
+++ b/pkg/sessions/cookie/session_store.go
@@ -28,7 +28,7 @@ var _ sessions.SessionStore = &SessionStore{}
 // interface that stores sessions in client side cookies
 type SessionStore struct {
 	CookieOptions *options.CookieOptions
-	CookieCipher  *encryption.Cipher
+	CookieCipher  encryption.Cipher
 }
 
 // Save takes a sessions.SessionState and stores the information from it
@@ -84,12 +84,12 @@ func (s *SessionStore) Clear(rw http.ResponseWriter, req *http.Request) error {
 }
 
 // cookieForSession serializes a session state for storage in a cookie
-func cookieForSession(s *sessions.SessionState, c *encryption.Cipher) (string, error) {
+func cookieForSession(s *sessions.SessionState, c encryption.Cipher) (string, error) {
 	return s.EncodeSessionState(c)
 }
 
 // sessionFromCookie deserializes a session from a cookie value
-func sessionFromCookie(v string, c *encryption.Cipher) (s *sessions.SessionState, err error) {
+func sessionFromCookie(v string, c encryption.Cipher) (s *sessions.SessionState, err error) {
 	return sessions.DecodeSessionState(v, c)
 }
 

--- a/pkg/sessions/cookie/session_store.go
+++ b/pkg/sessions/cookie/session_store.go
@@ -59,7 +59,7 @@ func (s *SessionStore) Load(req *http.Request) (*sessions.SessionState, error) {
 		return nil, errors.New("cookie signature not valid")
 	}
 
-	session, err := sessionFromCookie(val, s.CookieCipher)
+	session, err := sessionFromCookie(string(val), s.CookieCipher)
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +104,7 @@ func (s *SessionStore) setSessionCookie(rw http.ResponseWriter, req *http.Reques
 // authentication details
 func (s *SessionStore) makeSessionCookie(req *http.Request, value string, now time.Time) []*http.Cookie {
 	if value != "" {
-		value = encryption.SignedValue(s.CookieOptions.Secret, s.CookieOptions.Name, value, now)
+		value = encryption.SignedValue(s.CookieOptions.Secret, s.CookieOptions.Name, []byte(value), now)
 	}
 	c := s.makeCookie(req, s.CookieOptions.Name, value, s.CookieOptions.Expire, now)
 	if len(c.Value) > 4096-len(s.CookieOptions.Name) {

--- a/pkg/sessions/redis/redis_store.go
+++ b/pkg/sessions/redis/redis_store.go
@@ -32,7 +32,7 @@ type TicketData struct {
 // SessionStore is an implementation of the sessions.SessionStore
 // interface that stores sessions in redis
 type SessionStore struct {
-	CookieCipher  *encryption.Cipher
+	CookieCipher  encryption.Cipher
 	CookieOptions *options.CookieOptions
 	Client        Client
 }

--- a/pkg/sessions/redis/redis_store.go
+++ b/pkg/sessions/redis/redis_store.go
@@ -175,7 +175,7 @@ func (store *SessionStore) Load(req *http.Request) (*sessions.SessionState, erro
 		return nil, fmt.Errorf("cookie signature not valid")
 	}
 	ctx := req.Context()
-	session, err := store.loadSessionFromString(ctx, val)
+	session, err := store.loadSessionFromString(ctx, string(val))
 	if err != nil {
 		return nil, fmt.Errorf("error loading session: %s", err)
 	}
@@ -237,7 +237,7 @@ func (store *SessionStore) Clear(rw http.ResponseWriter, req *http.Request) erro
 
 	// We only return an error if we had an issue with redis
 	// If there's an issue decoding the ticket, ignore it
-	ticket, _ := decodeTicket(store.CookieOptions.Name, val)
+	ticket, _ := decodeTicket(store.CookieOptions.Name, string(val))
 	if ticket != nil {
 		ctx := req.Context()
 		err := store.Client.Del(ctx, ticket.asHandle(store.CookieOptions.Name))
@@ -251,7 +251,7 @@ func (store *SessionStore) Clear(rw http.ResponseWriter, req *http.Request) erro
 // makeCookie makes a cookie, signing the value if present
 func (store *SessionStore) makeCookie(req *http.Request, value string, expires time.Duration, now time.Time) *http.Cookie {
 	if value != "" {
-		value = encryption.SignedValue(store.CookieOptions.Secret, store.CookieOptions.Name, value, now)
+		value = encryption.SignedValue(store.CookieOptions.Secret, store.CookieOptions.Name, []byte(value), now)
 	}
 	return cookies.MakeCookieFromOptions(
 		req,
@@ -302,7 +302,7 @@ func (store *SessionStore) getTicket(requestCookie *http.Cookie) (*TicketData, e
 	}
 
 	// Valid cookie, decode the ticket
-	ticket, err := decodeTicket(store.CookieOptions.Name, val)
+	ticket, err := decodeTicket(store.CookieOptions.Name, string(val))
 	if err != nil {
 		// If we can't decode the ticket we have to create a new one
 		return newTicket()

--- a/pkg/sessions/session_store_test.go
+++ b/pkg/sessions/session_store_test.go
@@ -367,7 +367,7 @@ var _ = Describe("NewSessionStore", func() {
 				_, err := rand.Read(secret)
 				Expect(err).ToNot(HaveOccurred())
 				cookieOpts.Secret = base64.URLEncoding.EncodeToString(secret)
-				cipher, err := encryption.NewCipher(encryption.SecretBytes(cookieOpts.Secret))
+				cipher, err := encryption.NewBase64Cipher(encryption.NewCFBCipher, encryption.SecretBytes(cookieOpts.Secret))
 				Expect(err).ToNot(HaveOccurred())
 				Expect(cipher).ToNot(BeNil())
 				opts.Cipher = cipher

--- a/pkg/sessions/session_store_test.go
+++ b/pkg/sessions/session_store_test.go
@@ -170,7 +170,7 @@ var _ = Describe("NewSessionStore", func() {
 				BeforeEach(func() {
 					By("Using a valid cookie with a different providers session encoding")
 					broken := "BrokenSessionFromADifferentSessionImplementation"
-					value := encryption.SignedValue(cookieOpts.Secret, cookieOpts.Name, broken, time.Now())
+					value := encryption.SignedValue(cookieOpts.Secret, cookieOpts.Name, []byte(broken), time.Now())
 					cookie := cookiesapi.MakeCookieFromOptions(request, cookieOpts.Name, value, cookieOpts, cookieOpts.Expire, time.Now())
 					request.AddCookie(cookie)
 

--- a/pkg/validation/options.go
+++ b/pkg/validation/options.go
@@ -38,7 +38,7 @@ func Validate(o *options.Options) error {
 
 	msgs := make([]string, 0)
 
-	var cipher *encryption.Cipher
+	var cipher encryption.Cipher
 	if o.Cookie.Secret == "" {
 		msgs = append(msgs, "missing setting: cookie-secret")
 	} else {

--- a/pkg/validation/options.go
+++ b/pkg/validation/options.go
@@ -62,7 +62,7 @@ func Validate(o *options.Options) error {
 					len(encryption.SecretBytes(o.Cookie.Secret)), suffix))
 		} else {
 			var err error
-			cipher, err = encryption.NewCipher(encryption.SecretBytes(o.Cookie.Secret))
+			cipher, err = encryption.NewBase64Cipher(encryption.NewCFBCipher, encryption.SecretBytes(o.Cookie.Secret))
 			if err != nil {
 				msgs = append(msgs, fmt.Sprintf("cookie-secret error: %v", err))
 			}


### PR DESCRIPTION
To support future session encoding efficiencies, Encrypt/Decrypt methods need to operate
on []byte and not strings (which requires a base64 encoding of the []byte ciphertext to make it a
valid string.

Encryption work related to https://github.com/oauth2-proxy/oauth2-proxy/pull/523

## Description

This moves encryption.Cipher to be an Interface for Encrypt([]byte) ([]byte, error) & Decrypt([]byte) (byte[], error) -- This allows various encryption techniques to be implemented that are ideal for various use cases:

(1) AES CFB + Base64 (current implementation, all code continues to use with with string=>string adjusted to []byte=>[]byte to match the interface)
(2) AES CFB: Raw CFB without Base64.  Ideal in the future for any binary data we want encrypted in a cookie (it is older, slower & unauthenticated -- but doesn't have IV + Secret reuse vulnerabilities)
(3) AES GCM. Implemented, unused.  Ideal for future use in session overhaul for DB backed stores that encrypt sessions with unique per session secrets (gives advantage of being authenticated encryption that CFB doesn't have)

## Motivation and Context

Base64 embedded in the Encrypt/Decrypt method to result in strings that could go in JSON results in session bloat contributing to the jumbo cookie & cookie splitting issues.

Additionally, upon future Redis session refactoring for binary encoded sessions, this can replace the existing reimplementation of crypto in the redis session store:

https://github.com/oauth2-proxy/oauth2-proxy/blob/be9eaaeb48132a34748fa474eb2077a8d270dfdc/pkg/sessions/redis/redis_store.go#L255

## How Has This Been Tested?

Lots of new crypto related unit tests added & tested interactively locally

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
