### PR TITLE
Use singleflight to prevent calling duplicate Redis command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [#635](https://github.com/oauth2-proxy/oauth2-proxy/pull/635) Support specifying alternative provider TLS trust source(s) (@k-wall)
 - [#649](https://github.com/oauth2-proxy/oauth2-proxy/pull/650) Resolve an issue where an empty healthcheck URL and ping-user-agent returns the healthcheck response (@jordancrawfordnz)
 - [#662](https://github.com/oauth2-proxy/oauth2-proxy/pull/662) Do not add Cache-Control header to response from auth only endpoint (@johejo)
+- [#671](https://github.com/oauth2-proxy/oauth2-proxy/pull/671) Use singleflight to prevent calling duplicate Redis command (@johejo)
 
 # v6.0.0
 

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550
 	golang.org/x/net v0.0.0-20200226121028-0de0cce0169b
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
-	golang.org/x/sync v0.0.0-20190423024810-112230192c58
+	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect
 	google.golang.org/api v0.20.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/fsnotify/fsnotify v1.4.9
-	github.com/go-redis/redis/v7 v7.2.0
+	github.com/go-redis/redis/v7 v7.4.0
 	github.com/justinas/alice v1.2.0
 	github.com/kr/pretty v0.2.0 // indirect
 	github.com/mbland/hmacauth v0.0.0-20170912233209-44256dfd4bfa

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550
 	golang.org/x/net v0.0.0-20200226121028-0de0cce0169b
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
+	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect
 	google.golang.org/api v0.20.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -235,6 +235,7 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
-github.com/go-redis/redis/v7 v7.2.0 h1:CrCexy/jYWZjW0AyVoHlcJUeZN19VWlbepTh1Vq6dJs=
-github.com/go-redis/redis/v7 v7.2.0/go.mod h1:JDNMw23GTyLNC4GZu9njt15ctBQVn7xjRfnwdHj/Dcg=
+github.com/go-redis/redis/v7 v7.4.0 h1:7obg6wUoj05T0EpY0o8B59S9w5yeMWql7sw2kwNW1x4=
+github.com/go-redis/redis/v7 v7.4.0/go.mod h1:JDNMw23GTyLNC4GZu9njt15ctBQVn7xjRfnwdHj/Dcg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=

--- a/go.sum
+++ b/go.sum
@@ -237,6 +237,8 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 h1:qwRHBd0NqMbJxfbotnDhm2ByMI1Shq4Y6oRJo21SGJA=
+golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/pkg/sessions/redis/client.go
+++ b/pkg/sessions/redis/client.go
@@ -2,9 +2,11 @@ package redis
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/go-redis/redis/v7"
+	"golang.org/x/sync/singleflight"
 )
 
 // Client is wrapper interface for redis.Client and redis.ClusterClient.
@@ -18,6 +20,8 @@ var _ Client = (*client)(nil)
 
 type client struct {
 	*redis.Client
+
+	group singleflight.Group
 }
 
 func newClient(c *redis.Client) Client {
@@ -25,21 +29,44 @@ func newClient(c *redis.Client) Client {
 }
 
 func (c *client) Get(ctx context.Context, key string) ([]byte, error) {
-	return c.WithContext(ctx).Get(key).Bytes()
+	v, err, _ := c.group.Do(key, func() (interface{}, error) {
+		b, err := c.WithContext(ctx).Get(key).Bytes()
+		if err != nil {
+			return nil, err
+		}
+		return b, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	b, ok := v.([]byte)
+	if !ok {
+		return nil, fmt.Errorf("invalid value type: key=%s, value%v", key, v)
+	}
+	return b, nil
 }
 
 func (c *client) Set(ctx context.Context, key string, value []byte, expiration time.Duration) error {
-	return c.WithContext(ctx).Set(key, value, expiration).Err()
+	_, err, _ := c.group.Do(key, func() (interface{}, error) {
+		return nil, c.WithContext(ctx).Set(key, value, expiration).Err()
+	})
+	return err
 }
 
 func (c *client) Del(ctx context.Context, key string) error {
-	return c.WithContext(ctx).Del(key).Err()
+	_, err, _ := c.group.Do(key, func() (interface{}, error) {
+		return nil, c.WithContext(ctx).Del(key).Err()
+	})
+	return err
 }
 
 var _ Client = (*clusterClient)(nil)
 
 type clusterClient struct {
 	*redis.ClusterClient
+
+	group singleflight.Group
 }
 
 func newClusterClient(c *redis.ClusterClient) Client {
@@ -47,13 +74,34 @@ func newClusterClient(c *redis.ClusterClient) Client {
 }
 
 func (c *clusterClient) Get(ctx context.Context, key string) ([]byte, error) {
-	return c.WithContext(ctx).Get(key).Bytes()
+	v, err, _ := c.group.Do(key, func() (interface{}, error) {
+		b, err := c.WithContext(ctx).Get(key).Bytes()
+		if err != nil {
+			return nil, err
+		}
+		return b, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	b, ok := v.([]byte)
+	if !ok {
+		return nil, fmt.Errorf("invalid value type: key=%s, value%v", key, v)
+	}
+	return b, nil
 }
 
 func (c *clusterClient) Set(ctx context.Context, key string, value []byte, expiration time.Duration) error {
-	return c.WithContext(ctx).Set(key, value, expiration).Err()
+	_, err, _ := c.group.Do(key, func() (interface{}, error) {
+		return nil, c.WithContext(ctx).Set(key, value, expiration).Err()
+	})
+	return err
 }
 
 func (c *clusterClient) Del(ctx context.Context, key string) error {
-	return c.WithContext(ctx).Del(key).Err()
+	_, err, _ := c.group.Do(key, func() (interface{}, error) {
+		return nil, c.WithContext(ctx).Del(key).Err()
+	})
+	return err
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Use singleflight to prevent calling duplicate Redis command.
<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

related #667 
This isn't caching, but I think that it is effective in terms of users also who do not use the cache.
I'm also trying to implement the stampede approach, but I'm a little struggling to configure options and minimize the impact on existing tests.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It's a small change that uses singleflight.
It will not affect the result of unit test.
Performance comparison testing may be required.
I would appreciate feedback.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
