### PR TITLE
Increase testing around redis_store

### DIFF
--- a/pkg/sessions/redis/redis_store.go
+++ b/pkg/sessions/redis/redis_store.go
@@ -186,17 +186,17 @@ func (store *SessionStore) Load(req *http.Request) (*sessions.SessionState, erro
 func (store *SessionStore) loadSessionFromString(ctx context.Context, value string) (*sessions.SessionState, error) {
 	ticket, err := decodeTicket(store.CookieOptions.Name, value)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error decoding ticket: %s", err)
 	}
 
 	resultBytes, err := store.Client.Get(ctx, ticket.asHandle(store.CookieOptions.Name))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error retrieving from store: %s", err)
 	}
 
 	block, err := aes.NewCipher(ticket.Secret)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error creating new cipher: %s", err)
 	}
 	// Use secret as the IV too, because each entry has it's own key
 	stream := cipher.NewCFBDecrypter(block, ticket.Secret)
@@ -204,7 +204,7 @@ func (store *SessionStore) loadSessionFromString(ctx context.Context, value stri
 
 	session, err := sessions.DecodeSessionState(string(resultBytes), store.CookieCipher)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error decoding session: %s", err)
 	}
 	return session, nil
 }

--- a/pkg/sessions/redis/redis_store_test.go
+++ b/pkg/sessions/redis/redis_store_test.go
@@ -19,6 +19,7 @@ func TestRedisStore(t *testing.T) {
 		redisServer, err := miniredis.Run()
 		require.NoError(t, err)
 		defer redisServer.Close()
+
 		opts := options.NewOptions()
 		redisURL := url.URL{
 			Scheme: "redis",
@@ -27,12 +28,111 @@ func TestRedisStore(t *testing.T) {
 		opts.Session.Redis.ConnectionURL = redisURL.String()
 		redisStore, err := NewRedisSessionStore(&opts.Session, &opts.Cookie)
 		require.NoError(t, err)
+
+		recorder := httptest.NewRecorder()
 		err = redisStore.Save(
-			httptest.NewRecorder(),
+			recorder,
 			httptest.NewRequest(http.MethodGet, "/", nil),
 			&sessions.SessionState{})
 		assert.NoError(t, err)
+		cookies := recorder.Result().Cookies()
+		assert.Len(t, cookies, 1)
+		assert.Equal(t, cookies[0].Name, opts.Cookie.Name)
 	})
+
+	t.Run("load session on empty redis standalone fails", func(t *testing.T) {
+		redisServer, err := miniredis.Run()
+		require.NoError(t, err)
+		defer redisServer.Close()
+
+		opts := options.NewOptions()
+		redisURL := url.URL{
+			Scheme: "redis",
+			Host:   redisServer.Addr(),
+		}
+		opts.Session.Redis.ConnectionURL = redisURL.String()
+		redisStore, err := NewRedisSessionStore(&opts.Session, &opts.Cookie)
+		require.NoError(t, err)
+
+		sessionState, err := redisStore.Load(
+			httptest.NewRequest(http.MethodGet, "/", nil),
+		)
+		assert.Nil(t, sessionState)
+		assert.Error(t, err, "error loading session")
+	})
+
+	t.Run("save+load session on redis standalone success", func(t *testing.T) {
+		redisServer, err := miniredis.Run()
+		require.NoError(t, err)
+		defer redisServer.Close()
+
+		opts := options.NewOptions()
+		redisURL := url.URL{
+			Scheme: "redis",
+			Host:   redisServer.Addr(),
+		}
+		opts.Session.Redis.ConnectionURL = redisURL.String()
+		redisStore, err := NewRedisSessionStore(&opts.Session, &opts.Cookie)
+		require.NoError(t, err)
+
+		recorder := httptest.NewRecorder()
+		prevSessionState := &sessions.SessionState{}
+		err = redisStore.Save(
+			recorder,
+			httptest.NewRequest(http.MethodGet, "/", nil),
+			prevSessionState)
+		assert.NoError(t, err)
+		cookies := recorder.Result().Cookies()
+		assert.Len(t, cookies, 1)
+		assert.Equal(t, cookies[0].Name, opts.Cookie.Name)
+
+		request := httptest.NewRequest(http.MethodGet, "/", nil)
+		request.AddCookie(cookies[0])
+		sessionState, err := redisStore.Load(request)
+		assert.NoError(t, err)
+		assert.Equal(t, prevSessionState.Email, sessionState.Email)
+	})
+
+	t.Run("save+load+clear+load session on redis standalone success", func(t *testing.T) {
+		redisServer, err := miniredis.Run()
+		require.NoError(t, err)
+		defer redisServer.Close()
+
+		opts := options.NewOptions()
+		redisURL := url.URL{
+			Scheme: "redis",
+			Host:   redisServer.Addr(),
+		}
+		opts.Session.Redis.ConnectionURL = redisURL.String()
+		redisStore, err := NewRedisSessionStore(&opts.Session, &opts.Cookie)
+		require.NoError(t, err)
+
+		recorder := httptest.NewRecorder()
+		prevSessionState := &sessions.SessionState{}
+		err = redisStore.Save(
+			recorder,
+			httptest.NewRequest(http.MethodGet, "/", nil),
+			prevSessionState)
+		assert.NoError(t, err)
+		cookies := recorder.Result().Cookies()
+		assert.Len(t, cookies, 1)
+		assert.Equal(t, cookies[0].Name, opts.Cookie.Name)
+
+		request := httptest.NewRequest(http.MethodGet, "/", nil)
+		request.AddCookie(cookies[0])
+		sessionState, err := redisStore.Load(request)
+		assert.NoError(t, err)
+		assert.Equal(t, prevSessionState.Email, sessionState.Email)
+
+		err = redisStore.Clear(recorder, request)
+		assert.NoError(t, err)
+
+		request.AddCookie(cookies[0])
+		sessionState, err = redisStore.Load(request)
+		assert.Nil(t, sessionState)
+		assert.Error(t, err, "retrieving from store")
+	})
+
 	t.Run("save session on redis sentinel", func(t *testing.T) {
 		redisServer, err := miniredis.Run()
 		require.NoError(t, err)


### PR DESCRIPTION
## Description

This commit increases the testing around the redis session store,
demonstrating save/load/clear behavior. The error reporting in
loadSessionFromString is also improved some to help distinguish
between the error conditions from this function.

## Motivation and Context

The motivation behind these changes is a larger debugging project to
identify an authentication loop some of my users have reported that
appear coincident with redis losing all its keys.

## How Has This Been Tested?

These changes are tests themselves and only slightly modify functional code. 

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
