### PR TITLE
Ensure decrypted user/email are valid UTF8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 
 ## Changes since v5.1.1
 
+- [#601](https://github.com/oauth2-proxy/oauth2-proxy/pull/601) Ensure decrypted user/email are valid UTF8 (@JoelSpeed)
 - [#560](https://github.com/oauth2-proxy/oauth2-proxy/pull/560) Fallback to UserInfo is User ID claim not present (@JoelSpeed)
 - [#598](https://github.com/oauth2-proxy/oauth2-proxy/pull/598) acr_values no longer sent to IdP when empty (@ScottGuymer)
 - [#548](https://github.com/oauth2-proxy/oauth2-proxy/pull/548) Separate logging options out of main options structure (@JoelSpeed)

--- a/pkg/apis/sessions/session_state.go
+++ b/pkg/apis/sessions/session_state.go
@@ -2,8 +2,10 @@ package sessions
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
+	"unicode/utf8"
 
 	"github.com/oauth2-proxy/oauth2-proxy/pkg/encryption"
 )
@@ -106,6 +108,9 @@ func DecodeSessionState(v string, c *encryption.Cipher) (*SessionState, error) {
 		if ss.Email != "" {
 			decryptedEmail, errEmail := c.Decrypt(ss.Email)
 			if errEmail == nil {
+				if !utf8.ValidString(decryptedEmail) {
+					return nil, errors.New("invalid value for decrypted email")
+				}
 				ss.Email = decryptedEmail
 			}
 		}
@@ -113,6 +118,9 @@ func DecodeSessionState(v string, c *encryption.Cipher) (*SessionState, error) {
 		if ss.User != "" {
 			decryptedUser, errUser := c.Decrypt(ss.User)
 			if errUser == nil {
+				if !utf8.ValidString(decryptedUser) {
+					return nil, errors.New("invalid value for decrypted user")
+				}
 				ss.User = decryptedUser
 			}
 		}

--- a/pkg/apis/sessions/session_state_test.go
+++ b/pkg/apis/sessions/session_state_test.go
@@ -49,15 +49,7 @@ func TestSessionStateSerialization(t *testing.T) {
 	// ensure a different cipher can't decode properly (ie: it gets gibberish)
 	ss, err = sessions.DecodeSessionState(encoded, c2)
 	t.Logf("%#v", ss)
-	assert.Equal(t, nil, err)
-	assert.NotEqual(t, "user@domain.com", ss.User)
-	assert.NotEqual(t, s.Email, ss.Email)
-	assert.NotEqual(t, s.PreferredUsername, ss.PreferredUsername)
-	assert.Equal(t, s.CreatedAt.Unix(), ss.CreatedAt.Unix())
-	assert.Equal(t, s.ExpiresOn.Unix(), ss.ExpiresOn.Unix())
-	assert.NotEqual(t, s.AccessToken, ss.AccessToken)
-	assert.NotEqual(t, s.IDToken, ss.IDToken)
-	assert.NotEqual(t, s.RefreshToken, ss.RefreshToken)
+	assert.NotEqual(t, nil, err)
 }
 
 func TestSessionStateSerializationWithUser(t *testing.T) {
@@ -91,14 +83,7 @@ func TestSessionStateSerializationWithUser(t *testing.T) {
 	// ensure a different cipher can't decode properly (ie: it gets gibberish)
 	ss, err = sessions.DecodeSessionState(encoded, c2)
 	t.Logf("%#v", ss)
-	assert.Equal(t, nil, err)
-	assert.NotEqual(t, s.User, ss.User)
-	assert.NotEqual(t, s.Email, ss.Email)
-	assert.NotEqual(t, s.PreferredUsername, ss.PreferredUsername)
-	assert.Equal(t, s.CreatedAt.Unix(), ss.CreatedAt.Unix())
-	assert.Equal(t, s.ExpiresOn.Unix(), ss.ExpiresOn.Unix())
-	assert.NotEqual(t, s.AccessToken, ss.AccessToken)
-	assert.NotEqual(t, s.RefreshToken, ss.RefreshToken)
+	assert.NotEqual(t, nil, err)
 }
 
 func TestSessionStateSerializationNoCipher(t *testing.T) {
@@ -277,6 +262,14 @@ func TestDecodeSessionState(t *testing.T) {
 			Encoded: `{"Email":"user@domain.com","User":"just-user","IDToken":"XXXX"}`,
 			Cipher:  c,
 			Error:   true,
+		},
+		{
+			SessionState: sessions.SessionState{
+				Email: "user@domain.com",
+				User:  "YmFzZTY0LWVuY29kZWQtdXNlcgo=", // Base64 encoding of base64-encoded-user
+			},
+			Error:  true,
+			Cipher: c,
 		},
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

<!--- Describe your changes in detail -->
When migrating from an unencrypted to an encrypted session, if a user or email is valid base64, it will decode and be unencrypted by the cipher. Since the original string would have been utf8, we should be able to detect if this decryption was bad by checking the string is valid utf8

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Moving from unencrpyted to encrypted sessions can break logins for some users. Since we are forcing this for v6.0.0, we should try to mitigate the issues somewhat.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual testing with the local-environment, which happens to have a valid base64 string as it's user 

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.