### PR TITLE
contrib: Add Jsonnet and manifests for Kubernetes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+tmp
 oauth2-proxy
 vendor
 dist

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,0 +1,12 @@
+# Jsonnet
+
+```
+jb install github.com/oauth2-proxy/oauth2-proxy/contrib/jsonnet
+```
+
+See [jsonnet/examples](jsonnet/examples) for examples.
+
+# Kustomize
+
+See [kustomization.yaml](kustomization.yaml.example) example.
+

--- a/contrib/jsonnet/examples/basic.jsonnet
+++ b/contrib/jsonnet/examples/basic.jsonnet
@@ -1,0 +1,65 @@
+local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
+local op = import 'github.com/oauth2-proxy/oauth2-proxy/contrib/jsonnet/oauth2-proxy.libsonnet';
+local deployment = k.apps.v1.deployment;
+local container = deployment.mixin.spec.template.spec.containersType;
+local envVar = container.envType;
+local resourceRequirements = container.mixin.resourcesType;
+local secret = k.core.v1.secret;
+
+local oauth2Proxy = op {
+  _config+:: {
+    namespace: 'oauth2-proxy',
+
+    oauth2Proxy+:: {
+      name: 'oauth2-proxy',
+      version: 'v6.0.0',
+
+      configToml: |||
+        client_id         = "123456.apps.googleusercontent.com"
+        upstreams         = ["yourapp:80"]
+      |||,
+
+      env: [
+        envVar.fromSecretRef(
+          'OAUTH2_PROXY_CLIENT_SECRET',
+          secretRefName=$._config.oauth2Proxy.name,
+          secretRefKey='clientSecret'
+        ),
+        envVar.fromSecretRef(
+          'OAUTH2_PROXY_COOKIE_SECRET',
+          secretRefName=$._config.oauth2Proxy.name,
+          secretRefKey='cookieSecret'
+        ),
+      ],
+    },
+  },
+
+  oauth2Proxy+: {
+    secret:
+      secret.new($._config.oauth2Proxy.name, {
+        clientSecret: std.base64('xxxxxxxxxx'),
+        cookieSecret: std.base64('xxxxxxxxxx'),
+      }) +
+      secret.mixin.metadata.withNamespace($._config.oauth2Proxy.namespace) +
+      secret.mixin.metadata.withLabels($._config.oauth2Proxy.commonLabels),
+
+    container+::
+      container.mixin.resources.withLimits({ cpu: '100m', memory: '100Mi' }) +
+      container.mixin.resources.withRequests({ cpu: '100m', memory: '100Mi' }),
+
+    deployment+:
+      deployment.mixin.spec.withReplicas(3) +
+      deployment.mixin.spec.template.metadata.withAnnotationsMixin({
+        'checksum/oauth2-proxy-secret': std.md5(std.toString($.oauth2Proxy.secret)),
+      }),
+  },
+}.oauth2Proxy;
+
+k.core.v1.list.new([
+  oauth2Proxy.configMap,
+  oauth2Proxy.deployment,
+  oauth2Proxy.podDisruptionBudget,
+  oauth2Proxy.secret,
+  oauth2Proxy.service,
+  oauth2Proxy.serviceAccount,
+])

