### PR TITLE
render error page on 502 proxy status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 
 ## Changes since v5.1.1
 
+- [#574](https://github.com/oauth2-proxy/oauth2-proxy/pull/574) render error page on 502 proxy status (@amnay-mo)
 - [#569](https://github.com/oauth2-proxy/oauth2-proxy/pull/569) Updated autocompletion for `--` long options. (@Izzette)
 - [#489](https://github.com/oauth2-proxy/oauth2-proxy/pull/489) Move Options and Validation to separate packages (@JoelSpeed)
 - [#556](https://github.com/oauth2-proxy/oauth2-proxy/pull/556) Remove unintentional auto-padding of secrets that were too short (@NickMeves)


### PR DESCRIPTION
## Description

Render an error page with detailed error on proxy 502 status
Fixes #545 

## Motivation and Context

A blank 502 page is displayed whenever the reverse proxy can't get a valid response from an upstream

## How Has This Been Tested?

I Tested using the local environment provided in the contrib files (the httpbin + dex setup)

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
