### PR TITLE
Update CODEOWNERS to request review from reviewers team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
-# Default owner should be a core maintainer unless overridden by later rules in this file
-* @steakunderscore @JoelSpeed
+# Default owner should be a core org reviewers unless overridden by later rules in this file
+* @oauth2-proxy/reviewers
 
 # login.gov provider
 # Note:  If @timothy-spencer terms out of his appointment, your best bet


### PR DESCRIPTION
This means that we can keep the list of reviewers up to date based on team membership, rather than this file. Will make it easier to add and remove people going forward