--- a/contrib/jsonnet/examples/ingress-nginx-integration.jsonnet
+++ b/contrib/jsonnet/examples/ingress-nginx-integration.jsonnet
@@ -1,0 +1,114 @@
+local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
+local op = import 'github.com/oauth2-proxy/oauth2-proxy/contrib/jsonnet/oauth2-proxy.libsonnet';
+local deployment = k.apps.v1.deployment;
+local container = deployment.mixin.spec.template.spec.containersType;
+local envVar = container.envType;
+local resourceRequirements = container.mixin.resourcesType;
+local secret = k.core.v1.secret;
+local ingress = k.networking.v1beta1.ingress;
+local ingressRule = ingress.mixin.spec.rulesType;
+local httpIngressPath = ingressRule.mixin.http.pathsType;
+
+local oauth2Proxy = op {
+  _config+:: {
+    namespace: 'oauth2-proxy',
+
+    oauth2Proxy+:: {
+      name: 'oauth2-proxy',
+      namespace: $._config.namespace,
+      version: 'v6.0.0',
+
+      configToml: |||
+        client_id         = "123456.apps.googleusercontent.com"
+        cookie_domains    = [".yourcompany.com"]
+        email_domains     = [".yourcompany.com"]
+        reverse_proxy     = true
+        upstreams         = ["file:///dev/null"]
+        whitelist_domains = [".yourcompany.com"]
+      |||,
+
+      env: [
+        envVar.fromSecretRef(
+          'OAUTH2_PROXY_CLIENT_SECRET',
+          secretRefName=$._config.oauth2Proxy.name,
+          secretRefKey='clientSecret'
+        ),
+        envVar.fromSecretRef(
+          'OAUTH2_PROXY_COOKIE_SECRET',
+          secretRefName=$._config.oauth2Proxy.name,
+          secretRefKey='cookieSecret'
+        ),
+      ],
+    },
+  },
+
+  oauth2Proxy+: {
+    secret:
+      secret.new($._config.oauth2Proxy.name, {
+        clientSecret: std.base64('xxxxxxxxxx'),
+        cookieSecret: std.base64('xxxxxxxxxx'),
+      }) +
+      secret.mixin.metadata.withNamespace($._config.oauth2Proxy.namespace) +
+      secret.mixin.metadata.withLabels($._config.oauth2Proxy.commonLabels),
+
+    container+::
+      container.mixin.resources.withLimits({ cpu: '100m', memory: '100Mi' }) +
+      container.mixin.resources.withRequests({ cpu: '100m', memory: '100Mi' }),
+
+    deployment+:
+      deployment.mixin.spec.withReplicas(3) +
+      deployment.mixin.spec.template.metadata.withAnnotationsMixin({
+        'checksum/oauth2-proxy-secret': std.md5(std.toString($.oauth2Proxy.secret)),
+      }),
+
+    ingress:
+      ingress.new() +
+      ingress.mixin.metadata.withName($._config.oauth2Proxy.name) +
+      ingress.mixin.metadata.withNamespace($._config.namespace) +
+      ingress.mixin.metadata.withLabels($._config.oauth2Proxy.commonLabels) +
+      ingress.mixin.spec.withRules([
+        ingressRule.new() +
+        ingressRule.withHost('oauth2-proxy.yourcompany.com') +
+        ingressRule.mixin.http.withPaths(
+          httpIngressPath.new() +
+          httpIngressPath.mixin.backend.withServiceName($._config.oauth2Proxy.name) +
+          httpIngressPath.mixin.backend.withServicePort('http')
+        ),
+      ]),
+  },
+
+}.oauth2Proxy;
+
+local yourApp = {
+  yourApp: {
+    ingress:
+      ingress.new() +
+      ingress.mixin.metadata.withName('yourapp') +
+      ingress.mixin.metadata.withNamespace('yourapp') +
+      ingress.mixin.metadata.withLabels({ app: 'yourapp' }) +
+      ingress.mixin.metadata.withAnnotations({
+        'nginx.ingress.kubernetes.io/auth-url': 'http://oauth2-proxy.oauth2-proxy.svc.cluster.local:4180/oauth2/auth',
+        'nginx.ingress.kubernetes.io/auth-signin': 'https://oauth2-proxy.yourcompany.com/oauth2/start?rd=$scheme%3A%2F%2F$http_host$escaped_request_uri',
+      }) +
+      ingress.mixin.spec.withRules([
+        ingressRule.new() +
+        ingressRule.withHost('yourapp.yourcompany.com') +
+        ingressRule.mixin.http.withPaths(
+          httpIngressPath.new() +
+          httpIngressPath.mixin.backend.withServiceName('yourapp') +
+          httpIngressPath.mixin.backend.withServicePort(80)
+        ),
+      ]),
+  },
+}.yourApp;
+
+k.core.v1.list.new([
+  oauth2Proxy.configMap,
+  oauth2Proxy.deployment,
+  oauth2Proxy.ingress,
+  oauth2Proxy.podDisruptionBudget,
+  oauth2Proxy.secret,
+  oauth2Proxy.service,
+  oauth2Proxy.serviceAccount,
+  yourApp.ingress,
+])

