### PR TITLE
allow option to get full userinfo via X-Auth-Oidc-Info-Token, required by some Oidc providers like Okta

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -78,6 +78,7 @@ An example [oauth2-proxy.cfg]({{ site.gitweb }}/contrib/oauth2-proxy.cfg.example
 | `--oidc-issuer-url` | string | the OpenID Connect issuer URL. ie: `"https://accounts.google.com"` | |
 | `--oidc-jwks-url` | string | OIDC JWKS URI for token verification; required if OIDC discovery is disabled | |
 | `--pass-access-token` | bool | pass OAuth access_token to upstream via X-Forwarded-Access-Token header | false |
+| `--pass-oidc-info-token` | bool | Pass full User info with all requested scopes via X-Auth-Oidc-Info-Token; required for some Oidc providers like Okta that don't pass all scopes in the authorization-header by default (For example, Okta considers scopes like groups reserved which can be accessed by requesting a subsequent POST to profileUrl with the access token)  | false |
 | `--pass-authorization-header` | bool | pass OIDC IDToken to upstream via Authorization Bearer header | false |
 | `--pass-basic-auth` | bool | pass HTTP Basic Auth, X-Forwarded-User, X-Forwarded-Email and X-Forwarded-Preferred-Username information to upstream | true |
 | `--prefer-email-to-user` | bool | Prefer to use the Email address as the Username when passing information to upstream. Will only use Username if Email is unavailable, eg. htaccess authentication. Used in conjunction with `--pass-basic-auth` and `--pass-user-headers` | false |

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -106,6 +106,7 @@ type OAuthProxy struct {
 	PassUserHeaders         bool
 	BasicAuthPassword       string
 	PassAccessToken         bool
+	PassOidcInfoToken       bool
 	SetAuthorization        bool
 	PassAuthorization       bool
 	PreferEmailToUser       bool
@@ -356,6 +357,7 @@ func NewOAuthProxy(opts *options.Options, validator func(string) bool) (*OAuthPr
 		PassUserHeaders:         opts.PassUserHeaders,
 		BasicAuthPassword:       opts.BasicAuthPassword,
 		PassAccessToken:         opts.PassAccessToken,
+		PassOidcInfoToken:       opts.PassOidcInfoToken,
 		SetAuthorization:        opts.SetAuthorization,
 		PassAuthorization:       opts.PassAuthorization,
 		PreferEmailToUser:       opts.PreferEmailToUser,
@@ -1129,6 +1131,13 @@ func (p *OAuthProxy) addHeadersForProxying(rw http.ResponseWriter, req *http.Req
 		rw.Header().Set("GAP-Auth", session.User)
 	} else {
 		rw.Header().Set("GAP-Auth", session.Email)
+	}
+
+	if p.PassOidcInfoToken && session.AccessToken != "" {
+		token, err := p.provider.GetOidcInfoToken(req.Context(), session.AccessToken)
+		if err == nil {
+			rw.Header().Set("X-Auth-Oidc-Info-Token", token)
+		}
 	}
 }
 

--- a/pkg/apis/options/options.go
+++ b/pkg/apis/options/options.go
@@ -74,6 +74,7 @@ type Options struct {
 	PreferEmailToUser             bool          `flag:"prefer-email-to-user" cfg:"prefer_email_to_user"`
 	BasicAuthPassword             string        `flag:"basic-auth-password" cfg:"basic_auth_password"`
 	PassAccessToken               bool          `flag:"pass-access-token" cfg:"pass_access_token"`
+	PassOidcInfoToken             bool          `flag:"pass-oidc-info-token" cfg:"pass_oidc_info_token"`
 	PassHostHeader                bool          `flag:"pass-host-header" cfg:"pass_host_header"`
 	SkipProviderButton            bool          `flag:"skip-provider-button" cfg:"skip_provider_button"`
 	PassUserHeaders               bool          `flag:"pass-user-headers" cfg:"pass_user_headers"`
@@ -200,6 +201,7 @@ func NewFlagSet() *pflag.FlagSet {
 	flagSet.Bool("pass-user-headers", true, "pass X-Forwarded-User and X-Forwarded-Email information to upstream")
 	flagSet.String("basic-auth-password", "", "the password to set when passing the HTTP Basic Auth header")
 	flagSet.Bool("pass-access-token", false, "pass OAuth access_token to upstream via X-Forwarded-Access-Token header")
+	flagSet.Bool("pass-oidc-info-token", false, "Pass full User info with all requested scopes via X-Auth-Oidc-Info-Token, required for some Oidc providers like Okta to get full profile info")
 	flagSet.Bool("pass-host-header", true, "pass the request Host Header to upstream")
 	flagSet.Bool("pass-authorization-header", false, "pass the Authorization Header to upstream")
 	flagSet.Bool("set-authorization-header", false, "set Authorization response headers (useful in Nginx auth_request mode)")

--- a/providers/oidc_test.go
+++ b/providers/oidc_test.go
@@ -167,6 +167,14 @@ func TestOIDCProviderRedeem(t *testing.T) {
 	assert.Equal(t, "123456789", session.User)
 }
 
+func TestOIDCProviderGetOidcInfoToken(t *testing.T) {
+	body, _ := json.Marshal(defaultIDToken)
+	server, provider := newTestSetup(body)
+	defer server.Close()
+	_, err := provider.GetOidcInfoToken(context.Background(), accessToken)
+	assert.Equal(t, nil, err, "Error while Accessing oidc token")
+}
+
 func TestOIDCProviderRedeem_custom_userid(t *testing.T) {
 
 	idToken, _ := newSignedTestIDToken(defaultIDToken)

--- a/providers/provider_default.go
+++ b/providers/provider_default.go
@@ -109,6 +109,10 @@ func (p *ProviderData) GetPreferredUsername(ctx context.Context, s *sessions.Ses
 	return "", errors.New("not implemented")
 }
 
+func (p *ProviderData) GetOidcInfoToken(ctx context.Context, accessToken string) (string, error) {
+	return "", errors.New("not implemented")
+}
+
 // ValidateGroup validates that the provided email exists in the configured provider
 // email group(s).
 func (p *ProviderData) ValidateGroup(email string) bool {

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -19,6 +19,7 @@ type Provider interface {
 	GetLoginURL(redirectURI, finalRedirect string) string
 	RefreshSessionIfNeeded(ctx context.Context, s *sessions.SessionState) (bool, error)
 	CreateSessionStateFromBearerToken(ctx context.Context, rawIDToken string, idToken *oidc.IDToken) (*sessions.SessionState, error)
+	GetOidcInfoToken(ctx context.Context, accessToken string) (string, error)
 }
 
 // New provides a new Provider based on the configured provider string


### PR DESCRIPTION
allow option to get full userinfo via X-Auth-Oidc-Info-Token, required to get reserved scopes in Oidc providers like Okta

Some Oidc providers like Okta do not provide full user info by default that includes all the scopes like groups (More details here: https://support.okta.com/help/s/article/Okta-Groups-or-Attribute-Missing-from-Id-Token). These providers allow you to get these claims by a POST endpoint to the ProfileURL by using the access token returned by the authorization url. This commit extends this capability by adding the Post endpoint and by allowing users to get this information via a custom Header X-Auth-Oidc-Info-Token
