### PR TITLE
Fix secretBytes adding unintended padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,16 @@
   - In some scenarios `X-Forwarded-User` will now be empty. Use `X-Forwarded-Email` instead.
   - In some scenarios, this may break setting Basic Auth on upstream or responses.
     Use `--prefer-email-to-user` to restore falling back to the Email in these cases.
+- [#556](https://github.com/oauth2-proxy/oauth2-proxy/pull/556) Remove unintentional auto-padding of secrets that were too short
+  - Previously, after cookie-secrets were potentially opportunistically base64 decoded to raw bytes,
+    they were unintentionally padded to a multiple of 4.
+  - This led to many wrong sized secrets to still end up valid AES lengths of 16, 24, or 32. Or it led to confusing errors
+    reporting an invalid length of 20 or 28 when the user input cookie-secret was not that length.
+  - Now we will only base64 decode a cookie-secret to raw bytes if it is 16, 24, or 32 bytes long. Otherwise, we will convert
+    the direct cookie-secret to bytes without silent padding added.
 
 ## Changes since v5.1.1
+- [#556](https://github.com/oauth2-proxy/oauth2-proxy/pull/556) Remove unintentional auto-padding of secrets that were too short (@NickMeves)
 - [#538](https://github.com/oauth2-proxy/oauth2-proxy/pull/538) Refactor sessions/utils.go functionality to other areas (@NickMeves)
 - [#503](https://github.com/oauth2-proxy/oauth2-proxy/pull/503) Implements --real-client-ip-header option to select the header from which to obtain a proxied client's IP (@Izzette)
 - [#529](https://github.com/oauth2-proxy/oauth2-proxy/pull/529) Add local test environments for testing changes and new features (@JoelSpeed)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,9 +33,9 @@
   - In some scenarios, this may break setting Basic Auth on upstream or responses.
     Use `--prefer-email-to-user` to restore falling back to the Email in these cases.
 - [#556](https://github.com/oauth2-proxy/oauth2-proxy/pull/556) Remove unintentional auto-padding of secrets that were too short
-  - Previously, after cookie-secrets were potentially opportunistically base64 decoded to raw bytes,
-    they were unintentionally padded to a multiple of 4.
-  - This led to many wrong sized secrets to still end up valid AES lengths of 16, 24, or 32. Or it led to confusing errors
+  - Previously, after cookie-secrets were opportunistically base64 decoded to raw bytes,
+    they were padded to have a length divisible by 4.
+  - This led to wrong sized secrets being valid AES lengths of 16, 24, or 32  bytes. Or it led to confusing errors
     reporting an invalid length of 20 or 28 when the user input cookie-secret was not that length.
   - Now we will only base64 decode a cookie-secret to raw bytes if it is 16, 24, or 32 bytes long. Otherwise, we will convert
     the direct cookie-secret to bytes without silent padding added.

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -898,7 +898,7 @@ func NewProcessCookieTest(opts ProcessCookieTestOpts, modifiers ...OptionsModifi
 	}
 	pcTest.opts.ClientID = "asdfljk"
 	pcTest.opts.ClientSecret = "lkjfdsig"
-	pcTest.opts.Cookie.Secret = "0123456789abcdefabcd"
+	pcTest.opts.Cookie.Secret = "0123456789abcdef0123456789abcdef"
 	// First, set the CookieRefresh option so proxy.AesCipher is created,
 	// needed to encrypt the access_token.
 	pcTest.opts.Cookie.Refresh = time.Hour

--- a/options_test.go
+++ b/options_test.go
@@ -233,7 +233,7 @@ func TestCookieRefreshMustBeLessThanCookieExpire(t *testing.T) {
 	o := testOptions()
 	assert.Equal(t, nil, o.Validate())
 
-	o.Cookie.Secret = "0123456789abcdefabcd"
+	o.Cookie.Secret = "0123456789abcdef"
 	o.Cookie.Refresh = o.Cookie.Expire
 	assert.NotEqual(t, nil, o.Validate())
 

--- a/pkg/encryption/cipher_test.go
+++ b/pkg/encryption/cipher_test.go
@@ -19,6 +19,8 @@ func TestSecretBytesEncoded(t *testing.T) {
 			_, err := io.ReadFull(rand.Reader, secret)
 			assert.Equal(t, nil, err)
 
+			// We test both padded & raw Base64 to ensure we handle both
+			// potential user input routes for Base64
 			base64Padded := base64.URLEncoding.EncodeToString(secret)
 			sb := SecretBytes(base64Padded)
 			assert.Equal(t, secret, sb)
@@ -41,6 +43,8 @@ func TestSecretBytesEncodedWrongSize(t *testing.T) {
 			_, err := io.ReadFull(rand.Reader, secret)
 			assert.Equal(t, nil, err)
 
+			// We test both padded & raw Base64 to ensure we handle both
+			// potential user input routes for Base64
 			base64Padded := base64.URLEncoding.EncodeToString(secret)
 			sb := SecretBytes(base64Padded)
 			assert.NotEqual(t, secret, sb)


### PR DESCRIPTION
Removes improper padding from SecretBytes function. If it is Base64 decode-able, confirms it decodes to 16,24,32 length (for AES ciphers).

Otherwise, falls back to []bytes(secret) directly without a length check (and lets options validity checks handle detecting the wrong length and sending an error message)

NOTE: This is a breaking change for some legacy cookie secrets that were unintentionally treated as valid due to this bug.

## Motivation and Context

Fixes #547

## How Has This Been Tested?

Unit tests added.

NOTE: other unit tests had to be changed since they mocked invalid secrets that previously slipped by due to the buggy padding implementation padding them to 16 bytes.

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
