### PR TITLE
Add RulesEngine for Authorization Logic

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -115,8 +115,9 @@ An example [oauth2-proxy.cfg]({{ site.gitweb }}/contrib/oauth2-proxy.cfg.example
 | `--signature-key` | string | GAP-Signature request signature key (algorithm:secretkey) | |
 | `--silence-ping-logging` | bool | disable logging of requests to ping endpoint | false |
 | `--skip-auth-preflight` | bool | will skip authentication for OPTIONS requests | false |
-| `--skip-auth-regex` | string | bypass authentication for requests paths that match (may be given multiple times) | |
-| `--skip-auth-strip-headers` | bool | strips `X-Forwarded-*` style authentication headers & `Authorization` header if they would be set by oauth2-proxy for request paths in `--skip-auth-regex` | false |
+| `--skip-auth-regex` | string \| list | (DEPRECATED for `--skip-auth-route`) bypass authentication for requests paths that match (may be given multiple times) | |
+| `--skip-auth-route` | string \| list | bypass authentication for requests that match the method & path. Format: method=path_regex OR path_regex alone for all methods | |
+| `--skip-auth-strip-headers` | bool | strips `X-Forwarded-*` style authentication headers & `Authorization` header if they would be set by oauth2-proxy for allowlisted requests (`--skip-auth-route`, `--skip-auth-regex`, `--skip-auth-preflight`, `--trusted-ip`) | false |
 | `--skip-jwt-bearer-tokens` | bool | will skip requests that have verified JWT bearer tokens | false |
 | `--skip-oidc-discovery` | bool | bypass OIDC endpoint discovery. `--login-url`, `--redeem-url` and `--oidc-jwks-url` must be configured in this case | false |
 | `--skip-provider-button` | bool | will skip sign-in-page to directly reach the next step: oauth/start | false |

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -189,7 +189,7 @@ func NewOAuthProxy(opts *options.Options, validator func(string) bool) (*OAuthPr
 		PassAccessToken:         opts.PassAccessToken,
 		SetAuthorization:        opts.SetAuthorization,
 		PassAuthorization:       opts.PassAuthorization,
-		SkipAuthStripHeaders:    opts.Authorization.SkipAuthStripHeaders,
+		SkipAuthStripHeaders:    opts.SkipAuthStripHeaders,
 		PreferEmailToUser:       opts.PreferEmailToUser,
 		SkipProviderButton:      opts.SkipProviderButton,
 		templates:               templates,

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -698,7 +698,7 @@ func TestStripAuthHeaders(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			opts := baseTestOptions()
-			opts.Authorization.SkipAuthStripHeaders = tc.SkipAuthStripHeaders
+			opts.SkipAuthStripHeaders = tc.SkipAuthStripHeaders
 			opts.PassBasicAuth = tc.PassBasicAuth
 			opts.PassUserHeaders = tc.PassUserHeaders
 			opts.PassAccessToken = tc.PassAccessToken

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -698,7 +698,7 @@ func TestStripAuthHeaders(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			opts := baseTestOptions()
-			opts.SkipAuthStripHeaders = tc.SkipAuthStripHeaders
+			opts.Authorization.SkipAuthStripHeaders = tc.SkipAuthStripHeaders
 			opts.PassBasicAuth = tc.PassBasicAuth
 			opts.PassUserHeaders = tc.PassUserHeaders
 			opts.PassAccessToken = tc.PassAccessToken
@@ -713,7 +713,7 @@ func TestStripAuthHeaders(t *testing.T) {
 
 			proxy, err := NewOAuthProxy(opts, func(_ string) bool { return true })
 			assert.NoError(t, err)
-			if proxy.skipAuthStripHeaders {
+			if proxy.SkipAuthStripHeaders {
 				proxy.stripAuthHeaders(req)
 			}
 
@@ -723,6 +723,213 @@ func TestStripAuthHeaders(t *testing.T) {
 				} else {
 					assert.Equal(t, req.Header.Get(header), initialHeaders[header])
 				}
+			}
+		})
+	}
+}
+
+func TestAuthSkippedForPreflightRequests(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		_, err := w.Write([]byte("response"))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}))
+	t.Cleanup(upstream.Close)
+
+	opts := baseTestOptions()
+	opts.UpstreamServers = options.Upstreams{
+		{
+			ID:   upstream.URL,
+			Path: "/",
+			URI:  upstream.URL,
+		},
+	}
+	opts.Authorization.SkipAuthPreflight = true
+	err := validation.Validate(opts)
+	assert.NoError(t, err)
+
+	upstreamURL, _ := url.Parse(upstream.URL)
+	opts.SetProvider(NewTestProvider(upstreamURL, ""))
+
+	proxy, err := NewOAuthProxy(opts, func(string) bool { return false })
+	if err != nil {
+		t.Fatal(err)
+	}
+	rw := httptest.NewRecorder()
+	req, _ := http.NewRequest("OPTIONS", "/preflight-request", nil)
+	proxy.ServeHTTP(rw, req)
+
+	assert.Equal(t, 200, rw.Code)
+	assert.Equal(t, "response", rw.Body.String())
+}
+
+func TestTrustedIPs(t *testing.T) {
+	tests := []struct {
+		name               string
+		trustedIPs         []string
+		reverseProxy       bool
+		realClientIPHeader string
+		req                *http.Request
+		expectTrusted      bool
+	}{
+		// Check unconfigured behavior.
+		{
+			name:               "Default",
+			trustedIPs:         nil,
+			reverseProxy:       false,
+			realClientIPHeader: "X-Real-IP", // Default value
+			req: func() *http.Request {
+				req, _ := http.NewRequest("GET", "/", nil)
+				return req
+			}(),
+			expectTrusted: false,
+		},
+		// Check using req.RemoteAddr (Options.ReverseProxy == false).
+		{
+			name:               "WithRemoteAddr",
+			trustedIPs:         []string{"127.0.0.1"},
+			reverseProxy:       false,
+			realClientIPHeader: "X-Real-IP", // Default value
+			req: func() *http.Request {
+				req, _ := http.NewRequest("GET", "/", nil)
+				req.RemoteAddr = "127.0.0.1:43670"
+				return req
+			}(),
+			expectTrusted: true,
+		},
+		// Check ignores req.RemoteAddr match when behind a reverse proxy / missing header.
+		{
+			name:               "IgnoresRemoteAddrInReverseProxyMode",
+			trustedIPs:         []string{"127.0.0.1"},
+			reverseProxy:       true,
+			realClientIPHeader: "X-Real-IP", // Default value
+			req: func() *http.Request {
+				req, _ := http.NewRequest("GET", "/", nil)
+				req.RemoteAddr = "127.0.0.1:44324"
+				return req
+			}(),
+			expectTrusted: false,
+		},
+		// Check successful trusting of localhost in IPv4.
+		{
+			name:               "TrustsLocalhostInReverseProxyMode",
+			trustedIPs:         []string{"127.0.0.0/8", "::1"},
+			reverseProxy:       true,
+			realClientIPHeader: "X-Forwarded-For",
+			req: func() *http.Request {
+				req, _ := http.NewRequest("GET", "/", nil)
+				req.Header.Add("X-Forwarded-For", "127.0.0.1")
+				return req
+			}(),
+			expectTrusted: true,
+		},
+		// Check successful trusting of localhost in IPv6.
+		{
+			name:               "TrustsIP6LocalostInReverseProxyMode",
+			trustedIPs:         []string{"127.0.0.0/8", "::1"},
+			reverseProxy:       true,
+			realClientIPHeader: "X-Forwarded-For",
+			req: func() *http.Request {
+				req, _ := http.NewRequest("GET", "/", nil)
+				req.Header.Add("X-Forwarded-For", "::1")
+				return req
+			}(),
+			expectTrusted: true,
+		},
+		// Check does not trust random IPv4 address.
+		{
+			name:               "DoesNotTrustRandomIP4Address",
+			trustedIPs:         []string{"127.0.0.0/8", "::1"},
+			reverseProxy:       true,
+			realClientIPHeader: "X-Forwarded-For",
+			req: func() *http.Request {
+				req, _ := http.NewRequest("GET", "/", nil)
+				req.Header.Add("X-Forwarded-For", "12.34.56.78")
+				return req
+			}(),
+			expectTrusted: false,
+		},
+		// Check does not trust random IPv6 address.
+		{
+			name:               "DoesNotTrustRandomIP6Address",
+			trustedIPs:         []string{"127.0.0.0/8", "::1"},
+			reverseProxy:       true,
+			realClientIPHeader: "X-Forwarded-For",
+			req: func() *http.Request {
+				req, _ := http.NewRequest("GET", "/", nil)
+				req.Header.Add("X-Forwarded-For", "::2")
+				return req
+			}(),
+			expectTrusted: false,
+		},
+		// Check respects correct header.
+		{
+			name:               "RespectsCorrectHeaderInReverseProxyMode",
+			trustedIPs:         []string{"127.0.0.0/8", "::1"},
+			reverseProxy:       true,
+			realClientIPHeader: "X-Forwarded-For",
+			req: func() *http.Request {
+				req, _ := http.NewRequest("GET", "/", nil)
+				req.Header.Add("X-Real-IP", "::1")
+				return req
+			}(),
+			expectTrusted: false,
+		},
+		// Check doesn't trust if garbage is provided.
+		{
+			name:               "DoesNotTrustGarbageInReverseProxyMode",
+			trustedIPs:         []string{"127.0.0.0/8", "::1"},
+			reverseProxy:       true,
+			realClientIPHeader: "X-Forwarded-For",
+			req: func() *http.Request {
+				req, _ := http.NewRequest("GET", "/", nil)
+				req.Header.Add("X-Forwarded-For", "adsfljk29242as!!")
+				return req
+			}(),
+			expectTrusted: false,
+		},
+		// Check doesn't trust if garbage is provided (no reverse-proxy).
+		{
+			name:               "DoesNotTrustGarbage",
+			trustedIPs:         []string{"127.0.0.0/8", "::1"},
+			reverseProxy:       false,
+			realClientIPHeader: "X-Real-IP",
+			req: func() *http.Request {
+				req, _ := http.NewRequest("GET", "/", nil)
+				req.RemoteAddr = "adsfljk29242as!!"
+				return req
+			}(),
+			expectTrusted: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := baseTestOptions()
+			opts.UpstreamServers = options.Upstreams{
+				{
+					ID:     "static",
+					Path:   "/",
+					Static: true,
+				},
+			}
+			opts.Authorization.TrustedIPs = tt.trustedIPs
+			opts.ReverseProxy = tt.reverseProxy
+			opts.RealClientIPHeader = tt.realClientIPHeader
+			err := validation.Validate(opts)
+			assert.NoError(t, err)
+
+			proxy, err := NewOAuthProxy(opts, func(string) bool { return true })
+			assert.NoError(t, err)
+			rw := httptest.NewRecorder()
+
+			proxy.ServeHTTP(rw, tt.req)
+			if tt.expectTrusted {
+				assert.Equal(t, 200, rw.Code)
+			} else {
+				assert.Equal(t, 403, rw.Code)
 			}
 		})
 	}