--- a/contrib/jsonnet/jsonnetfile.json
+++ b/contrib/jsonnet/jsonnetfile.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/ksonnet/ksonnet-lib.git",
+          "subdir": ""
+        }
+      },
+      "version": "master"
+    }
+  ],
+  "legacyImports": false
+}

--- a/contrib/jsonnet/jsonnetfile.lock.json
+++ b/contrib/jsonnet/jsonnetfile.lock.json
@@ -1,0 +1,16 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/ksonnet/ksonnet-lib.git",
+          "subdir": ""
+        }
+      },
+      "version": "0d2f82676817bbf9e4acf6495b2090205f323b9f",
+      "sum": "h28BXZ7+vczxYJ2sCt8JuR9+yznRtU/iA6DCpQUrtEg="
+    }
+  ],
+  "legacyImports": false
+}

--- a/contrib/jsonnet/kustomize.jsonnet
+++ b/contrib/jsonnet/kustomize.jsonnet
@@ -1,0 +1,23 @@
+local op = import 'oauth2-proxy.libsonnet';
+
+local oauth2Proxy = op {
+  _config+:: {
+    namespace: 'oauth2-proxy',
+  },
+}.oauth2Proxy;
+
+local manifests = {
+  [std.asciiLower(resource)]: oauth2Proxy[resource]
+  for resource in std.objectFields(oauth2Proxy)
+  if !std.member(['ConfigMap'], oauth2Proxy[resource].kind)
+};
+
+local kustomization = {
+  apiVersion: 'kustomize.config.k8s.io/v1beta1',
+  kind: 'Kustomization',
+  resources: [name + '.yaml' for name in std.objectFields(manifests)],
+};
+
+manifests {
+  kustomization: kustomization,
+}

