### PR TITLE
Fix time issue causing finicky failures in logging tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ## Changes since v6.0.0
 
+- [#689](https://github.com/oauth2-proxy/oauth2-proxy/pull/689) Fix finicky logging_handler_test from time drift (@NickMeves)
 - [#699](https://github.com/oauth2-proxy/oauth2-proxy/pull/699) Align persistence ginkgo tests with conventions (@NickMeves)
 - [#696](https://github.com/oauth2-proxy/oauth2-proxy/pull/696) Preserve query when building redirect
 - [#561](https://github.com/oauth2-proxy/oauth2-proxy/pull/561) Refactor provider URLs to package level vars (@JoelSpeed)


### PR DESCRIPTION
Fixes a time drift issue in the logging_handler_test that recently caused a master build to fail.

## Description

Allows up to 2 seconds of time drift in the expected output to handle slow CI systems (or tests that kick off near a second turn) without needing to monkey patch `time.Now`

UPDATE - removes time from the test logging template instead

## Motivation and Context

No finicky tests failing builds

## How Has This Been Tested?

Unit tests.

Note, in fixing this, I caught and fixed some tests in the test table that weren't testing as intended.

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
