### PR TITLE
Add compression option for session

### DIFF
--- a/contrib/oauth2-proxy.cfg.example
+++ b/contrib/oauth2-proxy.cfg.example
@@ -84,7 +84,6 @@
 ##            (ie: 1h means tokens are refreshed on request 1hr+ after it was set)
 ## Secure   - secure cookies are only sent by the browser of a HTTPS connection (recommended)
 ## HttpOnly - httponly cookies are not readable by javascript (recommended)
-## Compress - compress the cookie with gzip before store (recommended for large tokens like MS Azure)
 # cookie_name = "_oauth2_proxy"
 # cookie_secret = ""
 # cookie_domains = ""
@@ -92,4 +91,3 @@
 # cookie_refresh = ""
 # cookie_secure = true
 # cookie_httponly = true
-# cookie_compress = false

--- a/contrib/oauth2-proxy.cfg.example
+++ b/contrib/oauth2-proxy.cfg.example
@@ -84,6 +84,7 @@
 ##            (ie: 1h means tokens are refreshed on request 1hr+ after it was set)
 ## Secure   - secure cookies are only sent by the browser of a HTTPS connection (recommended)
 ## HttpOnly - httponly cookies are not readable by javascript (recommended)
+## Compress - compress the cookie with gzip before store (recommended for large tokens like MS Azure)
 # cookie_name = "_oauth2_proxy"
 # cookie_secret = ""
 # cookie_domains = ""
@@ -91,3 +92,4 @@
 # cookie_refresh = ""
 # cookie_secure = true
 # cookie_httponly = true