@@ -1441,43 +1648,6 @@ func TestAuthOnlyEndpointSetBasicAuthFalseRequestHeaders(t *testing.T) {
 	assert.Equal(t, 0, len(pcTest.rw.Header().Values("Authorization")), "should not have Authorization header entries")
 }
 
-func TestAuthSkippedForPreflightRequests(t *testing.T) {
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(200)
-		_, err := w.Write([]byte("response"))
-		if err != nil {
-			t.Fatal(err)
-		}
-	}))
-	t.Cleanup(upstream.Close)
-
-	opts := baseTestOptions()
-	opts.UpstreamServers = options.Upstreams{
-		{
-			ID:   upstream.URL,
-			Path: "/",
-			URI:  upstream.URL,
-		},
-	}
-	opts.SkipAuthPreflight = true
-	err := validation.Validate(opts)
-	assert.NoError(t, err)
-
-	upstreamURL, _ := url.Parse(upstream.URL)
-	opts.SetProvider(NewTestProvider(upstreamURL, ""))
-
-	proxy, err := NewOAuthProxy(opts, func(string) bool { return false })
-	if err != nil {
-		t.Fatal(err)
-	}
-	rw := httptest.NewRecorder()
-	req, _ := http.NewRequest("OPTIONS", "/preflight-request", nil)
-	proxy.ServeHTTP(rw, req)
-
-	assert.Equal(t, 200, rw.Code)
-	assert.Equal(t, "response", rw.Body.String())
-}
-
 type SignatureAuthenticator struct {
 	auth hmacauth.HmacAuth
 }
@@ -1950,7 +2120,7 @@ func Test_noCacheHeaders(t *testing.T) {
 			URI:  upstream.URL,
 		},
 	}
-	opts.SkipAuthRegex = []string{".*"}
+	opts.Authorization.SkipAuthRegex = []string{".*"}
 	err := validation.Validate(opts)
 	assert.NoError(t, err)
 	proxy, err := NewOAuthProxy(opts, func(_ string) bool { return true })
@@ -2029,173 +2199,4 @@ func baseTestOptions() *options.Options {
 	opts.ClientSecret = clientSecret
 	opts.EmailDomains = []string{"*"}
 	return opts
-}
-
-func TestTrustedIPs(t *testing.T) {
-	tests := []struct {
-		name               string
-		trustedIPs         []string
-		reverseProxy       bool
-		realClientIPHeader string
-		req                *http.Request
-		expectTrusted      bool
-	}{
-		// Check unconfigured behavior.
-		{
-			name:               "Default",
-			trustedIPs:         nil,
-			reverseProxy:       false,
-			realClientIPHeader: "X-Real-IP", // Default value
-			req: func() *http.Request {
-				req, _ := http.NewRequest("GET", "/", nil)
-				return req
-			}(),
-			expectTrusted: false,
-		},
-		// Check using req.RemoteAddr (Options.ReverseProxy == false).
-		{
-			name:               "WithRemoteAddr",
-			trustedIPs:         []string{"127.0.0.1"},
-			reverseProxy:       false,
-			realClientIPHeader: "X-Real-IP", // Default value
-			req: func() *http.Request {
-				req, _ := http.NewRequest("GET", "/", nil)
-				req.RemoteAddr = "127.0.0.1:43670"
-				return req
-			}(),
-			expectTrusted: true,
-		},
-		// Check ignores req.RemoteAddr match when behind a reverse proxy / missing header.
-		{
-			name:               "IgnoresRemoteAddrInReverseProxyMode",
-			trustedIPs:         []string{"127.0.0.1"},
-			reverseProxy:       true,
-			realClientIPHeader: "X-Real-IP", // Default value
-			req: func() *http.Request {
-				req, _ := http.NewRequest("GET", "/", nil)
-				req.RemoteAddr = "127.0.0.1:44324"
-				return req
-			}(),
-			expectTrusted: false,
-		},
-		// Check successful trusting of localhost in IPv4.
-		{
-			name:               "TrustsLocalhostInReverseProxyMode",
-			trustedIPs:         []string{"127.0.0.0/8", "::1"},
-			reverseProxy:       true,
-			realClientIPHeader: "X-Forwarded-For",
-			req: func() *http.Request {
-				req, _ := http.NewRequest("GET", "/", nil)
-				req.Header.Add("X-Forwarded-For", "127.0.0.1")
-				return req
-			}(),
-			expectTrusted: true,
-		},
-		// Check successful trusting of localhost in IPv6.
-		{
-			name:               "TrustsIP6LocalostInReverseProxyMode",
-			trustedIPs:         []string{"127.0.0.0/8", "::1"},
-			reverseProxy:       true,
-			realClientIPHeader: "X-Forwarded-For",
-			req: func() *http.Request {
-				req, _ := http.NewRequest("GET", "/", nil)
-				req.Header.Add("X-Forwarded-For", "::1")
-				return req
-			}(),
-			expectTrusted: true,
-		},
-		// Check does not trust random IPv4 address.
-		{
-			name:               "DoesNotTrustRandomIP4Address",
-			trustedIPs:         []string{"127.0.0.0/8", "::1"},
-			reverseProxy:       true,
-			realClientIPHeader: "X-Forwarded-For",
-			req: func() *http.Request {
-				req, _ := http.NewRequest("GET", "/", nil)
-				req.Header.Add("X-Forwarded-For", "12.34.56.78")
-				return req
-			}(),
-			expectTrusted: false,
-		},
-		// Check does not trust random IPv6 address.
-		{
-			name:               "DoesNotTrustRandomIP6Address",
-			trustedIPs:         []string{"127.0.0.0/8", "::1"},
-			reverseProxy:       true,
-			realClientIPHeader: "X-Forwarded-For",
-			req: func() *http.Request {
-				req, _ := http.NewRequest("GET", "/", nil)
-				req.Header.Add("X-Forwarded-For", "::2")
-				return req
-			}(),
-			expectTrusted: false,
-		},
-		// Check respects correct header.
-		{
-			name:               "RespectsCorrectHeaderInReverseProxyMode",
-			trustedIPs:         []string{"127.0.0.0/8", "::1"},
-			reverseProxy:       true,
-			realClientIPHeader: "X-Forwarded-For",
-			req: func() *http.Request {
-				req, _ := http.NewRequest("GET", "/", nil)
-				req.Header.Add("X-Real-IP", "::1")
-				return req
-			}(),
-			expectTrusted: false,
-		},
-		// Check doesn't trust if garbage is provided.
-		{
-			name:               "DoesNotTrustGarbageInReverseProxyMode",
-			trustedIPs:         []string{"127.0.0.0/8", "::1"},
-			reverseProxy:       true,
-			realClientIPHeader: "X-Forwarded-For",
-			req: func() *http.Request {
-				req, _ := http.NewRequest("GET", "/", nil)
-				req.Header.Add("X-Forwarded-For", "adsfljk29242as!!")
-				return req
-			}(),
-			expectTrusted: false,
-		},
-		// Check doesn't trust if garbage is provided (no reverse-proxy).
-		{
-			name:               "DoesNotTrustGarbage",
-			trustedIPs:         []string{"127.0.0.0/8", "::1"},
-			reverseProxy:       false,
-			realClientIPHeader: "X-Real-IP",
-			req: func() *http.Request {
-				req, _ := http.NewRequest("GET", "/", nil)
-				req.RemoteAddr = "adsfljk29242as!!"
-				return req
-			}(),
-			expectTrusted: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			opts := baseTestOptions()
-			opts.UpstreamServers = options.Upstreams{
-				{
-					ID:     "static",
-					Path:   "/",
-					Static: true,
-				},
-			}
-			opts.TrustedIPs = tt.trustedIPs
-			opts.ReverseProxy = tt.reverseProxy
-			opts.RealClientIPHeader = tt.realClientIPHeader
-			validation.Validate(opts)
-
-			proxy, err := NewOAuthProxy(opts, func(string) bool { return true })
-			assert.NoError(t, err)
-			rw := httptest.NewRecorder()
-
-			proxy.ServeHTTP(rw, tt.req)
-			if tt.expectTrusted {
-				assert.Equal(t, 200, rw.Code)
-			} else {
-				assert.Equal(t, 403, rw.Code)
-			}
-		})
-	}
 }

