### PR TITLE
Split strings values by "," in the struct StringArray{}

### DIFF
--- a/string_array.go
+++ b/string_array.go
@@ -14,7 +14,7 @@ func (a *StringArray) Get() interface{} {
 
 // Set appends a string to the StringArray
 func (a *StringArray) Set(s string) error {
-	*a = append(*a, s)
+	*a = append(*a, strings.Split(s, ",")...)
 	return nil
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When a list of elements is defined in the cli with the argument -upstream they are not split by ",". As result when convert this string slice to slice of url.URL don't work correctly.

<!--- Describe your changes in detail -->

## Motivation and Context
In the documentation says that is possible to use a list of upstreams defined in the arguments, but doesn't work in the 5.1.1 version.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
It's a very simple change. After start the service with a list of upstreams we can see the debug messages "mapping path %q => upstream  %q"" with the right path -> host following the list.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
