### PR TITLE
Use double dashes in service example

### DIFF
--- a/contrib/oauth2-proxy.service.example
+++ b/contrib/oauth2-proxy.service.example
@@ -12,7 +12,7 @@ After=syslog.target network.target
 User=www-data
 Group=www-data
 
-ExecStart=/usr/local/bin/oauth2-proxy -config=/etc/oauth2-proxy.cfg
+ExecStart=/usr/local/bin/oauth2-proxy --config=/etc/oauth2-proxy.cfg
 ExecReload=/bin/kill -HUP $MAINPID
 
 KillMode=process


### PR DESCRIPTION
## Description

The service example still uses `-config`instead of `--config`, which leads the service to not start. This single character change fixes it.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It is reflecting the changes made in https://github.com/oauth2-proxy/oauth2-proxy/pull/484 and https://github.com/oauth2-proxy/oauth2-proxy/pull/530.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