--- a/pkg/apis/options/authorization.go
+++ b/pkg/apis/options/authorization.go
@@ -35,7 +35,6 @@ func authorizationFlagSet() *pflag.FlagSet {
 	flagSet.StringSlice("skip-auth-regex", []string{}, "(DEPRECATED for --skip-auth-route) bypass authentication for requests path's that match (may be given multiple times)")
 	flagSet.StringSlice("skip-auth-route", []string{}, "bypass authentication for requests that match the method & path. Format: method=path_regex OR path_regex alone for all methods")
 	flagSet.Bool("skip-auth-preflight", false, "will skip authentication for OPTIONS requests")
-	flagSet.Bool("skip-auth-strip-headers", false, "strips X-Forwarded-* style authentication headers & Authorization header if they would be set by oauth2-proxy for trusted requests (--skip-auth-route, --skip-auth-regex, --skip-auth-preflight, --trusted-ip)")
 	flagSet.StringSlice("trusted-ip", []string{}, "list of IPs or CIDR ranges to allow to bypass authentication. WARNING: trusting by IP has inherent security flaws, read the configuration documentation for more information.")
 
 	return flagSet

--- a/pkg/apis/options/authorization.go
+++ b/pkg/apis/options/authorization.go
@@ -2,51 +2,26 @@ package options
 
 import (
 	"github.com/oauth2-proxy/oauth2-proxy/pkg/authorization"
-	"github.com/spf13/pflag"
 )
 
-// Authorization holds configuration options related to trusted requests which
-// would skip authentication
-type Authorization struct {
-	SkipAuthRegex        []string `flag:"skip-auth-regex" cfg:"skip_auth_regex"`
-	SkipAuthRoutes       []string `flag:"skip-auth-route" cfg:"skip_auth_routes"`
-	SkipAuthPreflight    bool     `flag:"skip-auth-preflight" cfg:"skip_auth_preflight"`
-	SkipAuthStripHeaders bool     `flag:"skip-auth-strip-headers" cfg:"skip_auth_strip_headers"`
-	TrustedIPs           []string `flag:"trusted-ip" cfg:"trusted_ips"`
+// RequestRules is a collection of request based authorization rules
+type RequestRules []RequestRule
 
-	// internal set after validation
-	rulesEngine authorization.RulesEngine
-}
+// RequestRule contains the various options to configure a request only
+// based Rule that occurs before authentication
+type RequestRule struct {
+	// ID is a unique ID for the rule
+	ID string
 
-// GetRulesEngine gets the private rules engine
-func (a *Authorization) GetRulesEngine() authorization.RulesEngine {
-	return a.rulesEngine
-}
+	// policy is either Allow, Deny or Auth
+	Policy authorization.Policy
 
-// SetRulesEngine sets the private rules engine
-func (a *Authorization) SetRulesEngine(e authorization.RulesEngine) {
-	a.rulesEngine = e
-}
+	// Path is a regex that will be tested against the req.URL.Path
+	Path string
 
-// authorizationFlagSet creates a new FlagSet with all of the flags required by Authorization
-func authorizationFlagSet() *pflag.FlagSet {
-	flagSet := pflag.NewFlagSet("authorization", pflag.ExitOnError)
+	// Methods is list of HTTP methods. This group is an OR operation.
+	Methods []string
 
-	flagSet.StringSlice("skip-auth-regex", []string{}, "(DEPRECATED for --skip-auth-route) bypass authentication for requests path's that match (may be given multiple times)")
-	flagSet.StringSlice("skip-auth-route", []string{}, "bypass authentication for requests that match the method & path. Format: method=path_regex OR path_regex alone for all methods")
-	flagSet.Bool("skip-auth-preflight", false, "will skip authentication for OPTIONS requests")
-	flagSet.StringSlice("trusted-ip", []string{}, "list of IPs or CIDR ranges to allow to bypass authentication. WARNING: trusting by IP has inherent security flaws, read the configuration documentation for more information.")
-
-	return flagSet
-}
-
-// authorizationDefaults creates default Authorization options
-func authorizationDefaults() Authorization {
-	return Authorization{
-		TrustedIPs:           nil,
-		SkipAuthRegex:        nil,
-		SkipAuthRoutes:       nil,
-		SkipAuthPreflight:    false,
-		SkipAuthStripHeaders: false,
-	}
+	// IPS is a list of IPs or CIDRs. This group is an OR operation
+	IPs []string
 }

--- a/pkg/apis/options/authorization.go
+++ b/pkg/apis/options/authorization.go
@@ -1,0 +1,53 @@
+package options
+
+import (
+	"github.com/oauth2-proxy/oauth2-proxy/pkg/authorization"
+	"github.com/spf13/pflag"
+)
+
+// Authorization holds configuration options related to trusted requests which
+// would skip authentication
+type Authorization struct {
+	SkipAuthRegex        []string `flag:"skip-auth-regex" cfg:"skip_auth_regex"`
+	SkipAuthRoutes       []string `flag:"skip-auth-route" cfg:"skip_auth_routes"`
+	SkipAuthPreflight    bool     `flag:"skip-auth-preflight" cfg:"skip_auth_preflight"`
+	SkipAuthStripHeaders bool     `flag:"skip-auth-strip-headers" cfg:"skip_auth_strip_headers"`
+	TrustedIPs           []string `flag:"trusted-ip" cfg:"trusted_ips"`
+
+	// internal set after validation
+	rulesEngine authorization.RulesEngine
+}
+
+// GetRulesEngine gets the private rules engine
+func (a *Authorization) GetRulesEngine() authorization.RulesEngine {
+	return a.rulesEngine
+}
+
+// SetRulesEngine sets the private rules engine
+func (a *Authorization) SetRulesEngine(e authorization.RulesEngine) {
+	a.rulesEngine = e
+}
+
+// authorizationFlagSet creates a new FlagSet with all of the flags required by Authorization
+func authorizationFlagSet() *pflag.FlagSet {
+	flagSet := pflag.NewFlagSet("authorization", pflag.ExitOnError)
+
+	flagSet.StringSlice("skip-auth-regex", []string{}, "(DEPRECATED for --skip-auth-route) bypass authentication for requests path's that match (may be given multiple times)")
+	flagSet.StringSlice("skip-auth-route", []string{}, "bypass authentication for requests that match the method & path. Format: method=path_regex OR path_regex alone for all methods")
+	flagSet.Bool("skip-auth-preflight", false, "will skip authentication for OPTIONS requests")
+	flagSet.Bool("skip-auth-strip-headers", false, "strips X-Forwarded-* style authentication headers & Authorization header if they would be set by oauth2-proxy for trusted requests (--skip-auth-route, --skip-auth-regex, --skip-auth-preflight, --trusted-ip)")
+	flagSet.StringSlice("trusted-ip", []string{}, "list of IPs or CIDR ranges to allow to bypass authentication. WARNING: trusting by IP has inherent security flaws, read the configuration documentation for more information.")
+
+	return flagSet
+}
+
+// authorizationDefaults creates default Authorization options
+func authorizationDefaults() Authorization {
+	return Authorization{
+		TrustedIPs:           nil,
+		SkipAuthRegex:        nil,
+		SkipAuthRoutes:       nil,
+		SkipAuthPreflight:    false,
+		SkipAuthStripHeaders: false,
+	}
+}

--- a/pkg/apis/options/options.go
+++ b/pkg/apis/options/options.go
@@ -56,14 +56,14 @@ type Options struct {
 	Banner                   string   `flag:"banner" cfg:"banner"`
 	Footer                   string   `flag:"footer" cfg:"footer"`
 
-	Authorization Authorization  `cfg:",squash"`
-	Cookie        Cookie         `cfg:",squash"`
-	Session       SessionOptions `cfg:",squash"`
-	Logging       Logging        `cfg:",squash"`
+	Cookie  Cookie         `cfg:",squash"`
+	Session SessionOptions `cfg:",squash"`
+	Logging Logging        `cfg:",squash"`
 
 	// Not used in the legacy config, name not allowed to match an external key (upstreams)
 	// TODO(JoelSpeed): Rename when legacy config is removed
-	UpstreamServers Upstreams `cfg:",internal"`
+	UpstreamServers   Upstreams    `cfg:",internal"`
+	RequestAuthZRules RequestRules `cfg:",squash"`
 
 	SkipAuthStripHeaders  bool     `flag:"skip-auth-strip-headers" cfg:"skip_auth_strip_headers"`
 	SkipJwtBearerTokens   bool     `flag:"skip-jwt-bearer-tokens" cfg:"skip_jwt_bearer_tokens"`
@@ -143,10 +143,10 @@ func NewOptions() *Options {
 		RealClientIPHeader:               "X-Real-IP",
 		ForceHTTPS:                       false,
 		DisplayHtpasswdForm:              true,
-		Authorization:                    authorizationDefaults(),
 		Cookie:                           cookieDefaults(),
 		Session:                          sessionOptionsDefaults(),
 		AzureTenant:                      "common",
+		SkipAuthStripHeaders:             false,
 		SetXAuthRequest:                  false,
 		PassBasicAuth:                    true,
 		SetBasicAuth:                     false,
@@ -255,9 +255,9 @@ func NewFlagSet() *pflag.FlagSet {
 
 	flagSet.String("user-id-claim", "email", "which claim contains the user ID")
 
-	flagSet.AddFlagSet(authorizationFlagSet())
 	flagSet.AddFlagSet(cookieFlagSet())
 	flagSet.AddFlagSet(loggingFlagSet())
+	flagSet.AddFlagSet(legacyAuthorizationFlagSet())
 	flagSet.AddFlagSet(legacyUpstreamsFlagSet())
 
 	return flagSet

--- a/pkg/apis/options/options.go
+++ b/pkg/apis/options/options.go
@@ -65,6 +65,7 @@ type Options struct {
 	// TODO(JoelSpeed): Rename when legacy config is removed
 	UpstreamServers Upstreams `cfg:",internal"`
 
+	SkipAuthStripHeaders  bool     `flag:"skip-auth-strip-headers" cfg:"skip_auth_strip_headers"`
 	SkipJwtBearerTokens   bool     `flag:"skip-jwt-bearer-tokens" cfg:"skip_jwt_bearer_tokens"`
 	ExtraJwtIssuers       []string `flag:"extra-jwt-issuers" cfg:"extra_jwt_issuers"`
 	PassBasicAuth         bool     `flag:"pass-basic-auth" cfg:"pass_basic_auth"`
@@ -184,6 +185,7 @@ func NewFlagSet() *pflag.FlagSet {
 	flagSet.Bool("pass-access-token", false, "pass OAuth access_token to upstream via X-Forwarded-Access-Token header")
 	flagSet.Bool("pass-authorization-header", false, "pass the Authorization Header to upstream")
 	flagSet.Bool("set-authorization-header", false, "set Authorization response headers (useful in Nginx auth_request mode)")
+	flagSet.Bool("skip-auth-strip-headers", false, "strips X-Forwarded-* style authentication headers & Authorization header if they would be set by oauth2-proxy for trusted requests (--skip-auth-route, --skip-auth-regex, --skip-auth-preflight, --trusted-ip)")
 	flagSet.Bool("skip-provider-button", false, "will skip sign-in-page to directly reach the next step: oauth/start")
 	flagSet.Bool("ssl-insecure-skip-verify", false, "skip validation of certificates presented when using HTTPS providers")
 	flagSet.Bool("skip-jwt-bearer-tokens", false, "will skip requests that have verified JWT bearer tokens (default false)")

--- a/pkg/apis/options/options.go
+++ b/pkg/apis/options/options.go
@@ -2,13 +2,11 @@ package options
 
 import (
 	"crypto"
-	"net/url"
-	"regexp"
-
 	oidc "github.com/coreos/go-oidc"
 	ipapi "github.com/oauth2-proxy/oauth2-proxy/pkg/apis/ip"
 	"github.com/oauth2-proxy/oauth2-proxy/providers"
 	"github.com/spf13/pflag"
+	"net/url"
 )
 
 // SignatureData holds hmacauth signature hash and key
@@ -20,21 +18,21 @@ type SignatureData struct {
 // Options holds Configuration Options that can be set by Command Line Flag,
 // or Config File
 type Options struct {
-	ProxyPrefix        string   `flag:"proxy-prefix" cfg:"proxy_prefix"`
-	PingPath           string   `flag:"ping-path" cfg:"ping_path"`
-	PingUserAgent      string   `flag:"ping-user-agent" cfg:"ping_user_agent"`
-	HTTPAddress        string   `flag:"http-address" cfg:"http_address"`
-	HTTPSAddress       string   `flag:"https-address" cfg:"https_address"`
-	ReverseProxy       bool     `flag:"reverse-proxy" cfg:"reverse_proxy"`
-	RealClientIPHeader string   `flag:"real-client-ip-header" cfg:"real_client_ip_header"`
-	TrustedIPs         []string `flag:"trusted-ip" cfg:"trusted_ips"`
-	ForceHTTPS         bool     `flag:"force-https" cfg:"force_https"`
-	RawRedirectURL     string   `flag:"redirect-url" cfg:"redirect_url"`
-	ClientID           string   `flag:"client-id" cfg:"client_id"`
-	ClientSecret       string   `flag:"client-secret" cfg:"client_secret"`
-	ClientSecretFile   string   `flag:"client-secret-file" cfg:"client_secret_file"`
-	TLSCertFile        string   `flag:"tls-cert-file" cfg:"tls_cert_file"`
-	TLSKeyFile         string   `flag:"tls-key-file" cfg:"tls_key_file"`
+	ProxyPrefix        string `flag:"proxy-prefix" cfg:"proxy_prefix"`
+	PingPath           string `flag:"ping-path" cfg:"ping_path"`
+	PingUserAgent      string `flag:"ping-user-agent" cfg:"ping_user_agent"`
+	ProxyWebSockets    bool   `flag:"proxy-websockets" cfg:"proxy_websockets"`
+	HTTPAddress        string `flag:"http-address" cfg:"http_address"`
+	HTTPSAddress       string `flag:"https-address" cfg:"https_address"`
+	ReverseProxy       bool   `flag:"reverse-proxy" cfg:"reverse_proxy"`
+	RealClientIPHeader string `flag:"real-client-ip-header" cfg:"real_client_ip_header"`
+	ForceHTTPS         bool   `flag:"force-https" cfg:"force_https"`
+	RawRedirectURL     string `flag:"redirect-url" cfg:"redirect_url"`
+	ClientID           string `flag:"client-id" cfg:"client_id"`
+	ClientSecret       string `flag:"client-secret" cfg:"client_secret"`
+	ClientSecretFile   string `flag:"client-secret-file" cfg:"client_secret_file"`
+	TLSCertFile        string `flag:"tls-cert-file" cfg:"tls_cert_file"`
+	TLSKeyFile         string `flag:"tls-key-file" cfg:"tls_key_file"`
 
 	AuthenticatedEmailsFile  string   `flag:"authenticated-emails-file" cfg:"authenticated_emails_file"`
 	KeycloakGroup            string   `flag:"keycloak-group" cfg:"keycloak_group"`
@@ -58,16 +56,15 @@ type Options struct {
 	Banner                   string   `flag:"banner" cfg:"banner"`
 	Footer                   string   `flag:"footer" cfg:"footer"`
 
-	Cookie  Cookie         `cfg:",squash"`
-	Session SessionOptions `cfg:",squash"`
-	Logging Logging        `cfg:",squash"`
+	Authorization Authorization  `cfg:",squash"`
+	Cookie        Cookie         `cfg:",squash"`
+	Session       SessionOptions `cfg:",squash"`
+	Logging       Logging        `cfg:",squash"`
 
 	// Not used in the legacy config, name not allowed to match an external key (upstreams)
 	// TODO(JoelSpeed): Rename when legacy config is removed
 	UpstreamServers Upstreams `cfg:",internal"`
 
-	SkipAuthRegex         []string `flag:"skip-auth-regex" cfg:"skip_auth_regex"`
-	SkipAuthStripHeaders  bool     `flag:"skip-auth-strip-headers" cfg:"skip_auth_strip_headers"`
 	SkipJwtBearerTokens   bool     `flag:"skip-jwt-bearer-tokens" cfg:"skip_jwt_bearer_tokens"`
 	ExtraJwtIssuers       []string `flag:"extra-jwt-issuers" cfg:"extra_jwt_issuers"`
 	PassBasicAuth         bool     `flag:"pass-basic-auth" cfg:"pass_basic_auth"`
@@ -81,7 +78,6 @@ type Options struct {
 	SetXAuthRequest       bool     `flag:"set-xauthrequest" cfg:"set_xauthrequest"`
 	SetAuthorization      bool     `flag:"set-authorization-header" cfg:"set_authorization_header"`
 	PassAuthorization     bool     `flag:"pass-authorization-header" cfg:"pass_authorization_header"`
-	SkipAuthPreflight     bool     `flag:"skip-auth-preflight" cfg:"skip_auth_preflight"`
 
 	// These options allow for other providers besides Google, with
 	// potential overrides.
@@ -112,7 +108,6 @@ type Options struct {
 
 	// internal values that are set after config validation
 	redirectURL        *url.URL
-	compiledRegex      []*regexp.Regexp
 	provider           providers.Provider
 	signatureData      *SignatureData
 	oidcVerifier       *oidc.IDTokenVerifier
@@ -122,7 +117,6 @@ type Options struct {
 
 // Options for Getting internal values
 func (o *Options) GetRedirectURL() *url.URL                        { return o.redirectURL }
-func (o *Options) GetCompiledRegex() []*regexp.Regexp              { return o.compiledRegex }
 func (o *Options) GetProvider() providers.Provider                 { return o.provider }
 func (o *Options) GetSignatureData() *SignatureData                { return o.signatureData }
 func (o *Options) GetOIDCVerifier() *oidc.IDTokenVerifier          { return o.oidcVerifier }
@@ -131,7 +125,6 @@ func (o *Options) GetRealClientIPParser() ipapi.RealClientIPParser { return o.re
 
 // Options for Setting internal values
 func (o *Options) SetRedirectURL(s *url.URL)                        { o.redirectURL = s }
-func (o *Options) SetCompiledRegex(s []*regexp.Regexp)              { o.compiledRegex = s }
 func (o *Options) SetProvider(s providers.Provider)                 { o.provider = s }
 func (o *Options) SetSignatureData(s *SignatureData)                { o.signatureData = s }
 func (o *Options) SetOIDCVerifier(s *oidc.IDTokenVerifier)          { o.oidcVerifier = s }
@@ -149,11 +142,11 @@ func NewOptions() *Options {
 		RealClientIPHeader:               "X-Real-IP",
 		ForceHTTPS:                       false,
 		DisplayHtpasswdForm:              true,
+		Authorization:                    authorizationDefaults(),
 		Cookie:                           cookieDefaults(),
 		Session:                          sessionOptionsDefaults(),
 		AzureTenant:                      "common",
 		SetXAuthRequest:                  false,
-		SkipAuthPreflight:                false,
 		PassBasicAuth:                    true,
 		SetBasicAuth:                     false,
 		PassUserHeaders:                  true,
@@ -178,7 +171,6 @@ func NewFlagSet() *pflag.FlagSet {
 	flagSet.String("https-address", ":443", "<addr>:<port> to listen on for HTTPS clients")
 	flagSet.Bool("reverse-proxy", false, "are we running behind a reverse proxy, controls whether headers like X-Real-Ip are accepted")
 	flagSet.String("real-client-ip-header", "X-Real-IP", "Header used to determine the real IP of the client (one of: X-Forwarded-For, X-Real-IP, or X-ProxyUser-IP)")
-	flagSet.StringSlice("trusted-ip", []string{}, "list of IPs or CIDR ranges to allow to bypass authentication. WARNING: trusting by IP has inherent security flaws, read the configuration documentation for more information.")
 	flagSet.Bool("force-https", false, "force HTTPS redirect for HTTP requests")
 	flagSet.String("tls-cert-file", "", "path to certificate file")
 	flagSet.String("tls-key-file", "", "path to private key file")
@@ -192,10 +184,7 @@ func NewFlagSet() *pflag.FlagSet {
 	flagSet.Bool("pass-access-token", false, "pass OAuth access_token to upstream via X-Forwarded-Access-Token header")
 	flagSet.Bool("pass-authorization-header", false, "pass the Authorization Header to upstream")
 	flagSet.Bool("set-authorization-header", false, "set Authorization response headers (useful in Nginx auth_request mode)")
-	flagSet.StringSlice("skip-auth-regex", []string{}, "bypass authentication for requests path's that match (may be given multiple times)")
-	flagSet.Bool("skip-auth-strip-headers", false, "strips X-Forwarded-* style authentication headers & Authorization header if they would be set by oauth2-proxy for request paths in --skip-auth-regex")
 	flagSet.Bool("skip-provider-button", false, "will skip sign-in-page to directly reach the next step: oauth/start")
-	flagSet.Bool("skip-auth-preflight", false, "will skip authentication for OPTIONS requests")
 	flagSet.Bool("ssl-insecure-skip-verify", false, "skip validation of certificates presented when using HTTPS providers")
 	flagSet.Bool("skip-jwt-bearer-tokens", false, "will skip requests that have verified JWT bearer tokens (default false)")
 	flagSet.StringSlice("extra-jwt-issuers", []string{}, "if skip-jwt-bearer-tokens is set, a list of extra JWT issuer=audience pairs (where the issuer URL has a .well-known/openid-configuration or a .well-known/jwks.json)")
@@ -264,6 +253,7 @@ func NewFlagSet() *pflag.FlagSet {
 
 	flagSet.String("user-id-claim", "email", "which claim contains the user ID")
 
+	flagSet.AddFlagSet(authorizationFlagSet())
 	flagSet.AddFlagSet(cookieFlagSet())
 	flagSet.AddFlagSet(loggingFlagSet())
 	flagSet.AddFlagSet(legacyUpstreamsFlagSet())

--- a/pkg/authorization/conditions/interfaces.go
+++ b/pkg/authorization/conditions/interfaces.go
@@ -1,0 +1,13 @@
+package conditions
+
+import (
+	"net/http"
+
+	"github.com/oauth2-proxy/oauth2-proxy/pkg/apis/sessions"
+)
+
+// Condition is the underlying building block of a Rule
+type Condition interface {
+	// Match returns a bool based on details of the Request or Session
+	Match(*http.Request, *sessions.SessionState) bool
+}

--- a/pkg/authorization/conditions/ips.go
+++ b/pkg/authorization/conditions/ips.go
@@ -1,0 +1,59 @@
+package conditions
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	ipapi "github.com/oauth2-proxy/oauth2-proxy/pkg/apis/ip"
+	"github.com/oauth2-proxy/oauth2-proxy/pkg/apis/sessions"
+	"github.com/oauth2-proxy/oauth2-proxy/pkg/ip"
+	"github.com/oauth2-proxy/oauth2-proxy/pkg/logger"
+)
+
+type ips struct {
+	ips      *ip.NetSet
+	ipParser ipapi.RealClientIPParser
+}
+
+// NewIPs takes trusted IPs and builds a unified ip.NetSet to use as a
+// authorization.Condition
+func NewIPs(trustedIPs []string, parser ipapi.RealClientIPParser) (Condition, error) {
+	ns := ip.NewNetSet()
+	var failed []string
+	failed = nil
+	for _, trustedIP := range trustedIPs {
+		if ipNet := ip.ParseIPNet(trustedIP); ipNet != nil {
+			ns.AddIPNet(*ipNet)
+		} else {
+			failed = append(failed, trustedIP)
+		}
+	}
+	if failed != nil {
+		return nil, fmt.Errorf("could not parse trusted IP network(s): %s", strings.Join(failed, ", "))
+	}
+	return &ips{
+		ips:      ns,
+		ipParser: parser,
+	}, nil
+}
+
+// Match checks if the request remote IP is in the ip.NetSet
+// This is reverse proxy aware if an ipParser is set.
+func (i *ips) Match(req *http.Request, _ *sessions.SessionState) bool {
+	if req == nil {
+		return false
+	}
+	remoteAddr, err := ip.GetClientIP(i.ipParser, req)
+	if err != nil {
+		logger.Printf("Error obtaining real IP for trusted IP list: %v", err)
+		// Possibly spoofed X-Real-IP header
+		return false
+	}
+
+	if remoteAddr == nil {
+		return false
+	}
+
+	return i.ips.Has(remoteAddr)
+}

--- a/pkg/authorization/conditions/methods.go
+++ b/pkg/authorization/conditions/methods.go
@@ -1,0 +1,34 @@
+package conditions
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/oauth2-proxy/oauth2-proxy/pkg/apis/sessions"
+)
+
+type methods struct {
+	methods map[string]struct{}
+}
+
+// NewMethods takes a list of methods and creates the methods field set
+func NewMethods(httpMethods []string) Condition {
+	ms := map[string]struct{}{}
+	for _, method := range httpMethods {
+		ms[strings.ToUpper(method)] = struct{}{}
+	}
+	return &methods{
+		methods: ms,
+	}
+}
+
+// Match does a set membership test of the request method
+func (m *methods) Match(req *http.Request, _ *sessions.SessionState) bool {
+	if req == nil {
+		return false
+	}
+	if _, ok := m.methods[req.Method]; ok {
+		return true
+	}
+	return false
+}

--- a/pkg/authorization/conditions/path.go
+++ b/pkg/authorization/conditions/path.go
@@ -1,0 +1,32 @@
+package conditions
+
+import (
+	"fmt"
+	"net/http"
+	"regexp"
+
+	"github.com/oauth2-proxy/oauth2-proxy/pkg/apis/sessions"
+)
+
+type path struct {
+	path *regexp.Regexp
+}
+
+// NewPath builds the PathRegex from a raw path regex string
+func NewPath(pathRegex string) (Condition, error) {
+	compiled, err := regexp.Compile(pathRegex)
+	if err != nil {
+		return nil, fmt.Errorf("error compiling regex /%s/: %v", pathRegex, err)
+	}
+	return &path{
+		path: compiled,
+	}, nil
+}
+
+// Match does a regex check against the request path
+func (p *path) Match(req *http.Request, _ *sessions.SessionState) bool {
+	if req == nil {
+		return false
+	}
+	return p.path.MatchString(req.URL.Path)
+}

--- a/pkg/authorization/interfaces.go
+++ b/pkg/authorization/interfaces.go
@@ -1,0 +1,35 @@
+package authorization
+
+import (
+	"net/http"
+
+	"github.com/oauth2-proxy/oauth2-proxy/pkg/apis/sessions"
+)
+
+// Policy is a Rule policy name
+type Policy string
+
+const (
+	AllowPolicy = Policy("ALLOW")
+	DenyPolicy  = Policy("DENY")
+	AuthPolicy  = Policy("AUTH")
+	SkipPolicy  = Policy("SKIP")
+)
+
+// Rule represents an authorization rule to be used for Allow & Deny
+// policies based on Request or SessionState fields
+type Rule interface {
+	// Match returns the Policy if the rule matches
+	Match(*http.Request, *sessions.SessionState) Policy
+}
+
+// RulesEngine manages Allow & Deny logic on a hierarchical Rules list
+type RulesEngine interface {
+	// AddRule adds a Rule to the hierarchical Rules list. First in
+	// takes precedence.
+	AddRule(Rule)
+
+	// Match returns the Policy name of the first matching Rule in the
+	// hierarchical Rules list.
+	Match(*http.Request, *sessions.SessionState) Policy
+}

--- a/pkg/authorization/interfaces.go
+++ b/pkg/authorization/interfaces.go
@@ -25,10 +25,6 @@ type Rule interface {
 
 // RulesEngine manages Allow & Deny logic on a hierarchical Rules list
 type RulesEngine interface {
-	// AddRule adds a Rule to the hierarchical Rules list. First in
-	// takes precedence.
-	AddRule(Rule)
-
 	// Match returns the Policy name of the first matching Rule in the
 	// hierarchical Rules list.
 	Match(*http.Request, *sessions.SessionState) Policy

--- a/pkg/authorization/rule.go
+++ b/pkg/authorization/rule.go
@@ -5,28 +5,10 @@ import (
 	"net/http"
 
 	ipapi "github.com/oauth2-proxy/oauth2-proxy/pkg/apis/ip"
+	"github.com/oauth2-proxy/oauth2-proxy/pkg/apis/options"
 	"github.com/oauth2-proxy/oauth2-proxy/pkg/apis/sessions"
 	"github.com/oauth2-proxy/oauth2-proxy/pkg/authorization/conditions"
 )
-
-// RequestRuleOptions are the various options to configure a request only
-// based Rule that occurs before authentication
-type RequestRuleOptions struct {
-	// ID is a unique ID for the rule
-	ID string
-
-	// policy is either Allow or Deny
-	Policy Policy
-
-	// Path is a regex that will be tested against the req.URL.Path
-	Path string
-
-	// methods is list of HTTP methods. This group is an OR operation.
-	Methods []string
-
-	// IPS is a list of IPs or CIDRs. This group is an OR operation
-	IPs []string
-}
 
 // rule represents an authorization rule to be used for Allow & Deny
 // policies on fields in a request & a session
@@ -37,7 +19,7 @@ type rule struct {
 }
 
 // NewRequestRule creates a new request based authorization rule
-func NewRequestRule(opts RequestRuleOptions, ipParser ipapi.RealClientIPParser) (Rule, error) {
+func NewRequestRule(opts options.RequestRule, ipParser ipapi.RealClientIPParser) (Rule, error) {
 	if !(opts.Policy == AllowPolicy || opts.Policy == DenyPolicy || opts.Policy == AuthPolicy) {
 		return nil, fmt.Errorf("invalid policy type: %s", opts.Policy)
 	}

--- a/pkg/authorization/rule.go
+++ b/pkg/authorization/rule.go
@@ -1,0 +1,83 @@
+package authorization
+
+import (
+	"fmt"
+	"net/http"
+
+	ipapi "github.com/oauth2-proxy/oauth2-proxy/pkg/apis/ip"
+	"github.com/oauth2-proxy/oauth2-proxy/pkg/apis/sessions"
+	"github.com/oauth2-proxy/oauth2-proxy/pkg/authorization/conditions"
+)
+
+// RequestRuleOptions are the various options to configure a request only
+// based Rule that occurs before authentication
+type RequestRuleOptions struct {
+	// ID is a unique ID for the rule
+	ID string
+
+	// policy is either Allow or Deny
+	Policy Policy
+
+	// Path is a regex that will be tested against the req.URL.Path
+	Path string
+
+	// methods is list of HTTP methods. This group is an OR operation.
+	Methods []string
+
+	// IPS is a list of IPs or CIDRs. This group is an OR operation
+	IPs []string
+}
+
+// rule represents an authorization rule to be used for Allow & Deny
+// policies on fields in a request & a session
+type rule struct {
+	id         string
+	policy     Policy
+	conditions []conditions.Condition
+}
+
+// NewRequestRule creates a new request based authorization rule
+func NewRequestRule(opts RequestRuleOptions, ipParser ipapi.RealClientIPParser) (Rule, error) {
+	if !(opts.Policy == AllowPolicy || opts.Policy == DenyPolicy || opts.Policy == AuthPolicy) {
+		return nil, fmt.Errorf("invalid policy type: %s", opts.Policy)
+	}
+
+	var conds []conditions.Condition
+
+	if opts.Path != "" {
+		pathCond, err := conditions.NewPath(opts.Path)
+		if err != nil {
+			return nil, err
+		}
+		conds = append(conds, pathCond)
+	}
+
+	if opts.Methods != nil {
+		conds = append(conds, conditions.NewMethods(opts.Methods))
+	}
+
+	if opts.IPs != nil {
+		nsCond, err := conditions.NewIPs(opts.IPs, ipParser)
+		if err != nil {
+			return nil, err
+		}
+		conds = append(conds, nsCond)
+	}
+
+	return &rule{
+		id:         opts.ID,
+		policy:     opts.Policy,
+		conditions: conds,
+	}, nil
+}
+
+// Match checks if a rules could match the conditions. If yes, it returns
+// the policy of the rule. If no, it returns SkipPolicy
+func (r *rule) Match(req *http.Request, ss *sessions.SessionState) Policy {
+	for _, c := range r.conditions {
+		if !c.Match(req, ss) {
+			return SkipPolicy
+		}
+	}
+	return r.policy
+}

--- a/pkg/authorization/rules_engine.go
+++ b/pkg/authorization/rules_engine.go
@@ -14,16 +14,11 @@ type engine struct {
 }
 
 // NewRulesEngine builds a RulesEngine for HTTP request based authZ
-func NewRulesEngine(defaultPolicy Policy) RulesEngine {
+func NewRulesEngine(rules []Rule, defaultPolicy Policy) RulesEngine {
 	return &engine{
-		rules:         []Rule{},
+		rules:         rules,
 		defaultPolicy: defaultPolicy,
 	}
-}
-
-// AddRule adds an authorization Rule to our RulesEngine.
-func (e *engine) AddRule(rule Rule) {
-	e.rules = append(e.rules, rule)
 }
 
 // Match compares an http.Request & SessionState against our list of rules for

--- a/pkg/authorization/rules_engine.go
+++ b/pkg/authorization/rules_engine.go
@@ -1,0 +1,42 @@
+package authorization
+
+import (
+	"net/http"
+
+	"github.com/oauth2-proxy/oauth2-proxy/pkg/apis/sessions"
+)
+
+// engine manages authorization Rules and which requests
+// pass or fail authorization
+type engine struct {
+	rules         []Rule
+	defaultPolicy Policy
+}
+
+// NewRulesEngine builds a RulesEngine for HTTP request based authZ
+func NewRulesEngine(defaultPolicy Policy) RulesEngine {
+	return &engine{
+		rules:         []Rule{},
+		defaultPolicy: defaultPolicy,
+	}
+}
+
+// AddRule adds an authorization Rule to our RulesEngine.
+func (e *engine) AddRule(rule Rule) {
+	e.rules = append(e.rules, rule)
+}
+
+// Match compares an http.Request & SessionState against our list of rules for
+// a given policy. Per rule, if a SkipPolicy is encountered it keeps going.
+// Otherwise it returns the policy of the matched rule
+func (e *engine) Match(req *http.Request, ss *sessions.SessionState) Policy {
+	for _, rule := range e.rules {
+		match := rule.Match(req, ss)
+		if match == SkipPolicy {
+			continue
+		} else {
+			return match
+		}
+	}
+	return e.defaultPolicy
+}

--- a/pkg/validation/authorization.go
+++ b/pkg/validation/authorization.go
@@ -1,0 +1,122 @@
+package validation
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	ipapi "github.com/oauth2-proxy/oauth2-proxy/pkg/apis/ip"
+	"github.com/oauth2-proxy/oauth2-proxy/pkg/apis/options"
+	"github.com/oauth2-proxy/oauth2-proxy/pkg/authorization"
+)
+
+func validateAuthorization(o *options.Options) []string {
+	msgs := []string{}
+
+	re := authorization.NewRulesEngine(authorization.AuthPolicy)
+	msgs = append(msgs, validateRoutes(&o.Authorization, re)...)
+	msgs = append(msgs, validateRegexes(&o.Authorization, re)...)
+	msgs = append(msgs, validatePreflight(&o.Authorization, re)...)
+	msgs = append(msgs, validateTrustedIPs(&o.Authorization, re, o.GetRealClientIPParser())...)
+
+	if len(o.Authorization.TrustedIPs) > 0 && o.ReverseProxy {
+		_, err := fmt.Fprintln(os.Stderr, "WARNING: mixing --trusted-ip with --reverse-proxy is a potential security vulnerability. An attacker can inject a trusted IP into an X-Real-IP or X-Forwarded-For header if they aren't properly protected outside of oauth2-proxy")
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	o.Authorization.SetRulesEngine(re)
+	return msgs
+}
+
+// validateRoutes validates method=path routes passed with options.Authorization.SkipAuthRoutes
+func validateRoutes(o *options.Authorization, e authorization.RulesEngine) []string {
+	msgs := []string{}
+	for i, route := range o.SkipAuthRoutes {
+		parts := strings.Split(route, "=")
+		if len(parts) == 1 {
+			rule, err := authorization.NewRequestRule(authorization.RequestRuleOptions{
+				ID:     fmt.Sprintf("route-%d", i),
+				Policy: authorization.AllowPolicy,
+				Path:   parts[0],
+			}, nil)
+			if err != nil {
+				msgs = append(msgs, fmt.Sprintf("%s", err))
+				continue
+			}
+
+			e.AddRule(rule)
+		} else {
+			method := parts[0]
+			regex := strings.Join(parts[1:], "=")
+			rule, err := authorization.NewRequestRule(authorization.RequestRuleOptions{
+				ID:      fmt.Sprintf("route-%d", i),
+				Policy:  authorization.AllowPolicy,
+				Path:    regex,
+				Methods: []string{method},
+			}, nil)
+			if err != nil {
+				msgs = append(msgs, fmt.Sprintf("%s", err))
+				continue
+			}
+
+			e.AddRule(rule)
+		}
+	}
+	return msgs
+}
+
+// validateRegex validates regex paths passed with options.Allowlist.SkipAuthRegex
+func validateRegexes(o *options.Authorization, e authorization.RulesEngine) []string {
+	msgs := []string{}
+	for i, regex := range o.SkipAuthRegex {
+		rule, err := authorization.NewRequestRule(authorization.RequestRuleOptions{
+			ID:     fmt.Sprintf("regex-%d", i),
+			Policy: authorization.AllowPolicy,
+			Path:   regex,
+		}, nil)
+		if err != nil {
+			msgs = append(msgs, fmt.Sprintf("%s", err))
+			continue
+		}
+
+		e.AddRule(rule)
+	}
+	return msgs
+}
+
+// validatePreflight converts the options.Authorization.SkipAuthPreflight into an
+// OPTIONS=.* route rule
+func validatePreflight(o *options.Authorization, e authorization.RulesEngine) []string {
+	msgs := []string{}
+	if o.SkipAuthPreflight {
+		rule, err := authorization.NewRequestRule(authorization.RequestRuleOptions{
+			ID:      "preflight",
+			Policy:  authorization.AllowPolicy,
+			Methods: []string{"OPTIONS"},
+		}, nil)
+		if err != nil {
+			msgs = append(msgs, fmt.Sprintf("%s", err))
+			return msgs
+		}
+
+		e.AddRule(rule)
+	}
+	return msgs
+}
+
+// validateTrustedIPs validates IP/CIDRs for IP based allowlists
+func validateTrustedIPs(o *options.Authorization, e authorization.RulesEngine, parser ipapi.RealClientIPParser) []string {
+	rule, err := authorization.NewRequestRule(authorization.RequestRuleOptions{
+		ID:     "trustedIP",
+		Policy: authorization.AllowPolicy,
+		IPs:    o.TrustedIPs,
+	}, parser)
+	if err != nil {
+		return []string{fmt.Sprintf("%s", err)}
+	}
+
+	e.AddRule(rule)
+	return []string{}
+}

--- a/pkg/validation/authorization.go
+++ b/pkg/validation/authorization.go
@@ -2,121 +2,47 @@ package validation
 
 import (
 	"fmt"
-	"os"
-	"strings"
+	"regexp"
 
-	ipapi "github.com/oauth2-proxy/oauth2-proxy/pkg/apis/ip"
 	"github.com/oauth2-proxy/oauth2-proxy/pkg/apis/options"
 	"github.com/oauth2-proxy/oauth2-proxy/pkg/authorization"
+	"github.com/oauth2-proxy/oauth2-proxy/pkg/ip"
 )
 
-func validateAuthorization(o *options.Options) []string {
+func validateAuthorizationRules(rules options.RequestRules) []string {
 	msgs := []string{}
 
-	re := authorization.NewRulesEngine(authorization.AuthPolicy)
-	msgs = append(msgs, validateRoutes(&o.Authorization, re)...)
-	msgs = append(msgs, validateRegexes(&o.Authorization, re)...)
-	msgs = append(msgs, validatePreflight(&o.Authorization, re)...)
-	msgs = append(msgs, validateTrustedIPs(&o.Authorization, re, o.GetRealClientIPParser())...)
-
-	if len(o.Authorization.TrustedIPs) > 0 && o.ReverseProxy {
-		_, err := fmt.Fprintln(os.Stderr, "WARNING: mixing --trusted-ip with --reverse-proxy is a potential security vulnerability. An attacker can inject a trusted IP into an X-Real-IP or X-Forwarded-For header if they aren't properly protected outside of oauth2-proxy")
-		if err != nil {
-			panic(err)
-		}
+	for _, rule := range rules {
+		msgs = append(msgs, validateRequestRule(rule)...)
 	}
 
-	o.Authorization.SetRulesEngine(re)
 	return msgs
 }
 
-// validateRoutes validates method=path routes passed with options.Authorization.SkipAuthRoutes
-func validateRoutes(o *options.Authorization, e authorization.RulesEngine) []string {
+func validateRequestRule(rule options.RequestRule) []string {
 	msgs := []string{}
-	for i, route := range o.SkipAuthRoutes {
-		parts := strings.Split(route, "=")
-		if len(parts) == 1 {
-			rule, err := authorization.NewRequestRule(authorization.RequestRuleOptions{
-				ID:     fmt.Sprintf("route-%d", i),
-				Policy: authorization.AllowPolicy,
-				Path:   parts[0],
-			}, nil)
-			if err != nil {
-				msgs = append(msgs, fmt.Sprintf("%s", err))
-				continue
-			}
 
-			e.AddRule(rule)
-		} else {
-			method := parts[0]
-			regex := strings.Join(parts[1:], "=")
-			rule, err := authorization.NewRequestRule(authorization.RequestRuleOptions{
-				ID:      fmt.Sprintf("route-%d", i),
-				Policy:  authorization.AllowPolicy,
-				Path:    regex,
-				Methods: []string{method},
-			}, nil)
-			if err != nil {
-				msgs = append(msgs, fmt.Sprintf("%s", err))
-				continue
-			}
-
-			e.AddRule(rule)
-		}
+	if rule.ID == "" {
+		msgs = append(msgs, "rule has empty id: ids are required for all request rules")
 	}
-	return msgs
-}
 
-// validateRegex validates regex paths passed with options.Allowlist.SkipAuthRegex
-func validateRegexes(o *options.Authorization, e authorization.RulesEngine) []string {
-	msgs := []string{}
-	for i, regex := range o.SkipAuthRegex {
-		rule, err := authorization.NewRequestRule(authorization.RequestRuleOptions{
-			ID:     fmt.Sprintf("regex-%d", i),
-			Policy: authorization.AllowPolicy,
-			Path:   regex,
-		}, nil)
-		if err != nil {
-			msgs = append(msgs, fmt.Sprintf("%s", err))
-			continue
-		}
-
-		e.AddRule(rule)
+	if !(rule.Policy == authorization.AllowPolicy ||
+		rule.Policy == authorization.DenyPolicy ||
+		rule.Policy == authorization.AuthPolicy) {
+		msgs = append(msgs, fmt.Sprintf("invalid policy type: %s", rule.Policy))
 	}
-	return msgs
-}
 
-// validatePreflight converts the options.Authorization.SkipAuthPreflight into an
-// OPTIONS=.* route rule
-func validatePreflight(o *options.Authorization, e authorization.RulesEngine) []string {
-	msgs := []string{}
-	if o.SkipAuthPreflight {
-		rule, err := authorization.NewRequestRule(authorization.RequestRuleOptions{
-			ID:      "preflight",
-			Policy:  authorization.AllowPolicy,
-			Methods: []string{"OPTIONS"},
-		}, nil)
-		if err != nil {
-			msgs = append(msgs, fmt.Sprintf("%s", err))
-			return msgs
-		}
-
-		e.AddRule(rule)
-	}
-	return msgs
-}
-
-// validateTrustedIPs validates IP/CIDRs for IP based allowlists
-func validateTrustedIPs(o *options.Authorization, e authorization.RulesEngine, parser ipapi.RealClientIPParser) []string {
-	rule, err := authorization.NewRequestRule(authorization.RequestRuleOptions{
-		ID:     "trustedIP",
-		Policy: authorization.AllowPolicy,
-		IPs:    o.TrustedIPs,
-	}, parser)
+	_, err := regexp.Compile(rule.Path)
 	if err != nil {
-		return []string{fmt.Sprintf("%s", err)}
+		msgs = append(msgs,
+			fmt.Sprintf("unable to compile request rule path regex /%s/: %v", rule.Path, err))
 	}
 
-	e.AddRule(rule)
-	return []string{}
+	for _, ruleIP := range rule.IPs {
+		if ipNet := ip.ParseIPNet(ruleIP); ipNet == nil {
+			msgs = append(msgs, fmt.Sprintf("could not parse trusted IP network(s): %s", ruleIP))
+		}
+	}
+
+	return msgs
 }

--- a/pkg/validation/authorization_test.go
+++ b/pkg/validation/authorization_test.go
@@ -1,0 +1,291 @@
+package validation
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/oauth2-proxy/oauth2-proxy/pkg/apis/options"
+	"github.com/oauth2-proxy/oauth2-proxy/pkg/authorization"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_validateAuthorization(t *testing.T) {
+	opts := &options.Options{
+		Authorization: options.Authorization{
+			SkipAuthRoutes: []string{
+				"POST=/foo/bar",
+				"PUT=^/foo/bar$",
+			},
+			SkipAuthRegex:     []string{"/foo/baz"},
+			SkipAuthPreflight: true,
+			TrustedIPs: []string{
+				"10.32.0.1/32",
+				"43.36.201.0/24",
+			},
+		},
+	}
+	assert.Equal(t, []string{}, validateAuthorization(opts))
+
+	re := opts.Authorization.GetRulesEngine()
+	// Trusted via SkipAuthRoutes
+	routeReq := &http.Request{
+		Method: "POST",
+		URL: &url.URL{
+			Path: "/foo/bar",
+		},
+		RemoteAddr: "1.2.3.4:443",
+	}
+	assert.Equal(t, authorization.AllowPolicy, re.Match(routeReq, nil))
+
+	// Trusted via SkipAuthRegex
+	regexReq := &http.Request{
+		Method: "GET",
+		URL: &url.URL{
+			Path: "/foo/baz",
+		},
+		RemoteAddr: "1.2.3.4:443",
+	}
+	assert.Equal(t, authorization.AllowPolicy, re.Match(regexReq, nil))
+
+	// Trusted via SkipAuthPreflight
+	preflightReq := &http.Request{
+		Method: "OPTIONS",
+		URL: &url.URL{
+			Path: "/any/path/works",
+		},
+		RemoteAddr: "1.2.3.4:443",
+	}
+	assert.Equal(t, authorization.AllowPolicy, re.Match(preflightReq, nil))
+
+	// Trusted via TrustedIPs
+	ipReq := &http.Request{
+		Method: "POST",
+		URL: &url.URL{
+			Path: "/super/secret/route",
+		},
+		RemoteAddr: "10.32.0.1:443",
+	}
+	assert.Equal(t, authorization.AllowPolicy, re.Match(ipReq, nil))
+
+	// Not trusted
+	authReq := &http.Request{
+		Method: "POST",
+		URL: &url.URL{
+			Path: "/super/secret/route",
+		},
+		RemoteAddr: "1.2.3.4:443",
+	}
+	assert.Equal(t, authorization.AuthPolicy, re.Match(authReq, nil))
+}
+
+func Test_validateRoutes(t *testing.T) {
+	testCases := map[string]struct {
+		Regexes  []string
+		Expected []string
+	}{
+		"Non-overlapping regex routes": {
+			Regexes: []string{
+				"/foo",
+				"POST=/foo/bar",
+				"PUT=^/foo/bar$",
+				"DELETE=/crazy/(?:regex)?/[^/]+/stuff$",
+			},
+			Expected: []string{},
+		},
+		"Overlapping regex routes removes duplicates": {
+			Regexes: []string{
+				"GET=/foo",
+				"POST=/foo/bar",
+				"^/foo/bar$",
+				"/crazy/(?:regex)?/[^/]+/stuff$",
+				"GET=/foo",
+			},
+			Expected: []string{},
+		},
+		"Bad regexes do not compile": {
+			Regexes: []string{
+				"POST=/(foo",
+				"OPTIONS=/foo/bar)",
+				"GET=^]/foo/bar[$",
+				"GET=^]/foo/bar[$",
+			},
+			Expected: []string{
+				"error compiling regex //(foo/: error parsing regexp: missing closing ): `/(foo`",
+				"error compiling regex //foo/bar)/: error parsing regexp: unexpected ): `/foo/bar)`",
+				"error compiling regex /^]/foo/bar[$/: error parsing regexp: missing closing ]: `[$`",
+				"error compiling regex /^]/foo/bar[$/: error parsing regexp: missing closing ]: `[$`",
+			},
+		},
+	}
+
+	for testName, tc := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			re := authorization.NewRulesEngine(authorization.AuthPolicy)
+			opts := &options.Authorization{
+				SkipAuthRoutes: tc.Regexes,
+			}
+			msgs := validateRoutes(opts, re)
+			assert.Equal(t, tc.Expected, msgs)
+			// Confirm validator populated the authorization.Routes
+			if len(msgs) == 0 {
+				req := &http.Request{
+					Method: "GET",
+					URL: &url.URL{
+						Path: "/foo",
+					},
+				}
+				assert.Equal(t, authorization.AllowPolicy, re.Match(req, nil))
+				req.URL.Path = "/wrong"
+				assert.Equal(t, authorization.AuthPolicy, re.Match(req, nil))
+			}
+		})
+	}
+}
+
+func Test_validateRegexes(t *testing.T) {
+	testCases := map[string]struct {
+		Regexes  []string
+		Expected []string
+	}{
+		"Non-overlapping regex routes": {
+			Regexes: []string{
+				"/foo",
+				"/foo/bar",
+				"^/foo/bar$",
+				"/crazy/(?:regex)?/[^/]+/stuff$",
+			},
+			Expected: []string{},
+		},
+		"Overlapping regex routes removes duplicates": {
+			Regexes: []string{
+				"/foo",
+				"/foo/bar",
+				"^/foo/bar$",
+				"/crazy/(?:regex)?/[^/]+/stuff$",
+				"^/foo/bar$",
+			},
+			Expected: []string{},
+		},
+		"Bad regexes do not compile": {
+			Regexes: []string{
+				"/(foo",
+				"/foo/bar)",
+				"^]/foo/bar[$",
+				"^]/foo/bar[$",
+			},
+			Expected: []string{
+				"error compiling regex //(foo/: error parsing regexp: missing closing ): `/(foo`",
+				"error compiling regex //foo/bar)/: error parsing regexp: unexpected ): `/foo/bar)`",
+				"error compiling regex /^]/foo/bar[$/: error parsing regexp: missing closing ]: `[$`",
+				"error compiling regex /^]/foo/bar[$/: error parsing regexp: missing closing ]: `[$`",
+			},
+		},
+	}
+
+	for testName, tc := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			re := authorization.NewRulesEngine(authorization.AuthPolicy)
+			opts := &options.Authorization{
+				SkipAuthRegex: tc.Regexes,
+			}
+			msgs := validateRegexes(opts, re)
+			assert.Equal(t, tc.Expected, msgs)
+			// Confirm validator populated the authorization.Routes
+			if len(msgs) == 0 {
+				req := &http.Request{
+					URL: &url.URL{
+						Path: "/foo",
+					},
+				}
+				assert.Equal(t, authorization.AllowPolicy, re.Match(req, nil))
+				req.URL.Path = "/wrong"
+				assert.Equal(t, authorization.AuthPolicy, re.Match(req, nil))
+			}
+		})
+	}
+}
+
+func Test_validatePreflight(t *testing.T) {
+	for _, skipped := range []bool{true, false} {
+		t.Run(fmt.Sprintf("%t", skipped), func(t *testing.T) {
+			re := authorization.NewRulesEngine(authorization.AuthPolicy)
+			opts := &options.Authorization{
+				SkipAuthPreflight: skipped,
+			}
+			msgs := validatePreflight(opts, re)
+			assert.Equal(t, msgs, []string{})
+
+			optionsReq := &http.Request{
+				Method: "OPTIONS",
+				URL: &url.URL{
+					Path: "/any/path/works",
+				},
+			}
+			assert.Equal(t, skipped, re.Match(optionsReq, nil) == authorization.AllowPolicy)
+
+			getReq := &http.Request{
+				Method: "GET",
+				URL: &url.URL{
+					Path: "/any/path/works",
+				},
+			}
+			assert.Equal(t, authorization.AuthPolicy, re.Match(getReq, nil))
+		})
+	}
+}
+
+func Test_validateTrustedIPs(t *testing.T) {
+	testCases := map[string]struct {
+		TrustedIPs []string
+		RequestIP  string
+		Expected   []string
+	}{
+		"Non-overlapping valid IPs": {
+			TrustedIPs: []string{
+				"127.0.0.1",
+				"10.32.0.1/32",
+				"43.36.201.0/24",
+				"::1",
+				"2a12:105:ee7:9234:0:0:0:0/64",
+			},
+			RequestIP: "43.36.201.100",
+			Expected:  []string{},
+		},
+		"Overlapping valid IPs": {
+			TrustedIPs: []string{
+				"135.180.78.199",
+				"135.180.78.199/32",
+				"d910:a5a1:16f8:ddf5:e5b9:5cef:a65e:41f4",
+				"d910:a5a1:16f8:ddf5:e5b9:5cef:a65e:41f4/128",
+			},
+			RequestIP: "135.180.78.199",
+			Expected:  []string{},
+		},
+		"Invalid IPs": {
+			TrustedIPs: []string{"[::1]", "alkwlkbn/32"},
+			Expected: []string{
+				"could not parse trusted IP network(s): [::1], alkwlkbn/32",
+			},
+		},
+	}
+
+	for testName, tc := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			re := authorization.NewRulesEngine(authorization.AuthPolicy)
+			opts := &options.Authorization{
+				TrustedIPs: tc.TrustedIPs,
+			}
+			msgs := validateTrustedIPs(opts, re, nil)
+			assert.Equal(t, tc.Expected, msgs)
+			// Confirm validator populated the authorization.IPs
+			if len(msgs) == 0 {
+				req := &http.Request{
+					RemoteAddr: fmt.Sprintf("%s:443", tc.RequestIP),
+				}
+				assert.Equal(t, authorization.AllowPolicy, re.Match(req, nil))
+			}
+		})
+	}
+}

--- a/pkg/validation/authorization_test.go
+++ b/pkg/validation/authorization_test.go
@@ -13,7 +13,7 @@ import (
 
 func Test_validateAuthorization(t *testing.T) {
 	opts := &options.Options{
-		Authorization: options.Authorization{
+		Authorization: options.LegacyAuthorization{
 			SkipAuthRoutes: []string{
 				"POST=/foo/bar",
 				"PUT=^/foo/bar$",
@@ -123,7 +123,7 @@ func Test_validateRoutes(t *testing.T) {
 	for testName, tc := range testCases {
 		t.Run(testName, func(t *testing.T) {
 			re := authorization.NewRulesEngine(authorization.AuthPolicy)
-			opts := &options.Authorization{
+			opts := &options.LegacyAuthorization{
 				SkipAuthRoutes: tc.Regexes,
 			}
 			msgs := validateRoutes(opts, re)
@@ -187,7 +187,7 @@ func Test_validateRegexes(t *testing.T) {
 	for testName, tc := range testCases {
 		t.Run(testName, func(t *testing.T) {
 			re := authorization.NewRulesEngine(authorization.AuthPolicy)
-			opts := &options.Authorization{
+			opts := &options.LegacyAuthorization{
 				SkipAuthRegex: tc.Regexes,
 			}
 			msgs := validateRegexes(opts, re)
@@ -211,7 +211,7 @@ func Test_validatePreflight(t *testing.T) {
 	for _, skipped := range []bool{true, false} {
 		t.Run(fmt.Sprintf("%t", skipped), func(t *testing.T) {
 			re := authorization.NewRulesEngine(authorization.AuthPolicy)
-			opts := &options.Authorization{
+			opts := &options.LegacyAuthorization{
 				SkipAuthPreflight: skipped,
 			}
 			msgs := validatePreflight(opts, re)
@@ -274,7 +274,7 @@ func Test_validateTrustedIPs(t *testing.T) {
 	for testName, tc := range testCases {
 		t.Run(testName, func(t *testing.T) {
 			re := authorization.NewRulesEngine(authorization.AuthPolicy)
-			opts := &options.Authorization{
+			opts := &options.LegacyAuthorization{
 				TrustedIPs: tc.TrustedIPs,
 			}
 			msgs := validateTrustedIPs(opts, re, nil)

--- a/pkg/validation/options.go
+++ b/pkg/validation/options.go
@@ -27,6 +27,7 @@ import (
 func Validate(o *options.Options) error {
 	msgs := validateCookie(o.Cookie)
 	msgs = append(msgs, validateSessionCookieMinimal(o)...)
+	msgs = append(msgs, validateAuthorizationRules(o.RequestAuthZRules)...)
 
 	if o.SSLInsecureSkipVerify {
 		insecureTransport := &http.Transport{
@@ -206,9 +207,6 @@ func Validate(o *options.Options) error {
 			return ip.GetClientString(o.GetRealClientIPParser(), r, false)
 		})
 	}
-
-	// Do this after ReverseProxy validation so RealClientIPParser is set
-	msgs = append(msgs, validateAuthorization(o)...)
 
 	if len(msgs) != 0 {
 		return fmt.Errorf("invalid configuration:\n  %s",

--- a/pkg/validation/options.go
+++ b/pkg/validation/options.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"regexp"
 	"strings"
 
 	"github.com/coreos/go-oidc"
@@ -178,14 +177,6 @@ func Validate(o *options.Options) error {
 
 	msgs = append(msgs, validateUpstreams(o.UpstreamServers)...)
 
-	for _, u := range o.SkipAuthRegex {
-		compiledRegex, err := regexp.Compile(u)
-		if err != nil {
-			msgs = append(msgs, fmt.Sprintf("error compiling regex=%q %s", u, err))
-			continue
-		}
-		o.SetCompiledRegex(append(o.GetCompiledRegex(), compiledRegex))
-	}
 	msgs = parseProviderInfo(o, msgs)
 
 	if len(o.GoogleGroups) > 0 || o.GoogleAdminEmail != "" || o.GoogleServiceAccountJSON != "" {
@@ -216,15 +207,8 @@ func Validate(o *options.Options) error {
 		})
 	}
 
-	if len(o.TrustedIPs) > 0 && o.ReverseProxy {
-		fmt.Fprintln(os.Stderr, "WARNING: trusting of IPs with --reverse-proxy poses risks if a header spoofing attack is possible.")
-	}
-
-	for i, ipStr := range o.TrustedIPs {
-		if nil == ip.ParseIPNet(ipStr) {
-			msgs = append(msgs, fmt.Sprintf("trusted_ips[%d] (%s) could not be recognized", i, ipStr))
-		}
-	}
+	// Do this after ReverseProxy validation so RealClientIPParser is set
+	msgs = append(msgs, validateAuthorization(o)...)
 
 	if len(msgs) != 0 {
 		return fmt.Errorf("invalid configuration:\n  %s",


### PR DESCRIPTION
## Description

Adds a generic rules engine that handles our existing AuthN exception cases (path regex & IPs) with the addition of HTTP Methods.

Generic for future support for authorization rules (IE Group membership from claim for access to a given path).

UPDATE: We may completely throw this out for https://www.openpolicyagent.org/docs/latest/integration/#integrating-with-the-go-api

## Motivation and Context

## How Has This Been Tested?

Unit tests. TODO - Interactive tests

## Checklist:


- [x] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
