### PR TITLE
Split cookies more precisely at 4096 bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Changes since v6.0.0
 
+- [#656](https://github.com/oauth2-proxy/oauth2-proxy/pull/656) Split long session cookies more precisely (@NickMeves)
 - [#619](https://github.com/oauth2-proxy/oauth2-proxy/pull/619) Improve Redirect to HTTPs behaviour (@JoelSpeed)
 - [#654](https://github.com/oauth2-proxy/oauth2-proxy/pull/654) Close client connections after each redis test (@JoelSpeed)
 - [#542](https://github.com/oauth2-proxy/oauth2-proxy/pull/542) Move SessionStore tests to independent package (@JoelSpeed)

--- a/pkg/sessions/cookie/session_store_test.go
+++ b/pkg/sessions/cookie/session_store_test.go
@@ -1,7 +1,10 @@
 package cookie
 
 import (
+	"fmt"
+	mathrand "math/rand"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -48,4 +51,116 @@ func Test_copyCookie(t *testing.T) {
 
 	got := copyCookie(c)
 	assert.Equal(t, c, got)
+}
+
+func Test_splitCookie(t *testing.T) {
+	testCases := map[string]struct {
+		Cookie        *http.Cookie
+		ExpectedSizes []int
+	}{
+		"Short cookie name": {
+			Cookie: &http.Cookie{
+				Name:  "short",
+				Value: strings.Repeat("v", 10000),
+			},
+			ExpectedSizes: []int{4089, 4089, 1822},
+		},
+		"Long cookie name": {
+			Cookie: &http.Cookie{
+				Name:  strings.Repeat("n", 251),
+				Value: strings.Repeat("a", 10000),
+			},
+			ExpectedSizes: []int{3843, 3843, 2314},
+		},
+		"Max cookie name": {
+			Cookie: &http.Cookie{
+				Name:  strings.Repeat("n", 256),
+				Value: strings.Repeat("a", 10000),
+			},
+			ExpectedSizes: []int{3840, 3840, 2320},
+		},
+		"Suffix overflow cookie name": {
+			Cookie: &http.Cookie{
+				Name:  strings.Repeat("n", 255),
+				Value: strings.Repeat("a", 10000),
+			},
+			ExpectedSizes: []int{3840, 3840, 2320},
+		},
+		"Double digit suffix cookie name results in different sizes": {
+			Cookie: &http.Cookie{
+				Name:  strings.Repeat("n", 253),
+				Value: strings.Repeat("a", 50000),
+			},
+			ExpectedSizes: []int{3841, 3841, 3841, 3841, 3841, 3841, 3841, 3841, 3841, 3841,
+				3840, 3840, 3840, 70},
+		},
+		"Double digit suffix overflow cookie name results in same sizes": {
+			Cookie: &http.Cookie{
+				Name:  strings.Repeat("n", 254),
+				Value: strings.Repeat("a", 50000),
+			},
+			ExpectedSizes: []int{3840, 3840, 3840, 3840, 3840, 3840, 3840, 3840, 3840, 3840,
+				3840, 3840, 3840, 80},
+		},
+	}
+	for testName, tc := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			for i, cookie := range splitCookie(tc.Cookie) {
+				assert.Equal(t, tc.ExpectedSizes[i], len(cookie.Value))
+			}
+		})
+	}
+}
+
+func Test_splitCookieName(t *testing.T) {
+	testCases := map[string]struct {
+		Name   string
+		Count  int
+		Output string
+	}{
+		"Standard length": {
+			Name:   "IAmSoNormal",
+			Count:  2,
+			Output: "IAmSoNormal_2",
+		},
+		"Max length": {
+			Name:   strings.Repeat("n", 256),
+			Count:  1,
+			Output: fmt.Sprintf("%s_%d", strings.Repeat("n", 254), 1),
+		},
+		"Large count overflow": {
+			Name:   strings.Repeat("n", 253),
+			Count:  1000,
+			Output: fmt.Sprintf("%s_%d", strings.Repeat("n", 251), 1000),
+		},
+	}
+	for testName, tc := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			splitName := splitCookieName(tc.Name, tc.Count)
+			assert.Equal(t, tc.Output, splitName)
+		})
+	}
+}
+
+func Test_splitCookie_joinCookies(t *testing.T) {
+	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+	v := make([]byte, 251)
+	for i := range v {
+		v[i] = charset[mathrand.Intn(len(charset))]
+	}
+	value := strings.Repeat(string(v), 1000)
+
+	for _, nameSize := range []int{1, 10, 50, 100, 200, 254} {
+		t.Run(fmt.Sprintf("%d length cookie name", nameSize), func(t *testing.T) {
+			cookie := &http.Cookie{
+				Name:  strings.Repeat("n", nameSize),
+				Value: value,
+			}
+			splitCookies := splitCookie(cookie)
+			joinedCookie, err := joinCookies(splitCookies)
+			assert.NoError(t, err)
+			assert.Equal(t, *cookie, *joinedCookie)
+		})
+	}
 }


### PR DESCRIPTION
We split cookies at 3840 bytes, assuming worst case cookie name is 256 bytes long. This more precisely splits and hopefully buys us ~240 more bytes of space preventing a cookie split.

## Description

Split cookies more precisely up to the 4096 name+value cookie length restriction. Additionally handle max length name corner cases better (so appending `"_%d", count` doesn't overflow the cookie name).

## Motivation and Context

Avoid cookie splitting in any ways possible.

## How Has This Been Tested?

New unit tests added to all cookie splitting & joining methods.

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
