### PR TITLE
Switch `--skip-auth-strip-headers` to true by default for security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Changes since v6.0.0
 
+- [#624](https://github.com/oauth2-proxy/oauth2-proxy/pull/624) Allow stripping authentication headers from whitelisted requests with `--skip-auth-strip-headers` (@NickMeves)
 - [#675](https://github.com/oauth2-proxy/oauth2-proxy/pull/675) Fix required ruby version and deprecated option for building docs (@mkontani)
 - [#669](https://github.com/oauth2-proxy/oauth2-proxy/pull/669) Reduce docker context to improve build times (@JoelSpeed)
 - [#668](https://github.com/oauth2-proxy/oauth2-proxy/pull/668) Use req.Host in --force-https when req.URL.Host is empty (@zucaritask)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,14 @@
 
 ## Breaking Changes
 
+- [#679](https://github.com/oauth2-proxy/oauth2-proxy/pull/679) Authentication headers will be stripped by default in whitelisted requests (@NickMeves)
+  - `--skip-auth-strip-headers` flag is now `true` by default. Can be set to `false` to preserve legacy behavior.
+  - `--pass-basic-auth` will now only control setting the `Authorization` header with basic auth. It no longer controls the `X-Forwarded-*` user headers (already configured with `--pass-user-headers`)
+  - `--pass-basic-auth` now is `false` by default to match related settings defaults.
+
 ## Changes since v6.0.0
 
+- [#679](https://github.com/oauth2-proxy/oauth2-proxy/pull/679) Authentication headers will be stripped by default in whitelisted requests (@NickMeves)
 - [#624](https://github.com/oauth2-proxy/oauth2-proxy/pull/624) Allow stripping authentication headers from whitelisted requests with `--skip-auth-strip-headers` (@NickMeves)
 - [#675](https://github.com/oauth2-proxy/oauth2-proxy/pull/675) Fix required ruby version and deprecated option for building docs (@mkontani)
 - [#669](https://github.com/oauth2-proxy/oauth2-proxy/pull/669) Reduce docker context to improve build times (@JoelSpeed)

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -115,7 +115,7 @@ An example [oauth2-proxy.cfg]({{ site.gitweb }}/contrib/oauth2-proxy.cfg.example
 | `--silence-ping-logging` | bool | disable logging of requests to ping endpoint | false |
 | `--skip-auth-preflight` | bool | will skip authentication for OPTIONS requests | false |
 | `--skip-auth-regex` | string | bypass authentication for requests paths that match (may be given multiple times) | |
-| `--skip-auth-strip-headers` | bool | strips `X-Forwarded-*` style authentication headers for request paths in --skip-auth-regex | false |
+| `--skip-auth-strip-headers` | bool | strips `X-Forwarded-*` style authentication headers & `Authorization` header if they would be set by oauth2-proxy for request paths in `--skip-auth-regex` | false |
 | `--skip-jwt-bearer-tokens` | bool | will skip requests that have verified JWT bearer tokens | false |
 | `--skip-oidc-discovery` | bool | bypass OIDC endpoint discovery. `--login-url`, `--redeem-url` and `--oidc-jwks-url` must be configured in this case | false |
 | `--skip-provider-button` | bool | will skip sign-in-page to directly reach the next step: oauth/start | false |

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -79,7 +79,7 @@ An example [oauth2-proxy.cfg]({{ site.gitweb }}/contrib/oauth2-proxy.cfg.example
 | `--oidc-jwks-url` | string | OIDC JWKS URI for token verification; required if OIDC discovery is disabled | |
 | `--pass-access-token` | bool | pass OAuth access_token to upstream via X-Forwarded-Access-Token header | false |
 | `--pass-authorization-header` | bool | pass OIDC IDToken to upstream via Authorization Bearer header | false |
-| `--pass-basic-auth` | bool | pass HTTP Basic Auth, X-Forwarded-User, X-Forwarded-Email and X-Forwarded-Preferred-Username information to upstream | true |
+| `--pass-basic-auth` | bool | pass HTTP Basic Auth built from Username & password from `--basic-auth-password` to upstream | false |
 | `--prefer-email-to-user` | bool | Prefer to use the Email address as the Username when passing information to upstream. Will only use Username if Email is unavailable, eg. htaccess authentication. Used in conjunction with `--pass-basic-auth` and `--pass-user-headers` | false |
 | `--pass-host-header` | bool | pass the request Host Header to upstream | true |
 | `--pass-user-headers` | bool | pass X-Forwarded-User, X-Forwarded-Email and X-Forwarded-Preferred-Username information to upstream | true |
@@ -115,7 +115,7 @@ An example [oauth2-proxy.cfg]({{ site.gitweb }}/contrib/oauth2-proxy.cfg.example
 | `--silence-ping-logging` | bool | disable logging of requests to ping endpoint | false |
 | `--skip-auth-preflight` | bool | will skip authentication for OPTIONS requests | false |
 | `--skip-auth-regex` | string | bypass authentication for requests paths that match (may be given multiple times) | |
-| `--skip-auth-strip-headers` | bool | strips `X-Forwarded-*` style authentication headers & `Authorization` header if they would be set by oauth2-proxy for request paths in `--skip-auth-regex` | false |
+| `--skip-auth-strip-headers` | bool | strips `X-Forwarded-*` style authentication headers & `Authorization` header if they would be set by oauth2-proxy for request paths in `--skip-auth-regex` | true |
 | `--skip-jwt-bearer-tokens` | bool | will skip requests that have verified JWT bearer tokens | false |
 | `--skip-oidc-discovery` | bool | bypass OIDC endpoint discovery. `--login-url`, `--redeem-url` and `--oidc-jwks-url` must be configured in this case | false |
 | `--skip-provider-button` | bool | will skip sign-in-page to directly reach the next step: oauth/start | false |

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -115,6 +115,7 @@ An example [oauth2-proxy.cfg]({{ site.gitweb }}/contrib/oauth2-proxy.cfg.example
 | `--silence-ping-logging` | bool | disable logging of requests to ping endpoint | false |
 | `--skip-auth-preflight` | bool | will skip authentication for OPTIONS requests | false |
 | `--skip-auth-regex` | string | bypass authentication for requests paths that match (may be given multiple times) | |
+| `--skip-auth-strip-headers` | bool | strips `X-Forwarded-*` style authentication headers for request paths in --skip-auth-regex | false |
 | `--skip-jwt-bearer-tokens` | bool | will skip requests that have verified JWT bearer tokens | false |
 | `--skip-oidc-discovery` | bool | bypass OIDC endpoint discovery. `--login-url`, `--redeem-url` and `--oidc-jwks-url` must be configured in this case | false |
 | `--skip-provider-button` | bool | will skip sign-in-page to directly reach the next step: oauth/start | false |

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -893,6 +893,7 @@ func (p *OAuthProxy) AuthenticateOnly(rw http.ResponseWriter, req *http.Request)
 	rw.WriteHeader(http.StatusAccepted)
 }
 
+// SkipAuthProxy proxies whitelisted requests and skips authentication
 func (p *OAuthProxy) SkipAuthProxy(rw http.ResponseWriter, req *http.Request) {
 	if p.skipAuthStripHeaders {
 		p.stripAuthHeaders(req)
@@ -1133,6 +1134,13 @@ func (p *OAuthProxy) addHeadersForProxying(rw http.ResponseWriter, req *http.Req
 
 // stripAuthHeaders removes Auth headers for whitelisted routes from skipAuthRegex
 func (p *OAuthProxy) stripAuthHeaders(req *http.Request) {
+	if p.PassBasicAuth {
+		req.Header.Del("X-Forwarded-User")
+		req.Header.Del("X-Forwarded-Email")
+		req.Header.Del("X-Forwarded-Preferred-Username")
+		req.Header.Del("Authorization")
+	}
+
 	if p.PassUserHeaders {
 		req.Header.Del("X-Forwarded-User")
 		req.Header.Del("X-Forwarded-Email")
@@ -1141,6 +1149,10 @@ func (p *OAuthProxy) stripAuthHeaders(req *http.Request) {
 
 	if p.PassAccessToken {
 		req.Header.Del("X-Forwarded-Access-Token")
+	}
+
+	if p.PassAuthorization {
+		req.Header.Del("Authorization")
 	}
 }
 

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -111,6 +111,7 @@ type OAuthProxy struct {
 	PreferEmailToUser       bool
 	skipAuthRegex           []string
 	skipAuthPreflight       bool
+	skipAuthStripHeaders    bool
 	skipJwtBearerTokens     bool
 	mainJwtBearerVerifier   *oidc.IDTokenVerifier
 	extraJwtBearerVerifiers []*oidc.IDTokenVerifier
@@ -343,6 +344,7 @@ func NewOAuthProxy(opts *options.Options, validator func(string) bool) (*OAuthPr
 		whitelistDomains:        opts.WhitelistDomains,
 		skipAuthRegex:           opts.SkipAuthRegex,
 		skipAuthPreflight:       opts.SkipAuthPreflight,
+		skipAuthStripHeaders:    opts.SkipAuthStripHeaders,
 		skipJwtBearerTokens:     opts.SkipJwtBearerTokens,
 		mainJwtBearerVerifier:   opts.GetOIDCVerifier(),
 		extraJwtBearerVerifiers: opts.GetJWTBearerVerifiers(),
@@ -718,7 +720,7 @@ func (p *OAuthProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	case path == p.RobotsPath:
 		p.RobotsTxt(rw)
 	case p.IsWhitelistedRequest(req):
-		p.serveMux.ServeHTTP(rw, req)
+		p.SkipAuthProxy(rw, req)
 	case path == p.SignInPath:
 		p.SignIn(rw, req)
 	case path == p.SignOutPath:
@@ -889,6 +891,13 @@ func (p *OAuthProxy) AuthenticateOnly(rw http.ResponseWriter, req *http.Request)
 	// we are authenticated
 	p.addHeadersForProxying(rw, req, session)
 	rw.WriteHeader(http.StatusAccepted)
+}
+
+func (p *OAuthProxy) SkipAuthProxy(rw http.ResponseWriter, req *http.Request) {
+	if p.skipAuthStripHeaders {
+		p.stripAuthHeaders(req)
+	}
+	p.serveMux.ServeHTTP(rw, req)
 }
 
 // Proxy proxies the user request if the user is authenticated else it prompts
@@ -1119,6 +1128,19 @@ func (p *OAuthProxy) addHeadersForProxying(rw http.ResponseWriter, req *http.Req
 		rw.Header().Set("GAP-Auth", session.User)
 	} else {
 		rw.Header().Set("GAP-Auth", session.Email)
+	}
+}
+
+// stripAuthHeaders removes Auth headers for whitelisted routes from skipAuthRegex
+func (p *OAuthProxy) stripAuthHeaders(req *http.Request) {
+	if p.PassUserHeaders {
+		req.Header.Del("X-Forwarded-User")
+		req.Header.Del("X-Forwarded-Email")
+		req.Header.Del("X-Forwarded-Preferred-Username")
+	}
+
+	if p.PassAccessToken {
+		req.Header.Del("X-Forwarded-Access-Token")
 	}
 }
 

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -1030,21 +1030,8 @@ func (p *OAuthProxy) addHeadersForProxying(rw http.ResponseWriter, req *http.Req
 	if p.PassBasicAuth {
 		if p.PreferEmailToUser && session.Email != "" {
 			req.SetBasicAuth(session.Email, p.BasicAuthPassword)
-			req.Header["X-Forwarded-User"] = []string{session.Email}
-			req.Header.Del("X-Forwarded-Email")
 		} else {
 			req.SetBasicAuth(session.User, p.BasicAuthPassword)
-			req.Header["X-Forwarded-User"] = []string{session.User}
-			if session.Email != "" {
-				req.Header["X-Forwarded-Email"] = []string{session.Email}
-			} else {
-				req.Header.Del("X-Forwarded-Email")
-			}
-		}
-		if session.PreferredUsername != "" {
-			req.Header["X-Forwarded-Preferred-Username"] = []string{session.PreferredUsername}
-		} else {
-			req.Header.Del("X-Forwarded-Preferred-Username")
 		}
 	}
 
@@ -1134,13 +1121,6 @@ func (p *OAuthProxy) addHeadersForProxying(rw http.ResponseWriter, req *http.Req
 
 // stripAuthHeaders removes Auth headers for whitelisted routes from skipAuthRegex
 func (p *OAuthProxy) stripAuthHeaders(req *http.Request) {
-	if p.PassBasicAuth {
-		req.Header.Del("X-Forwarded-User")
-		req.Header.Del("X-Forwarded-Email")
-		req.Header.Del("X-Forwarded-Preferred-Username")
-		req.Header.Del("Authorization")
-	}
-
 	if p.PassUserHeaders {
 		req.Header.Del("X-Forwarded-User")
 		req.Header.Del("X-Forwarded-Email")
@@ -1151,7 +1131,7 @@ func (p *OAuthProxy) stripAuthHeaders(req *http.Request) {
 		req.Header.Del("X-Forwarded-Access-Token")
 	}
 
-	if p.PassAuthorization {
+	if p.PassBasicAuth || p.PassAuthorization {
 		req.Header.Del("Authorization")
 	}
 }

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -643,8 +643,7 @@ func TestBasicAuthWithEmail(t *testing.T) {
 		})
 		assert.NoError(t, err)
 		proxy.addHeadersForProxying(rw, req, session)
-		assert.Equal(t, expectedUserHeader, req.Header["Authorization"][0])
-		assert.Equal(t, userName, req.Header["X-Forwarded-User"][0])
+		assert.Equal(t, expectedUserHeader, req.Header.Get("Authorization"))
 	}
 
 	opts.PreferEmailToUser = true
@@ -657,8 +656,7 @@ func TestBasicAuthWithEmail(t *testing.T) {
 		})
 		assert.NoError(t, err)
 		proxy.addHeadersForProxying(rw, req, session)
-		assert.Equal(t, expectedEmailHeader, req.Header["Authorization"][0])
-		assert.Equal(t, emailAddress, req.Header["X-Forwarded-User"][0])
+		assert.Equal(t, expectedEmailHeader, req.Header.Get("Authorization"))
 	}
 }
 
@@ -688,7 +686,7 @@ func TestPassUserHeadersWithEmail(t *testing.T) {
 		})
 		assert.NoError(t, err)
 		proxy.addHeadersForProxying(rw, req, session)
-		assert.Equal(t, userName, req.Header["X-Forwarded-User"][0])
+		assert.Equal(t, userName, req.Header.Get("X-Forwarded-User"))
 	}
 
 	opts.PreferEmailToUser = true
@@ -701,7 +699,7 @@ func TestPassUserHeadersWithEmail(t *testing.T) {
 		})
 		assert.NoError(t, err)
 		proxy.addHeadersForProxying(rw, req, session)
-		assert.Equal(t, emailAddress, req.Header["X-Forwarded-User"][0])
+		assert.Equal(t, emailAddress, req.Header.Get("X-Forwarded-User"))
 	}
 }
 
@@ -716,7 +714,7 @@ func TestStripAuthHeaders(t *testing.T) {
 	}{
 		"Default options": {
 			SkipAuthStripHeaders: true,
-			PassBasicAuth:        true,
+			PassBasicAuth:        false,
 			PassUserHeaders:      true,
 			PassAccessToken:      false,
 			PassAuthorization:    false,
@@ -725,24 +723,10 @@ func TestStripAuthHeaders(t *testing.T) {
 				"X-Forwarded-Email":              true,
 				"X-Forwarded-Preferred-Username": true,
 				"X-Forwarded-Access-Token":       false,
-				"Authorization":                  true,
+				"Authorization":                  false,
 			},
 		},
 		"Pass access token": {
-			SkipAuthStripHeaders: true,
-			PassBasicAuth:        true,
-			PassUserHeaders:      true,
-			PassAccessToken:      true,
-			PassAuthorization:    false,
-			StrippedHeaders: map[string]bool{
-				"X-Forwarded-User":               true,
-				"X-Forwarded-Email":              true,
-				"X-Forwarded-Preferred-Username": true,
-				"X-Forwarded-Access-Token":       true,
-				"Authorization":                  true,
-			},
-		},
-		"Nothing setting Authorization": {
 			SkipAuthStripHeaders: true,
 			PassBasicAuth:        false,
 			PassUserHeaders:      true,
@@ -754,6 +738,20 @@ func TestStripAuthHeaders(t *testing.T) {
 				"X-Forwarded-Preferred-Username": true,
 				"X-Forwarded-Access-Token":       true,
 				"Authorization":                  false,
+			},
+		},
+		"Pass basic auth": {
+			SkipAuthStripHeaders: true,
+			PassBasicAuth:        true,
+			PassUserHeaders:      true,
+			PassAccessToken:      true,
+			PassAuthorization:    false,
+			StrippedHeaders: map[string]bool{
+				"X-Forwarded-User":               true,
+				"X-Forwarded-Email":              true,
+				"X-Forwarded-Preferred-Username": true,
+				"X-Forwarded-Access-Token":       true,
+				"Authorization":                  true,
 			},
 		},
 		"Only Authorization header modified": {

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -703,6 +703,45 @@ func TestPassUserHeadersWithEmail(t *testing.T) {
 		proxy.addHeadersForProxying(rw, req, session)
 		assert.Equal(t, emailAddress, req.Header["X-Forwarded-User"][0])
 	}
+
+	// If stripping is disabled (default), headers set by client persist to backend
+	{
+		req, _ := http.NewRequest("GET", opts.ProxyPrefix+"/testCase3", nil)
+		req.Header.Set("X-Forwarded-User", userName)
+		req.Header.Set("X-Forwarded-Email", emailAddress)
+		req.Header.Set("X-Forwarded-Preferred-Username", userName)
+
+		proxy, err := NewOAuthProxy(opts, func(email string) bool {
+			return email == emailAddress
+		})
+		assert.NoError(t, err)
+		if proxy.skipAuthStripHeaders {
+			proxy.stripAuthHeaders(req)
+		}
+		assert.Equal(t, userName, req.Header.Get("X-Forwarded-User"))
+		assert.Equal(t, emailAddress, req.Header.Get("X-Forwarded-Email"))
+		assert.Equal(t, userName, req.Header.Get("X-Forwarded-Preferred-Username"))
+	}
+
+	// If stripping is enabled, headers set by client persist to backend
+	opts.SkipAuthStripHeaders = true
+	{
+		req, _ := http.NewRequest("GET", opts.ProxyPrefix+"/testCase2", nil)
+		req.Header.Set("X-Forwarded-User", userName)
+		req.Header.Set("X-Forwarded-Email", emailAddress)
+		req.Header.Set("X-Forwarded-Preferred-Username", userName)
+
+		proxy, err := NewOAuthProxy(opts, func(email string) bool {
+			return email == emailAddress
+		})
+		assert.NoError(t, err)
+		if proxy.skipAuthStripHeaders {
+			proxy.stripAuthHeaders(req)
+		}
+		assert.Equal(t, "", req.Header.Get("X-Forwarded-User"))
+		assert.Equal(t, "", req.Header.Get("X-Forwarded-Email"))
+		assert.Equal(t, "", req.Header.Get("X-Forwarded-Preferred-Username"))
+	}
 }
 
 type PassAccessTokenTest struct {

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -706,17 +706,15 @@ func TestPassUserHeadersWithEmail(t *testing.T) {
 }
 
 func TestStripAuthHeaders(t *testing.T) {
-	type testCase struct {
+	testCases := map[string]struct {
 		SkipAuthStripHeaders bool
 		PassBasicAuth        bool
 		PassUserHeaders      bool
 		PassAccessToken      bool
 		PassAuthorization    bool
 		StrippedHeaders      map[string]bool
-	}
-
-	testCases := []testCase{
-		{
+	}{
+		"Default options": {
 			SkipAuthStripHeaders: true,
 			PassBasicAuth:        true,
 			PassUserHeaders:      true,
@@ -730,7 +728,7 @@ func TestStripAuthHeaders(t *testing.T) {
 				"Authorization":                  true,
 			},
 		},
-		{
+		"Pass access token": {
 			SkipAuthStripHeaders: true,
 			PassBasicAuth:        true,
 			PassUserHeaders:      true,
@@ -744,7 +742,7 @@ func TestStripAuthHeaders(t *testing.T) {
 				"Authorization":                  true,
 			},
 		},
-		{
+		"Nothing setting Authorization": {
 			SkipAuthStripHeaders: true,
 			PassBasicAuth:        false,
 			PassUserHeaders:      true,
@@ -758,7 +756,7 @@ func TestStripAuthHeaders(t *testing.T) {
 				"Authorization":                  false,
 			},
 		},
-		{
+		"Only Authorization header modified": {
 			SkipAuthStripHeaders: true,
 			PassBasicAuth:        false,
 			PassUserHeaders:      false,
@@ -772,7 +770,7 @@ func TestStripAuthHeaders(t *testing.T) {
 				"Authorization":                  true,
 			},
 		},
-		{
+		"Don't strip any headers (default options)": {
 			SkipAuthStripHeaders: false,
 			PassBasicAuth:        true,
 			PassUserHeaders:      true,
@@ -786,7 +784,7 @@ func TestStripAuthHeaders(t *testing.T) {
 				"Authorization":                  false,
 			},
 		},
-		{
+		"Don't strip any headers (custom options)": {
 			SkipAuthStripHeaders: false,
 			PassBasicAuth:        true,
 			PassUserHeaders:      true,
@@ -810,34 +808,36 @@ func TestStripAuthHeaders(t *testing.T) {
 		"Authorization":                  "bearer IDToken",
 	}
 
-	for i, tc := range testCases {
-		opts := baseTestOptions()
-		opts.SkipAuthStripHeaders = tc.SkipAuthStripHeaders
-		opts.PassBasicAuth = tc.PassBasicAuth
-		opts.PassUserHeaders = tc.PassUserHeaders
-		opts.PassAccessToken = tc.PassAccessToken
-		opts.PassAuthorization = tc.PassAuthorization
-		err := validation.Validate(opts)
-		assert.NoError(t, err)
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			opts := baseTestOptions()
+			opts.SkipAuthStripHeaders = tc.SkipAuthStripHeaders
+			opts.PassBasicAuth = tc.PassBasicAuth
+			opts.PassUserHeaders = tc.PassUserHeaders
+			opts.PassAccessToken = tc.PassAccessToken
+			opts.PassAuthorization = tc.PassAuthorization
+			err := validation.Validate(opts)
+			assert.NoError(t, err)
 
-		req, _ := http.NewRequest("GET", fmt.Sprintf("%s/testCase/%d", opts.ProxyPrefix, i), nil)
-		for header, val := range initialHeaders {
-			req.Header.Set(header, val)
-		}
-
-		proxy, err := NewOAuthProxy(opts, func(_ string) bool { return true })
-		assert.NoError(t, err)
-		if proxy.skipAuthStripHeaders {
-			proxy.stripAuthHeaders(req)
-		}
-
-		for header, stripped := range tc.StrippedHeaders {
-			if stripped {
-				assert.Equal(t, req.Header.Get(header), "")
-			} else {
-				assert.Equal(t, req.Header.Get(header), initialHeaders[header])
+			req, _ := http.NewRequest("GET", fmt.Sprintf("%s/testCase", opts.ProxyPrefix), nil)
+			for header, val := range initialHeaders {
+				req.Header.Set(header, val)
 			}
-		}
+
+			proxy, err := NewOAuthProxy(opts, func(_ string) bool { return true })
+			assert.NoError(t, err)
+			if proxy.skipAuthStripHeaders {
+				proxy.stripAuthHeaders(req)
+			}
+
+			for header, stripped := range tc.StrippedHeaders {
+				if stripped {
+					assert.Equal(t, req.Header.Get(header), "")
+				} else {
+					assert.Equal(t, req.Header.Get(header), initialHeaders[header])
+				}
+			}
+		})
 	}
 }
 

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -703,44 +703,141 @@ func TestPassUserHeadersWithEmail(t *testing.T) {
 		proxy.addHeadersForProxying(rw, req, session)
 		assert.Equal(t, emailAddress, req.Header["X-Forwarded-User"][0])
 	}
+}
 
-	// If stripping is disabled (default), headers set by client persist to backend
-	{
-		req, _ := http.NewRequest("GET", opts.ProxyPrefix+"/testCase3", nil)
-		req.Header.Set("X-Forwarded-User", userName)
-		req.Header.Set("X-Forwarded-Email", emailAddress)
-		req.Header.Set("X-Forwarded-Preferred-Username", userName)
-
-		proxy, err := NewOAuthProxy(opts, func(email string) bool {
-			return email == emailAddress
-		})
-		assert.NoError(t, err)
-		if proxy.skipAuthStripHeaders {
-			proxy.stripAuthHeaders(req)
-		}
-		assert.Equal(t, userName, req.Header.Get("X-Forwarded-User"))
-		assert.Equal(t, emailAddress, req.Header.Get("X-Forwarded-Email"))
-		assert.Equal(t, userName, req.Header.Get("X-Forwarded-Preferred-Username"))
+func TestStripAuthHeaders(t *testing.T) {
+	type testCase struct {
+		SkipAuthStripHeaders bool
+		PassBasicAuth        bool
+		PassUserHeaders      bool
+		PassAccessToken      bool
+		PassAuthorization    bool
+		StrippedHeaders      map[string]bool
 	}
 
-	// If stripping is enabled, headers set by client persist to backend
-	opts.SkipAuthStripHeaders = true
-	{
-		req, _ := http.NewRequest("GET", opts.ProxyPrefix+"/testCase2", nil)
-		req.Header.Set("X-Forwarded-User", userName)
-		req.Header.Set("X-Forwarded-Email", emailAddress)
-		req.Header.Set("X-Forwarded-Preferred-Username", userName)
+	testCases := []testCase{
+		{
+			SkipAuthStripHeaders: true,
+			PassBasicAuth:        true,
+			PassUserHeaders:      true,
+			PassAccessToken:      false,
+			PassAuthorization:    false,
+			StrippedHeaders: map[string]bool{
+				"X-Forwarded-User":               true,
+				"X-Forwarded-Email":              true,
+				"X-Forwarded-Preferred-Username": true,
+				"X-Forwarded-Access-Token":       false,
+				"Authorization":                  true,
+			},
+		},
+		{
+			SkipAuthStripHeaders: true,
+			PassBasicAuth:        true,
+			PassUserHeaders:      true,
+			PassAccessToken:      true,
+			PassAuthorization:    false,
+			StrippedHeaders: map[string]bool{
+				"X-Forwarded-User":               true,
+				"X-Forwarded-Email":              true,
+				"X-Forwarded-Preferred-Username": true,
+				"X-Forwarded-Access-Token":       true,
+				"Authorization":                  true,
+			},
+		},
+		{
+			SkipAuthStripHeaders: true,
+			PassBasicAuth:        false,
+			PassUserHeaders:      true,
+			PassAccessToken:      true,
+			PassAuthorization:    false,
+			StrippedHeaders: map[string]bool{
+				"X-Forwarded-User":               true,
+				"X-Forwarded-Email":              true,
+				"X-Forwarded-Preferred-Username": true,
+				"X-Forwarded-Access-Token":       true,
+				"Authorization":                  false,
+			},
+		},
+		{
+			SkipAuthStripHeaders: true,
+			PassBasicAuth:        false,
+			PassUserHeaders:      false,
+			PassAccessToken:      false,
+			PassAuthorization:    true,
+			StrippedHeaders: map[string]bool{
+				"X-Forwarded-User":               false,
+				"X-Forwarded-Email":              false,
+				"X-Forwarded-Preferred-Username": false,
+				"X-Forwarded-Access-Token":       false,
+				"Authorization":                  true,
+			},
+		},
+		{
+			SkipAuthStripHeaders: false,
+			PassBasicAuth:        true,
+			PassUserHeaders:      true,
+			PassAccessToken:      false,
+			PassAuthorization:    false,
+			StrippedHeaders: map[string]bool{
+				"X-Forwarded-User":               false,
+				"X-Forwarded-Email":              false,
+				"X-Forwarded-Preferred-Username": false,
+				"X-Forwarded-Access-Token":       false,
+				"Authorization":                  false,
+			},
+		},
+		{
+			SkipAuthStripHeaders: false,
+			PassBasicAuth:        true,
+			PassUserHeaders:      true,
+			PassAccessToken:      true,
+			PassAuthorization:    false,
+			StrippedHeaders: map[string]bool{
+				"X-Forwarded-User":               false,
+				"X-Forwarded-Email":              false,
+				"X-Forwarded-Preferred-Username": false,
+				"X-Forwarded-Access-Token":       false,
+				"Authorization":                  false,
+			},
+		},
+	}
 
-		proxy, err := NewOAuthProxy(opts, func(email string) bool {
-			return email == emailAddress
-		})
+	initialHeaders := map[string]string{
+		"X-Forwarded-User":               "9fcab5c9b889a557",
+		"X-Forwarded-Email":              "john.doe@example.com",
+		"X-Forwarded-Preferred-Username": "john.doe",
+		"X-Forwarded-Access-Token":       "AccessToken",
+		"Authorization":                  "bearer IDToken",
+	}
+
+	for i, tc := range testCases {
+		opts := baseTestOptions()
+		opts.SkipAuthStripHeaders = tc.SkipAuthStripHeaders
+		opts.PassBasicAuth = tc.PassBasicAuth
+		opts.PassUserHeaders = tc.PassUserHeaders
+		opts.PassAccessToken = tc.PassAccessToken
+		opts.PassAuthorization = tc.PassAuthorization
+		err := validation.Validate(opts)
+		assert.NoError(t, err)
+
+		req, _ := http.NewRequest("GET", fmt.Sprintf("%s/testCase/%d", opts.ProxyPrefix, i), nil)
+		for header, val := range initialHeaders {
+			req.Header.Set(header, val)
+		}
+
+		proxy, err := NewOAuthProxy(opts, func(_ string) bool { return true })
 		assert.NoError(t, err)
 		if proxy.skipAuthStripHeaders {
 			proxy.stripAuthHeaders(req)
 		}
-		assert.Equal(t, "", req.Header.Get("X-Forwarded-User"))
-		assert.Equal(t, "", req.Header.Get("X-Forwarded-Email"))
-		assert.Equal(t, "", req.Header.Get("X-Forwarded-Preferred-Username"))
+
+		for header, stripped := range tc.StrippedHeaders {
+			if stripped {
+				assert.Equal(t, req.Header.Get(header), "")
+			} else {
+				assert.Equal(t, req.Header.Get(header), initialHeaders[header])
+			}
+		}
 	}
 }
 

--- a/pkg/apis/options/options.go
+++ b/pkg/apis/options/options.go
@@ -206,7 +206,7 @@ func NewFlagSet() *pflag.FlagSet {
 	flagSet.Bool("pass-authorization-header", false, "pass the Authorization Header to upstream")
 	flagSet.Bool("set-authorization-header", false, "set Authorization response headers (useful in Nginx auth_request mode)")
 	flagSet.StringSlice("skip-auth-regex", []string{}, "bypass authentication for requests path's that match (may be given multiple times)")
-	flagSet.Bool("skip-auth-strip-headers", false, "strips X-Forwarded-* style authentication headers for request paths in --skip-auth-regex")
+	flagSet.Bool("skip-auth-strip-headers", false, "strips X-Forwarded-* style authentication headers & Authorization header if they would be set by oauth2-proxy for request paths in --skip-auth-regex")
 	flagSet.Bool("skip-provider-button", false, "will skip sign-in-page to directly reach the next step: oauth/start")
 	flagSet.Bool("skip-auth-preflight", false, "will skip authentication for OPTIONS requests")
 	flagSet.Bool("ssl-insecure-skip-verify", false, "skip validation of certificates presented when using HTTPS providers")

--- a/pkg/apis/options/options.go
+++ b/pkg/apis/options/options.go
@@ -162,9 +162,9 @@ func NewOptions() *Options {
 		AzureTenant:                      "common",
 		SetXAuthRequest:                  false,
 		SkipAuthPreflight:                false,
-		SkipAuthStripHeaders:             false,
+		SkipAuthStripHeaders:             true,
 		FlushInterval:                    time.Duration(1) * time.Second,
-		PassBasicAuth:                    true,
+		PassBasicAuth:                    false,
 		SetBasicAuth:                     false,
 		PassUserHeaders:                  true,
 		PassAccessToken:                  false,
@@ -196,7 +196,7 @@ func NewFlagSet() *pflag.FlagSet {
 	flagSet.String("redirect-url", "", "the OAuth Redirect URL. ie: \"https://internalapp.yourcompany.com/oauth2/callback\"")
 	flagSet.Bool("set-xauthrequest", false, "set X-Auth-Request-User and X-Auth-Request-Email response headers (useful in Nginx auth_request mode)")
 	flagSet.StringSlice("upstream", []string{}, "the http url(s) of the upstream endpoint, file:// paths for static files or static://<status_code> for static response. Routing is based on the path")
-	flagSet.Bool("pass-basic-auth", true, "pass HTTP Basic Auth, X-Forwarded-User and X-Forwarded-Email information to upstream")
+	flagSet.Bool("pass-basic-auth", false, "pass HTTP Basic Auth built from Username & --basic-auth-password to upstream")
 	flagSet.Bool("set-basic-auth", false, "set HTTP Basic Auth information in response (useful in Nginx auth_request mode)")
 	flagSet.Bool("prefer-email-to-user", false, "Prefer to use the Email address as the Username when passing information to upstream. Will only use Username if Email is unavailable, eg. htaccess authentication. Used in conjunction with -pass-basic-auth and -pass-user-headers")
 	flagSet.Bool("pass-user-headers", true, "pass X-Forwarded-User and X-Forwarded-Email information to upstream")
@@ -206,7 +206,7 @@ func NewFlagSet() *pflag.FlagSet {
 	flagSet.Bool("pass-authorization-header", false, "pass the Authorization Header to upstream")
 	flagSet.Bool("set-authorization-header", false, "set Authorization response headers (useful in Nginx auth_request mode)")
 	flagSet.StringSlice("skip-auth-regex", []string{}, "bypass authentication for requests path's that match (may be given multiple times)")
-	flagSet.Bool("skip-auth-strip-headers", false, "strips X-Forwarded-* style authentication headers & Authorization header if they would be set by oauth2-proxy for request paths in --skip-auth-regex")
+	flagSet.Bool("skip-auth-strip-headers", true, "strips X-Forwarded-* style authentication headers & Authorization header if they would be set by oauth2-proxy for request paths in --skip-auth-regex")
 	flagSet.Bool("skip-provider-button", false, "will skip sign-in-page to directly reach the next step: oauth/start")
 	flagSet.Bool("skip-auth-preflight", false, "will skip authentication for OPTIONS requests")
 	flagSet.Bool("ssl-insecure-skip-verify", false, "skip validation of certificates presented when using HTTPS providers")

--- a/pkg/apis/options/options.go
+++ b/pkg/apis/options/options.go
@@ -66,6 +66,7 @@ type Options struct {
 
 	Upstreams                     []string      `flag:"upstream" cfg:"upstreams"`
 	SkipAuthRegex                 []string      `flag:"skip-auth-regex" cfg:"skip_auth_regex"`
+	SkipAuthStripHeaders          bool          `flag:"skip-auth-strip-headers" cfg:"skip_auth_strip_headers"`
 	SkipJwtBearerTokens           bool          `flag:"skip-jwt-bearer-tokens" cfg:"skip_jwt_bearer_tokens"`
 	ExtraJwtIssuers               []string      `flag:"extra-jwt-issuers" cfg:"extra_jwt_issuers"`
 	PassBasicAuth                 bool          `flag:"pass-basic-auth" cfg:"pass_basic_auth"`
@@ -161,6 +162,7 @@ func NewOptions() *Options {
 		AzureTenant:                      "common",
 		SetXAuthRequest:                  false,
 		SkipAuthPreflight:                false,
+		SkipAuthStripHeaders:             false,
 		FlushInterval:                    time.Duration(1) * time.Second,
 		PassBasicAuth:                    true,
 		SetBasicAuth:                     false,
@@ -204,6 +206,7 @@ func NewFlagSet() *pflag.FlagSet {
 	flagSet.Bool("pass-authorization-header", false, "pass the Authorization Header to upstream")
 	flagSet.Bool("set-authorization-header", false, "set Authorization response headers (useful in Nginx auth_request mode)")
 	flagSet.StringSlice("skip-auth-regex", []string{}, "bypass authentication for requests path's that match (may be given multiple times)")
+	flagSet.Bool("skip-auth-strip-headers", false, "strips X-Forwarded-* style authentication headers for request paths in --skip-auth-regex")
 	flagSet.Bool("skip-provider-button", false, "will skip sign-in-page to directly reach the next step: oauth/start")
 	flagSet.Bool("skip-auth-preflight", false, "will skip authentication for OPTIONS requests")
 	flagSet.Bool("ssl-insecure-skip-verify", false, "skip validation of certificates presented when using HTTPS providers")


### PR DESCRIPTION
Flips defaults of new secure configuration options set in #624 to `true` by default

## Description

Removes duplicated scope of user headers controlled by `--pass-basic-auth` and sets default of that to `false`

`--skip-auth-strip-headers` set to `true` for OOTB secure default settings

## Motivation and Context

`--pass-basic-auth` duplicated functionality already in `--pass-user-headers` and its `default` of `true` didn't match related configuration settings.

`--skip-auth-strip-headers` being secure by default prevents spoofing attacks against misconfigurations.

## How Has This Been Tested?

Unit Tests

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