--- a/contrib/jsonnet/oauth2-proxy.libsonnet
+++ b/contrib/jsonnet/oauth2-proxy.libsonnet
@@ -1,0 +1,111 @@
+local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
+local deployment = k.apps.v1.deployment;
+
+{
+  local cfg = $._config.oauth2Proxy,
+  local op = $.oauth2Proxy,
+
+  _config+:: {
+    namespace: error 'must provide namespace',
+
+    oauth2Proxy+:: {
+      name: 'oauth2-proxy',
+      namespace: $._config.namespace,
+      version: 'v6.0.0',
+      image: 'quay.io/oauth2-proxy/oauth2-proxy:' + self.version,
+
+      commonLabels:: {
+        'app.kubernetes.io/name': 'oauth2-proxy',
+        'app.kubernetes.io/instance': cfg.name,
+        'app.kubernetes.io/version': cfg.version,
+      },
+
+      podLabelSelector:: {
+        [labelName]: cfg.commonLabels[labelName]
+        for labelName in std.objectFields(cfg.commonLabels)
+        if !std.setMember(labelName, ['app.kubernetes.io/version'])
+      },
+
+      configToml: '',
+      env: [],
+    },
+  },
+
+  oauth2Proxy+: {
+
+    configMap:
+      local configMap = k.core.v1.configMap;
+      configMap.new(cfg.name, { 'oauth2-proxy.toml': cfg.configToml }),
+
+    container+::
+      local container = deployment.mixin.spec.template.spec.containersType;
+      local containerPort = container.portsType;
+      local containerVolumeMount = container.volumeMountsType;
+      local resourceRequirements = container.mixin.resourcesType;
+
+      container.new('oauth2-proxy', cfg.image) +
+      container.withPorts(containerPort.newNamed(4180, 'http')) +
+      container.withArgs([
+        '--http-address=0.0.0.0:4180',
+        '--config=/etc/oauth2-proxy/oauth2-proxy.toml',
+      ]) +
+      container.withEnv(cfg.env) +
+      container.mixin.livenessProbe +
+      container.mixin.livenessProbe.httpGet.withPort('http') +
+      container.mixin.livenessProbe.httpGet.withPath('/ping') +
+      container.mixin.readinessProbe +
+      container.mixin.readinessProbe.httpGet.withPort('http') +
+      container.mixin.readinessProbe.httpGet.withPath('/ping') +
+      container.withVolumeMounts([containerVolumeMount.new('config', '/etc/oauth2-proxy')]),
+
+    deployment+:
+      local affinity = deployment.mixin.spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecutionType;
+      local volume = k.apps.v1.deployment.mixin.spec.template.spec.volumesType;
+
+      deployment.new(cfg.name, 1, op.container, cfg.commonLabels) +
+      deployment.mixin.metadata.withLabels(cfg.commonLabels) +
+      deployment.mixin.spec.selector.withMatchLabels(cfg.podLabelSelector) +
+      deployment.mixin.spec.template.metadata.withAnnotations({
+        'checksum/oauth2-proxy-config': std.md5(std.toString(op.configMap)),
+      }) +
+      deployment.mixin.spec.template.spec.securityContext.withRunAsNonRoot(true) +
+      deployment.mixin.spec.template.spec.securityContext.withRunAsUser(2000) +
+      deployment.mixin.spec.template.spec.securityContext.withFsGroup(2000) +
+      deployment.mixin.spec.template.spec.withServiceAccountName(cfg.name) +
+      deployment.mixin.spec.template.spec.affinity.podAntiAffinity.withPreferredDuringSchedulingIgnoredDuringExecution(
+        affinity.new() +
+        affinity.withWeight(100) +
+        affinity.mixin.podAffinityTerm.withNamespaces(cfg.namespace) +
+        affinity.mixin.podAffinityTerm.withTopologyKey('kubernetes.io/hostname') +
+        affinity.mixin.podAffinityTerm.labelSelector.withMatchLabels(cfg.podLabelSelector)
+      ) +
+      deployment.mixin.spec.template.spec.withVolumes([
+        volume.withName('config') + volume.mixin.configMap.withName(cfg.name),
+      ]),
+
+    podDisruptionBudget:
+      local podDisruptionBudget = k.policy.v1beta1.podDisruptionBudget;
+
+      podDisruptionBudget.new() +
+      podDisruptionBudget.mixin.metadata.withName(cfg.name) +
+      podDisruptionBudget.mixin.metadata.withNamespace(cfg.namespace) +
+      podDisruptionBudget.mixin.metadata.withLabels(cfg.commonLabels) +
+      podDisruptionBudget.mixin.spec.withMaxUnavailable(1) +
+      podDisruptionBudget.mixin.spec.selector.withMatchLabels(cfg.podLabelSelector),
+
+    service:
+      local service = k.core.v1.service;
+      local servicePort = k.core.v1.service.mixin.spec.portsType;
+
+      service.new(cfg.name, cfg.podLabelSelector, servicePort.newNamed('http', 80, 'http')) +
+      service.mixin.metadata.withLabels(cfg.commonLabels) +
+      service.mixin.metadata.withNamespace(cfg.namespace),
+
+    serviceAccount:
+      local serviceAccount = k.core.v1.serviceAccount;
+
+      serviceAccount.new(cfg.name) +
+      serviceAccount.mixin.metadata.withNamespace(cfg.namespace) +
+      serviceAccount.mixin.metadata.withLabels(cfg.commonLabels),
+  },
+}

--- a/contrib/kustomization.yaml.example
+++ b/contrib/kustomization.yaml.example
@@ -1,0 +1,39 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- github.com/oauth2-proxy/oauth2-proxy/contrib/manifests?ref=master
+
+namespace: oauth2-proxy
+
+configMapGenerator:
+- name: oauth2-proxy
+  files:
+  - oauth2-proxy.toml
+
+secretGenerator:
+- name: oauth2-proxy
+  env: oauth2-proxy.properties
+
+patchesStrategicMerge:
+- |-
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: oauth2-proxy
+    namespace: oauth2-proxy
+  spec:
+    template:
+      spec:
+        containers:
+        - name: oauth2-proxy
+          env:
+          - name: OAUTH2_PROXY_CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: oauth2-proxy
+                key: clientSecret
+          - name: OAUTH2_PROXY_COOKIE_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: oauth2-proxy
+                key: cookieSecret

