### PR TITLE
Allow access token and id token to be exposed to a requesting client.

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ func main() {
 	flagSet.Bool("set-basic-auth", false, "set HTTP Basic Auth information in response (useful in Nginx auth_request mode)")
 	flagSet.Bool("prefer-email-to-user", false, "Prefer to use the Email address as the Username when passing information to upstream. Will only use Username if Email is unavailable, eg. htaccess authentication. Used in conjunction with -pass-basic-auth and -pass-user-headers")
 	flagSet.Bool("pass-user-headers", true, "pass X-Forwarded-User and X-Forwarded-Email information to upstream")
+	flagSet.Bool("token-tapping", false, "Allow the access and id tokens to be accessed using special proxy auth and userinfo endpoints")
 	flagSet.String("basic-auth-password", "", "the password to set when passing the HTTP Basic Auth header")
 	flagSet.Bool("pass-access-token", false, "pass OAuth access_token to upstream via X-Forwarded-Access-Token header")
 	flagSet.Bool("pass-host-header", true, "pass the request Host Header to upstream")

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"crypto/tls"
-	"encoding/base64"
 	b64 "encoding/base64"
 	"encoding/json"
 	"errors"
@@ -714,7 +713,7 @@ func extractJWTPayload(jwt string) ([]byte, error) {
 		return nil, fmt.Errorf("invalid jwt: expects 3 parts, got %d", len(parts))
 	}
 
-	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	payload, err := b64.RawURLEncoding.DecodeString(parts[1])
 	if err != nil {
 		return nil, err
 	}

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -744,7 +744,7 @@ func (p *OAuthProxy) setAccessTokenResponseHeaders(rw http.ResponseWriter, sessi
 //UserInfo endpoint outputs session email and preferred username in JSON format
 func (p *OAuthProxy) UserInfo(rw http.ResponseWriter, req *http.Request) {
 
-	forceRefresh := req.URL.Query().Get("forceRefresh") != "0"
+	forceRefresh := isTruthyQueryValue(req.URL.Query().Get("forceRefresh"))
 	session, err := p.getAuthenticatedSession(rw, req, forceRefresh)
 	if err != nil {
 		http.Error(rw, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
@@ -879,9 +879,13 @@ func (p *OAuthProxy) OAuthCallback(rw http.ResponseWriter, req *http.Request) {
 	}
 }
 
+func isTruthyQueryValue(s string) bool {
+	return s != "" && s != "0" && strings.ToLower(s) != "false"
+}
+
 // AuthenticateOnly checks whether the user is currently logged in
 func (p *OAuthProxy) AuthenticateOnly(rw http.ResponseWriter, req *http.Request) {
-	forceRefresh := req.URL.Query().Get("forceRefresh") != "0"
+	forceRefresh := isTruthyQueryValue(req.URL.Query().Get("forceRefresh"))
 	session, err := p.getAuthenticatedSession(rw, req, forceRefresh)
 	if err != nil {
 		http.Error(rw, "unauthorized request", http.StatusUnauthorized)

--- a/options.go
+++ b/options.go
@@ -81,6 +81,7 @@ type Options struct {
 	PassHostHeader                bool          `flag:"pass-host-header" cfg:"pass_host_header" env:"OAUTH2_PROXY_PASS_HOST_HEADER"`
 	SkipProviderButton            bool          `flag:"skip-provider-button" cfg:"skip_provider_button" env:"OAUTH2_PROXY_SKIP_PROVIDER_BUTTON"`
 	PassUserHeaders               bool          `flag:"pass-user-headers" cfg:"pass_user_headers" env:"OAUTH2_PROXY_PASS_USER_HEADERS"`
+	TokenTapping                  bool          `flag:"token-tapping" cfg:"token_tapping" env:"OAUTH2_PROXY_TOKEN_TAPPING"`
 	SSLInsecureSkipVerify         bool          `flag:"ssl-insecure-skip-verify" cfg:"ssl_insecure_skip_verify" env:"OAUTH2_PROXY_SSL_INSECURE_SKIP_VERIFY"`
 	SSLUpstreamInsecureSkipVerify bool          `flag:"ssl-upstream-insecure-skip-verify" cfg:"ssl_upstream_insecure_skip_verify" env:"OAUTH2_PROXY_SSL_UPSTREAM_INSECURE_SKIP_VERIFY"`
 	SetXAuthRequest               bool          `flag:"set-xauthrequest" cfg:"set_xauthrequest" env:"OAUTH2_PROXY_SET_XAUTHREQUEST"`


### PR DESCRIPTION
## Description

Allows extended token information to be returned to a client if required. It also adds the ability to explicitly request a token refresh prior to any configured expiration time. This functionality is disabled by default, but can be turned on using `--token-tapping`. If enabled, the following endpoints will return additional information:
* `/oauth2/userinfo` (raw idToken in json form and extra token headers, see below)
* `/oauth2/auth` (extra token headers, see below)

Extra HTTP headers are provided on the responses to the above endpoints and mirror the existing "xauth" semantics, but only for these endpoints to reduce overhead for all requests:
* `X-Auth-Request-Access-Token` (the current access token associated with the session)
* `X-Auth-Request-Expires-On` (a RFC3339 formated expiration time for that access token)

Further, the two endpoints above also accept an optional `?forceRefresh=1` query parameter that will bypass any remaining time on the token expiration and immediately trigger a refresh operation. This is useful for a number of scenarios:
* An application/admin operation changes permissions on something and that new status should be reflected immediately
* One or more user attributes has been modified (such as group/role/or other claim) and that should be reflected immediately.
* A token previously acquired using this system is about to expire and a client pro-actively requests a refresh (possibly in the background) to avoid interruptions or lag when the token actually expires.

## Motivation and Context

Sometimes it's desirable to be able to perform authenticated requests from a client javascript library or system. Without the ability to "tap" into the already existing authenticated session, these scenarios are forced to write extra backend service shims or re-implement authentication on the client side causing duplicate (and possibly divergent) views of authentication and a poor user experience (multiple login prompts, etc).

## How Has This Been Tested?

This is actively being tested with Win10, AAD, and MSAL as well as ad-hoc verification using curl.

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
