### PR TITLE
docs: Fix required ruby-version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Changes since v6.0.0
 
+- [#675](https://github.com/oauth2-proxy/oauth2-proxy/pull/675) Fix required ruby version and deprecated option for building docs (@mkontani)
 - [#669](https://github.com/oauth2-proxy/oauth2-proxy/pull/669) Reduce docker context to improve build times (@JoelSpeed)
 - [#668](https://github.com/oauth2-proxy/oauth2-proxy/pull/668) Use req.Host in --force-https when req.URL.Host is empty (@zucaritask)
 - [#660](https://github.com/oauth2-proxy/oauth2-proxy/pull/660) Use builder pattern to simplify requests to external endpoints (@JoelSpeed)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,7 +1,7 @@
 .PHONY: ruby
 ruby:
 	@ if [ ! $$(which ruby) ]; then \
-			echo "Please install ruby version 2.1.0 or higher"; \
+			echo "Please install ruby version 2.5.0 or higher"; \
 		fi
 
 .PHONY: bundle
@@ -11,7 +11,8 @@ bundle: ruby
 		fi
 
 vendor/bundle: bundle
-	bundle install --path vendor/bundle
+	bundle config set --local path 'vendor/bundle'
+	bundle install
 
 .PHONY: serve
 serve: vendor/bundle

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,5 +9,5 @@ When making changes to this docs site, please test your changes locally:
 docs$ make serve
 ```
 
-To run the docs site locally you will need Ruby at version 2.1.0 or
+To run the docs site locally you will need Ruby at version 2.5.0 or
 higher and `bundle` (`gem install bundler` if you already have Ruby).


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Building docs in local, I saw dependencies error and deprecated option.

<!--- Describe your changes in detail -->

## Motivation and Context

- fix required ruby version (2.1.0 -> 2.5.0)
- fix deprecated option (bundle install --path)


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The detail is below.

```
$ ruby --version
ruby 2.4.4p296 (2018-03-28 revision 63013) [x86_64-linux]

$ make serve
bundle install --path vendor/bundle
[DEPRECATED] The `--path` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set path 'vendor/bundle'`, and stop using this flag
The dependency tzinfo-data (>= 0) will be unused by any of the platforms Bundler is installing for. Bundler is installing for ruby but the dependency is only for x86-mingw32, x86-mswin32, x64-mingw32, java. To add those platforms to the bundle, run `bundle lock --add-platform x86-mingw32 x86-mswin32 x64-mingw32 java`.
Fetching gem metadata from https://rubygems.org/.........
activesupport-6.0.3.1 requires ruby version >= 2.5.0, which is incompatible with the current version, ruby 2.4.4p296
Makefile:14: recipe for target 'vendor/bundle' failed
make: *** [vendor/bundle] Error 5

# After applied this PR and update ruby-2.5.0 (bundler-2.1.2), it works well.
$ ruby --version
ruby 2.5.0p0 (2017-12-25 revision 61468) [x86_64-linux]

$ make serve
bundle config set --local path 'vendor/bundle'
bundle install
The dependency tzinfo-data (>= 0) will be unused by any of the platforms Bundler is installing for. Bundler is installing for ruby but the dependency is only for x86-mingw32, x86-mswin32, x64-mingw32, java. To add those platforms to the bundle, run `bundle lock --add-platform x86-mingw32 x86-mswin32 x64-mingw32 java`.
Fetching gem metadata from https://rubygems.org/.........
...
 Auto-regeneration: enabled for '/home/mkontani/git/github/oauth2-proxy/docs'
    Server address: http://127.0.0.1:4000/oauth2-proxy/
  Server running... press ctrl-c to stop.
```

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