+# cookie_compress = false

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -42,7 +42,6 @@ An example [oauth2-proxy.cfg]({{ site.gitweb }}/contrib/oauth2-proxy.cfg.example
 | `--cookie-secret` | string | the seed string for secure cookies (optionally base64 encoded) | |
 | `--cookie-secure` | bool | set [secure (HTTPS only) cookie flag](https://owasp.org/www-community/controls/SecureFlag) | true |
 | `--cookie-samesite` | string | set SameSite cookie attribute (ie: `"lax"`, `"strict"`, `"none"`, or `""`). | `""` |
-| `--cookie-compress` | bool | compress the cookie with gzip before store | false |
 | `--custom-templates-dir` | string | path to custom html templates | |
 | `--display-htpasswd-form` | bool | display username / password login form if an htpasswd file is provided | true |
 | `--email-domain` | string | authenticate emails with the specified domain (may be given multiple times). Use `*` to authenticate any email | |
@@ -106,6 +105,7 @@ An example [oauth2-proxy.cfg]({{ site.gitweb }}/contrib/oauth2-proxy.cfg.example
 | `--reverse-proxy` | bool | are we running behind a reverse proxy, controls whether headers like X-Real-Ip are accepted | false |
 | `--scope` | string | OAuth scope specification | |
 | `--session-store-type` | string | [Session data storage backend](configuration/sessions); redis or cookie | cookie |
+| `--session-compress` | bool | compress the cookie with gzip before store | false |
 | `--set-xauthrequest` | bool | set X-Auth-Request-User, X-Auth-Request-Email and X-Auth-Request-Preferred-Username response headers (useful in Nginx auth_request mode) | false |
 | `--set-authorization-header` | bool | set Authorization Bearer response header (useful in Nginx auth_request mode) | false |
 | `--set-basic-auth` | bool | set HTTP Basic Auth information in response (useful in Nginx auth_request mode) | false |

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -42,6 +42,7 @@ An example [oauth2-proxy.cfg]({{ site.gitweb }}/contrib/oauth2-proxy.cfg.example
 | `--cookie-secret` | string | the seed string for secure cookies (optionally base64 encoded) | |
 | `--cookie-secure` | bool | set [secure (HTTPS only) cookie flag](https://owasp.org/www-community/controls/SecureFlag) | true |
 | `--cookie-samesite` | string | set SameSite cookie attribute (ie: `"lax"`, `"strict"`, `"none"`, or `""`). | `""` |
+| `--cookie-compress` | bool | compress the cookie with gzip before store | false |
 | `--custom-templates-dir` | string | path to custom html templates | |
 | `--display-htpasswd-form` | bool | display username / password login form if an htpasswd file is provided | true |
 | `--email-domain` | string | authenticate emails with the specified domain (may be given multiple times). Use `*` to authenticate any email | |

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -80,6 +80,8 @@ type OAuthProxy struct {
 	CookieSameSite string
 	Validator      func(string) bool
 
+	SessionCompress bool
+
 	RobotsPath        string
 	PingPath          string
 	SignInPath        string
@@ -310,6 +312,8 @@ func NewOAuthProxy(opts *options.Options, validator func(string) bool) *OAuthPro
 		CookieSameSite: opts.Cookie.SameSite,
 		Validator:      validator,
 
+		SessionCompress: opts.SessionCompress,
+
 		RobotsPath:        "/robots.txt",
 		PingPath:          opts.PingPath,
 		SignInPath:        fmt.Sprintf("%s/sign_in", opts.ProxyPrefix),
@@ -380,6 +384,8 @@ func (p *OAuthProxy) redeemCode(ctx context.Context, host, code string) (s *sess
 	if err != nil {
 		return
 	}
+
+	s.Compress = p.SessionCompress
 
 	if s.Email == "" {
 		s.Email, err = p.provider.GetEmailAddress(ctx, s)

--- a/pkg/apis/options/options.go
+++ b/pkg/apis/options/options.go
@@ -281,6 +281,7 @@ func NewFlagSet() *pflag.FlagSet {
 	flagSet.Duration("cookie-refresh", time.Duration(0), "refresh the cookie after this duration; 0 to disable")
 	flagSet.Bool("cookie-secure", true, "set secure (HTTPS) cookie flag")
 	flagSet.Bool("cookie-httponly", true, "set HttpOnly cookie flag")
+	flagSet.Bool("cookie-compress", false, "compress the cookie with gzip before store")
 	flagSet.String("cookie-samesite", "", "set SameSite cookie attribute (ie: \"lax\", \"strict\", \"none\", or \"\"). ")
 
 	flagSet.String("session-store-type", "cookie", "the session storage provider to use")

--- a/pkg/apis/options/options.go
+++ b/pkg/apis/options/options.go
@@ -59,8 +59,9 @@ type Options struct {
 	Banner                   string   `flag:"banner" cfg:"banner"`
 	Footer                   string   `flag:"footer" cfg:"footer"`
 
-	Cookie  CookieOptions  `cfg:",squash"`
-	Session SessionOptions `cfg:",squash"`
+	Cookie          CookieOptions  `cfg:",squash"`
+	Session         SessionOptions `cfg:",squash"`
+	SessionCompress bool           `flag:"session-compress" cfg:"session_compress"`
 
 	Upstreams                     []string      `flag:"upstream" cfg:"upstreams"`
 	SkipAuthRegex                 []string      `flag:"skip-auth-regex" cfg:"skip_auth_regex"`
@@ -281,10 +282,11 @@ func NewFlagSet() *pflag.FlagSet {
 	flagSet.Duration("cookie-refresh", time.Duration(0), "refresh the cookie after this duration; 0 to disable")
 	flagSet.Bool("cookie-secure", true, "set secure (HTTPS) cookie flag")
 	flagSet.Bool("cookie-httponly", true, "set HttpOnly cookie flag")
-	flagSet.Bool("cookie-compress", false, "compress the cookie with gzip before store")
+
 	flagSet.String("cookie-samesite", "", "set SameSite cookie attribute (ie: \"lax\", \"strict\", \"none\", or \"\"). ")
 
 	flagSet.String("session-store-type", "cookie", "the session storage provider to use")
+	flagSet.Bool("session-compress", false, "session compressed using gzip")
 	flagSet.String("redis-connection-url", "", "URL of redis server for redis session storage (eg: redis://HOST[:PORT])")
 	flagSet.Bool("redis-use-sentinel", false, "Connect to redis via sentinels. Must set --redis-sentinel-master-name and --redis-sentinel-connection-urls to use this feature")
 	flagSet.String("redis-sentinel-master-name", "", "Redis sentinel master name. Used in conjunction with --redis-use-sentinel")


### PR DESCRIPTION
Introduce the option "-cookie-compress" to apply to gzip over the session before storing them. It will save bytes in HTTP headers when using cookie sessions.

## Description
It's a small change to apply a gzip compression just after generating the JSON of the session; only if the mentioned JSON is bigger than 256 bytes (minBytesToCompress). If the user doesn't activate the -cookie-compress option shouldn't have any effect and will work as before.

## Motivation and Context
MS Azure produce long tokens, and it becomes a long cookie session. We have issues with some HTTP servers like Apache and nginx because the generated headers were too big.

## How Has This Been Tested?
The PR include unit testing with the compression enabled. It's was also tested over stage environments with many users. 

## Checklist:
- [X] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [X] I have created a feature (non-master) branch for my PR.

The PR includes changes in the documentation and config examples but not in the CHANGELOG.