### PR TITLE
Reduce docker context to improve build times

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,5 @@
 Dockerfile.dev
+docs
+vendor
+.git
+oauth2-proxy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Changes since v6.0.0
 
+- [#669](https://github.com/oauth2-proxy/oauth2-proxy/pull/669) Reduce docker context to improve build times (@JoelSpeed)
 - [#668](https://github.com/oauth2-proxy/oauth2-proxy/pull/668) Use req.Host in --force-https when req.URL.Host is empty (@zucaritask)
 - [#660](https://github.com/oauth2-proxy/oauth2-proxy/pull/660) Use builder pattern to simplify requests to external endpoints (@JoelSpeed)
 - [#591](https://github.com/oauth2-proxy/oauth2-proxy/pull/591) Introduce upstream package with new reverse proxy implementation (@JoelSpeed)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM golang:1.14-buster AS builder
+ARG VERSION
 
 # Download tools
 RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.24.0
@@ -19,7 +20,7 @@ COPY . .
 #  build the key into the container and then tell it where it is
 #  by setting OAUTH2_PROXY_JWT_KEY_FILE=/etc/ssl/private/jwt_signing_key.pem
 #  in app.yaml instead.
-RUN make build && touch jwt_signing_key.pem
+RUN VERSION=${VERSION} make build && touch jwt_signing_key.pem
 
 # Copy binary to alpine
 FROM alpine:3.11

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,4 +1,5 @@
 FROM golang:1.14-buster AS builder
+ARG VERSION
 
 # Download tools
 RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.24.0
@@ -19,7 +20,7 @@ COPY . .
 #  build the key into the container and then tell it where it is
 #  by setting OAUTH2_PROXY_JWT_KEY_FILE=/etc/ssl/private/jwt_signing_key.pem
 #  in app.yaml instead.
-RUN GOARCH=arm64 make build && touch jwt_signing_key.pem
+RUN VERSION=${VERSION} GOARCH=arm64 make build && touch jwt_signing_key.pem
 
 # Copy binary to alpine
 FROM arm64v8/alpine:3.11

--- a/Dockerfile.armv6
+++ b/Dockerfile.armv6
@@ -1,4 +1,5 @@
 FROM golang:1.14-buster AS builder
+ARG VERSION
 
 # Download tools
 RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.24.0
@@ -19,7 +20,7 @@ COPY . .
 #  build the key into the container and then tell it where it is
 #  by setting OAUTH2_PROXY_JWT_KEY_FILE=/etc/ssl/private/jwt_signing_key.pem
 #  in app.yaml instead.
-RUN GOARCH=arm GOARM=6 make build && touch jwt_signing_key.pem
+RUN VERSION=${VERSION} GOARCH=arm GOARM=6 make build && touch jwt_signing_key.pem
 
 # Copy binary to alpine
 FROM arm32v6/alpine:3.11

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ GO ?= go
 GOLANGCILINT ?= golangci-lint
 
 BINARY := oauth2-proxy
-VERSION := $(shell git describe --always --dirty --tags 2>/dev/null || echo "undefined")
+VERSION ?= $(shell git describe --always --dirty --tags 2>/dev/null || echo "undefined")
 # Allow to override image registry.
 REGISTRY ?= quay.io/oauth2-proxy
 .NOTPARALLEL:
@@ -12,6 +12,8 @@ GO_MINOR_VERSION = $(shell $(GO) version | cut -c 14- | cut -d' ' -f1 | cut -d'.
 MINIMUM_SUPPORTED_GO_MAJOR_VERSION = 1
 MINIMUM_SUPPORTED_GO_MINOR_VERSION = 14
 GO_VERSION_VALIDATION_ERR_MSG = Golang version is not supported, please update to at least $(MINIMUM_SUPPORTED_GO_MAJOR_VERSION).$(MINIMUM_SUPPORTED_GO_MINOR_VERSION)
+
+DOCKER_BUILD := docker build --build-arg VERSION=${VERSION}
 
 ifeq ($(COVER),true)
 TESTCOVER ?= -coverprofile c.out
@@ -41,17 +43,17 @@ $(BINARY):
 
 .PHONY: docker
 docker:
-	docker build -f Dockerfile -t $(REGISTRY)/oauth2-proxy:latest .
+	$(DOCKER_BUILD) -f Dockerfile -t $(REGISTRY)/oauth2-proxy:latest .
 
 .PHONY: docker-all
 docker-all: docker
-	docker build -f Dockerfile -t $(REGISTRY)/oauth2-proxy:latest-amd64 .
-	docker build -f Dockerfile -t $(REGISTRY)/oauth2-proxy:${VERSION} .
-	docker build -f Dockerfile -t $(REGISTRY)/oauth2-proxy:${VERSION}-amd64 .
-	docker build -f Dockerfile.arm64 -t $(REGISTRY)/oauth2-proxy:latest-arm64 .
-	docker build -f Dockerfile.arm64 -t $(REGISTRY)/oauth2-proxy:${VERSION}-arm64 .
-	docker build -f Dockerfile.armv6 -t $(REGISTRY)/oauth2-proxy:latest-armv6 .
-	docker build -f Dockerfile.armv6 -t $(REGISTRY)/oauth2-proxy:${VERSION}-armv6 .
+	$(DOCKER_BUILD) -f Dockerfile -t $(REGISTRY)/oauth2-proxy:latest-amd64 .
+	$(DOCKER_BUILD) -f Dockerfile -t $(REGISTRY)/oauth2-proxy:${VERSION} .
+	$(DOCKER_BUILD) -f Dockerfile -t $(REGISTRY)/oauth2-proxy:${VERSION}-amd64 .
+	$(DOCKER_BUILD) -f Dockerfile.arm64 -t $(REGISTRY)/oauth2-proxy:latest-arm64 .
+	$(DOCKER_BUILD) -f Dockerfile.arm64 -t $(REGISTRY)/oauth2-proxy:${VERSION}-arm64 .
+	$(DOCKER_BUILD) -f Dockerfile.armv6 -t $(REGISTRY)/oauth2-proxy:latest-armv6 .
+	$(DOCKER_BUILD) -f Dockerfile.armv6 -t $(REGISTRY)/oauth2-proxy:${VERSION}-armv6 .
 
 .PHONY: docker-push
 docker-push:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Use the `.dockerignore` file to exclude large directories and files from the build to reduce the build context.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I've been using WSL lately which has very poor IO at the moment. The build context we were sending to build was 220MB on my machine (about 100MB in `.git`, 60MB in `docs/vendor`, 20MB in a `oauth2-proxy` binary I had sitting around).

With these added ignores, I reduced the context to 14MB and it now passes the context to docker within a reasonable time frame.

To achieve this, I had to pass the version as a build arg. Which does mean that we can now override the version in the Makefile, which is not ideal but I expect no one to actually use it when publishing releases so it should be fine, right?

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually built the image, ran the image with `--version` to see the builder version passed through correctly 

```
$ make docker
$ docker run --rm -it quay.io/oauth2-proxy/oauth2-proxy --version
oauth2-proxy v6.0.0-46-gd297666-dirty (built with go1.14.4)
```

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
