### PR TITLE
allow the keycloak provider to take a different user ID claim

### DIFF
--- a/pkg/validation/options.go
+++ b/pkg/validation/options.go
@@ -259,6 +259,7 @@ func parseProviderInfo(o *options.Options, msgs []string) []string {
 		p.SetUsers(o.GitHubUsers)
 	case *providers.KeycloakProvider:
 		p.SetGroup(o.KeycloakGroup)
+		p.SetUserIDClaim(o.UserIDClaim)
 	case *providers.GoogleProvider:
 		if o.GoogleServiceAccountJSON != "" {
 			file, err := os.Open(o.GoogleServiceAccountJSON)

--- a/providers/keycloak.go
+++ b/providers/keycloak.go
@@ -11,7 +11,8 @@ import (
 
 type KeycloakProvider struct {
 	*ProviderData
-	Group string
+	Group       string
+	UserIDClaim string
 }
 
 var _ Provider = (*KeycloakProvider)(nil)
@@ -63,6 +64,10 @@ func (p *KeycloakProvider) SetGroup(group string) {
 	p.Group = group
 }
 
+func (p *KeycloakProvider) SetUserIDClaim(claim string) {
+	p.UserIDClaim = claim
+}
+
 func (p *KeycloakProvider) GetEmailAddress(ctx context.Context, s *sessions.SessionState) (string, error) {
 	json, err := requests.New(p.ValidateURL.String()).
 		WithContext(ctx).
@@ -95,5 +100,8 @@ func (p *KeycloakProvider) GetEmailAddress(ctx context.Context, s *sessions.Sess
 		}
 	}
 
-	return json.Get("email").String()
+	if p.UserIDClaim != "" {
+		return json.Get(p.UserIDClaim).String()
+	}
+	return json.Get(emailClaim).String()
 }


### PR DESCRIPTION
## Description

The oidc provider already allows to take a different claim than "email" as the user ID. This PR just adds the functionality to the keycloak provider.

## Motivation and Context

Not using the _email_ claim allows for more options in identifying a user. In our case it allows to use a different 'email' address than stored in the email field to be used as the user ID.

## How Has This Been Tested?

I added some simple tests which test the existence and the absence of the wanted user ID claim.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
