### PR TITLE
Add `x-oauth-basic` nosec annotation & address gosec unhandled errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ## Changes since v6.0.0
 
+- [#719](https://github.com/oauth2-proxy/oauth2-proxy/pull/719) Add Gosec fixes to areas that are intermittently flagged on PRs (@NickMeves)
 - [#718](https://github.com/oauth2-proxy/oauth2-proxy/pull/718) Allow Logging to stdout with separate Error Log Channel
 - [#690](https://github.com/oauth2-proxy/oauth2-proxy/pull/690) Address GoSec security findings & remediate (@NickMeves)
 - [#689](https://github.com/oauth2-proxy/oauth2-proxy/pull/689) Fix finicky logging_handler_test from time drift (@NickMeves)

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -144,11 +144,10 @@ func (l *Logger) formatLogMessage(calldepth int, message string) []byte {
 		panic(err)
 	}
 
-	_, err = l.writer.Write([]byte("\n"))
+	_, err = logBuff.Write([]byte("\n"))
 	if err != nil {
 		panic(err)
 	}
-	logBuff.Write([]byte("\n"))
 
 	return logBuff.Bytes()
 }
@@ -162,11 +161,16 @@ func (l *Logger) Output(lvl Level, calldepth int, message string) {
 		return
 	}
 	msg := l.formatLogMessage(calldepth, message)
+
+	var err error
 	switch lvl {
 	case ERROR:
-		l.errWriter.Write(msg)
+		_, err = l.errWriter.Write(msg)
 	default:
-		l.writer.Write(msg)
+		_, err = l.writer.Write(msg)
+	}
+	if err != nil {
+		panic(err)
 	}
 }
 

--- a/pkg/middleware/jwt_session.go
+++ b/pkg/middleware/jwt_session.go
@@ -121,6 +121,7 @@ func (j *jwtSessionLoader) getBasicToken(token string) (string, error) {
 	// check user, user+password, or just password for a token
 	if j.jwtRegex.MatchString(user) {
 		// Support blank passwords or magic `x-oauth-basic` passwords - nothing else
+		/* #nosec G101 */
 		if password == "" || password == "x-oauth-basic" {
 			return user, nil
 		}


### PR DESCRIPTION
Add a `#nosec` annotation to hardcoded `x-oauth-basic` password & handle finicky unhandled errors that weren't caught in a previous merge

## Description

Gosec cleanup

## Motivation and Context

Other PRs are getting intermittent Gosec issues.

## How Has This Been Tested?

Unit Tests

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
