### PR TITLE
Remove redundant trimming

### DIFF
--- a/pkg/encryption/utils.go
+++ b/pkg/encryption/utils.go
@@ -15,7 +15,7 @@ import (
 
 // SecretBytes attempts to base64 decode the secret, if that fails it treats the secret as binary
 func SecretBytes(secret string) []byte {
-	b, err := base64.RawURLEncoding.DecodeString(strings.TrimRight(secret, "="))
+	b, err := base64.RawURLEncoding.DecodeString(secret)
 	if err == nil {
 		// Only return decoded form if a valid AES length
 		// Don't want unintentional decoding resulting in invalid lengths confusing a user


### PR DESCRIPTION
##  Description
Fixes #665 
Remove `TrimRight` when decode base64 encoded secret.

## Motivation and Context
Avoid making redundant byte.

## Checklist:
- [x] I have created a feature (non-master) branch for my PR.
