### PR TITLE
Preserve query when building redirect (fix for #695)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ## Changes since v6.0.0
 
+- [#696](https://github.com/oauth2-proxy/oauth2-proxy/pull/696) Preserve query when building redirect
 - [#561](https://github.com/oauth2-proxy/oauth2-proxy/pull/561) Refactor provider URLs to package level vars (@JoelSpeed)
 - [#682](https://github.com/oauth2-proxy/oauth2-proxy/pull/682) Refactor persistent session store session ticket management (@NickMeves)
 - [#688](https://github.com/oauth2-proxy/oauth2-proxy/pull/688) Refactor session loading to make use of middleware pattern (@JoelSpeed)

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -454,7 +454,8 @@ func (p *OAuthProxy) GetRedirect(req *http.Request) (redirect string, err error)
 		redirect = req.Form.Get("rd")
 	}
 	if !p.IsValidRedirect(redirect) {
-		redirect = req.URL.Path
+		// Use RequestURI to preserve ?query
+		redirect = req.URL.RequestURI()
 		if strings.HasPrefix(redirect, p.ProxyPrefix) {
 			redirect = "/"
 		}

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -1679,6 +1679,11 @@ func TestGetRedirect(t *testing.T) {
 			expectedRedirect: "/foo/bar",
 		},
 		{
+			name:             "request with query preserves query",
+			url:              "/foo?bar",
+			expectedRedirect: "/foo?bar",
+		},
+		{
 			name:             "request under ProxyPrefix redirects to root",
 			url:              proxy.ProxyPrefix + "/foo/bar",
 			expectedRedirect: "/",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Use URL.RequestURI() in GetRedirect() to preserve any query string

Note: If you cherry-pick just the unit test from this branch the UT will express the same behavior seen in https://github.com/oauth2-proxy/oauth2-proxy/issues/695

## Motivation and Context

Fixes:  https://github.com/oauth2-proxy/oauth2-proxy/issues/695

## How Has This Been Tested?

Added unit test for a request with querystring present.
Also built a new oauth2-proxy with these changes and ran it in my env. Confirmed that the redirect works as expected behind the reverse proxy (as described in the linked bug).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.

I'm not sure if these checkbox items apply, but let me know.