### PR TITLE
Only set healthcheck user agents when the ping-user-agent is set, and don't check blank user agents against healthcheck user agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [#542](https://github.com/oauth2-proxy/oauth2-proxy/pull/542) Move SessionStore tests to independent package (@JoelSpeed)
 - [#577](https://github.com/oauth2-proxy/oauth2-proxy/pull/577) Move Cipher and Session Store initialisation out of Validation (@JoelSpeed)
 - [#635](https://github.com/oauth2-proxy/oauth2-proxy/pull/635) Support specifying alternative provider TLS trust source(s) (@k-wall)
+- [#649](https://github.com/oauth2-proxy/oauth2-proxy/pull/650) Resolve an issue where an empty healthcheck URL and ping-user-agent returns the healthcheck response (@jordancrawfordnz)
 
 # v6.0.0
 

--- a/pkg/middleware/healthcheck.go
+++ b/pkg/middleware/healthcheck.go
@@ -17,13 +17,17 @@ func healthCheck(paths, userAgents []string, next http.Handler) http.Handler {
 	// Use a map as a set to check health check paths
 	pathSet := make(map[string]struct{})
 	for _, path := range paths {
-		pathSet[path] = struct{}{}
+		if len(path) > 0 {
+			pathSet[path] = struct{}{}
+		}
 	}
 
 	// Use a map as a set to check health check paths
 	userAgentSet := make(map[string]struct{})
 	for _, userAgent := range userAgents {
-		userAgentSet[userAgent] = struct{}{}
+		if len(userAgent) > 0 {
+			userAgentSet[userAgent] = struct{}{}
+		}
 	}
 
 	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
## Description
A blank user agent is considered == to an empty string. When no -ping-user-agent option is specified, this is considered to be an empty string.

This reveals two problems:
- When no ping-user-agent is specified, main.go sets up a health check user agent of ""
- When no user agent is specified, the empty string is still checked against the health check user agents.

Now, the health check user agents are only set if ping-user-agent is specified.
In addition, empty user agents are not checked against healthcheck user agents.

Additional tests have been added to verify these situations.

<!--- Describe your changes in detail -->

## Motivation and Context
Resolves #649.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Newly introduced automated testing and manually verifying it against the reproduction steps in #649.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
