### PR TITLE
Fallback to UserInfo is User ID claim not present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@
     Use `--prefer-email-to-user` to restore falling back to the Email in these cases.
 
 ## Changes since v5.1.1
+
+- [#560](https://github.com/oauth2-proxy/oauth2-proxy/pull/560) Fallback to UserInfo is User ID claim not present (@JoelSpeed)
 - [#538](https://github.com/oauth2-proxy/oauth2-proxy/pull/538) Refactor sessions/utils.go functionality to other areas (@NickMeves)
 - [#503](https://github.com/oauth2-proxy/oauth2-proxy/pull/503) Implements --real-client-ip-header option to select the header from which to obtain a proxied client's IP (@Izzette)
 - [#529](https://github.com/oauth2-proxy/oauth2-proxy/pull/529) Add local test environments for testing changes and new features (@JoelSpeed)

--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -198,7 +198,7 @@ func (p *OIDCProvider) createSessionStateInternal(ctx context.Context, rawIDToke
 
 	claims, err := p.findClaimsFromIDToken(ctx, idToken, accessToken, p.ProfileURL.String())
 	if err != nil {
-		return nil, fmt.Errorf("couldn't extract claims from id_token (%e)", err)
+		return nil, fmt.Errorf("couldn't extract claims from id_token (%v)", err)
 	}
 
 	newSession.IDToken = rawIDToken
@@ -242,20 +242,19 @@ func (p *OIDCProvider) findClaimsFromIDToken(ctx context.Context, idToken *oidc.
 	}
 
 	userID := claims.rawClaims[p.UserIDClaim]
-	if userID == nil {
-		return nil, fmt.Errorf("claims did not contains the required user-id-claim '%s'", p.UserIDClaim)
+	if userID != nil {
+		claims.UserID = fmt.Sprint(userID)
 	}
-	claims.UserID = fmt.Sprint(userID)
 
-	if p.UserIDClaim == emailClaim && claims.UserID == "" {
+	// userID claim was not present or was empty in the ID Token
+	if claims.UserID == "" {
 		if profileURL == "" {
-			return nil, fmt.Errorf("id_token did not contain an email")
+			return nil, fmt.Errorf("id_token did not contain user ID claim (%q)", p.UserIDClaim)
 		}
 
 		// If the userinfo endpoint profileURL is defined, then there is a chance the userinfo
 		// contents at the profileURL contains the email.
 		// Make a query to the userinfo endpoint, and attempt to locate the email from there.
-
 		req, err := http.NewRequestWithContext(ctx, "GET", profileURL, nil)
 		if err != nil {
 			return nil, err
@@ -267,12 +266,12 @@ func (p *OIDCProvider) findClaimsFromIDToken(ctx context.Context, idToken *oidc.
 			return nil, err
 		}
 
-		email, err := respJSON.Get("email").String()
+		userID, err := respJSON.Get(p.UserIDClaim).String()
 		if err != nil {
-			return nil, fmt.Errorf("neither id_token nor userinfo endpoint contained an email")
+			return nil, fmt.Errorf("neither id_token nor userinfo endpoint contained user ID claim (%q)", p.UserIDClaim)
 		}
 
-		claims.UserID = email
+		claims.UserID = userID
 	}
 
 	return claims, nil


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Previously, we would look for the email in the ID token and then fall back to checking the userinfo endpoint if it wasn't present. This behaviour was changed in #499. This PR restores that behaviour but allows the fallback for any user ID claim. 

Fixes #558 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix behaviour that was broken in #499 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
None yet

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