--- a/contrib/manifests/deployment.yaml
+++ b/contrib/manifests/deployment.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/instance: oauth2-proxy
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/version: v6.0.0
+  name: oauth2-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: oauth2-proxy
+      app.kubernetes.io/name: oauth2-proxy
+  template:
+    metadata:
+      annotations:
+        checksum/oauth2-proxy-config: ba67538e1df882c022bca2d903040ff0
+      labels:
+        app.kubernetes.io/instance: oauth2-proxy
+        app.kubernetes.io/name: oauth2-proxy
+        app.kubernetes.io/version: v6.0.0
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/instance: oauth2-proxy
+                  app.kubernetes.io/name: oauth2-proxy
+              namespaces:
+              - oauth2-proxy
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      containers:
+      - args:
+        - --http-address=0.0.0.0:4180
+        - --config=/etc/oauth2-proxy/oauth2-proxy.toml
+        env: []
+        image: quay.io/oauth2-proxy/oauth2-proxy:v6.0.0
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: http
+        name: oauth2-proxy
+        ports:
+        - containerPort: 4180
+          name: http
+        readinessProbe:
+          httpGet:
+            path: /ping
+            port: http
+        volumeMounts:
+        - mountPath: /etc/oauth2-proxy
+          name: config
+          readOnly: false
+      securityContext:
+        fsGroup: 2000
+        runAsNonRoot: true
+        runAsUser: 2000
+      serviceAccountName: oauth2-proxy
+      volumes:
+      - configMap:
+          name: oauth2-proxy
+        name: config

--- a/contrib/manifests/kustomization.yaml
+++ b/contrib/manifests/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deployment.yaml
+- poddisruptionbudget.yaml
+- service.yaml
+- serviceaccount.yaml

--- a/contrib/manifests/poddisruptionbudget.yaml
+++ b/contrib/manifests/poddisruptionbudget.yaml
@@ -1,0 +1,15 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/instance: oauth2-proxy
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/version: v6.0.0
+  name: oauth2-proxy
+  namespace: oauth2-proxy
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: oauth2-proxy
+      app.kubernetes.io/name: oauth2-proxy

--- a/contrib/manifests/service.yaml
+++ b/contrib/manifests/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: oauth2-proxy
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/version: v6.0.0
+  name: oauth2-proxy
+  namespace: oauth2-proxy
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: http
+  selector:
+    app.kubernetes.io/instance: oauth2-proxy
+    app.kubernetes.io/name: oauth2-proxy

--- a/contrib/manifests/serviceaccount.yaml
+++ b/contrib/manifests/serviceaccount.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: oauth2-proxy
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/version: v6.0.0
+  name: oauth2-proxy
+  namespace: oauth2-proxy


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Add Jsonnet library and manifests/kustomize base for Kubernetes deployment.
Manifests are built out of the Jsonnet library, so we can support 2 deployment methods out of 1.

I'm open to integrate this better in the repo and any other feedback, the `Makefile` change is kind of raw right now, and maybe the CI could check if the formatting is OK and the manifests up-to-date.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There is no official Kubernetes deployment (or even good examples) for `oauth2-proxy`, and the central Helm chart repository is deprecated and will be archived soon.

Related to #608

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Jsonnet examples**

Install the library into a new directory with `jb` (see README)... or cheat the `vendor` directory:

```shell
make contrib/jsonnet/vendor
mkdir -p contrib/jsonnet/vendor/github.com/oauth2-proxy/oauth2-proxy/contrib
ln -s ../../../../../ contrib/jsonnet/vendor/github.com/oauth2-proxy/oauth2-proxy/contrib/jsonnet
```

```shell
jsonnet -J contrib/jsonnet/vendor contrib/jsonnet/examples/basic.jsonnet
jsonnet -J contrib/jsonnet/vendor contrib/jsonnet/examples/ingress-nginx-integration.jsonnet
```

I have deployed it in our environment with this library and a configuration close to the `ingress-nginx-integration.jsonnet` example.

**Test Jsonnet build of manifests**

```shell
make k8s
kustomize build contrib/manifests
```

The config is missing from this output, the users are responsible for adding it (see `kustomization.yaml.example`).

**Check formatting**

```
make jsonnetfmt
```

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.