### PR TITLE
Allow OIDC Bearer Tokens without emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [#718](https://github.com/oauth2-proxy/oauth2-proxy/pull/718) Allow Logging to stdout with separate Error Log Channel
 - [#690](https://github.com/oauth2-proxy/oauth2-proxy/pull/690) Address GoSec security findings & remediate (@NickMeves)
 - [#689](https://github.com/oauth2-proxy/oauth2-proxy/pull/689) Fix finicky logging_handler_test from time drift (@NickMeves)
+- [#700](https://github.com/oauth2-proxy/oauth2-proxy/pull/700) Allow OIDC Bearer auth IDTokens to have empty email claim & profile URL (@NickMeves)
 - [#699](https://github.com/oauth2-proxy/oauth2-proxy/pull/699) Align persistence ginkgo tests with conventions (@NickMeves)
 - [#696](https://github.com/oauth2-proxy/oauth2-proxy/pull/696) Preserve query when building redirect
 - [#561](https://github.com/oauth2-proxy/oauth2-proxy/pull/561) Refactor provider URLs to package level vars (@JoelSpeed)

--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -231,7 +231,6 @@ func getOIDCHeader(accessToken string) http.Header {
 }
 
 func (p *OIDCProvider) findClaimsFromIDToken(ctx context.Context, idToken *oidc.IDToken, accessToken string, profileURL string) (*OIDCClaims, error) {
-
 	claims := &OIDCClaims{}
 	// Extract default claims.
 	if err := idToken.Claims(&claims); err != nil {
@@ -250,7 +249,8 @@ func (p *OIDCProvider) findClaimsFromIDToken(ctx context.Context, idToken *oidc.
 	// userID claim was not present or was empty in the ID Token
 	if claims.UserID == "" {
 		if profileURL == "" {
-			return nil, fmt.Errorf("id_token did not contain user ID claim (%q)", p.UserIDClaim)
+			claims.UserID = claims.Subject
+			return claims, nil
 		}
 
 		// If the userinfo endpoint profileURL is defined, then there is a chance the userinfo


### PR DESCRIPTION
This reverts to functionality before #499 where an OIDC
provider could be used with `--skip-jwt-bearer-tokens` and
tokens without an email or profileURL would still be valid.
This logic mirrors `middleware.createSessionStateFromBearerToken`
which used to be the universal logic before #499.

## Motivation and Context

Machine JWTs or applications that have JWTs without emails that used `--skip-jwt-bearer-token` to send an IDToken directly in a header to be validated (IE an OIDC PKSE CLI application that gets the IDToken client side) -- used to follow the same universal codepath that turned a generic IDToken into a session.

#499 Added richer support for OIDC claims and profileURL lookups, but it forced expectations on the format of the JWT that was stricter than before in `--skip-jwt-bearer-token` mode.

This change allows these v5.1.0 type tokens again instead of erroring out.

## How Has This Been Tested?

Unit Tests (+ new OIDC Bearer Token unit tests added for existing functionality)

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
