### PR TITLE
Add OIDC group membership validation

### DIFF
--- a/pkg/apis/options/options.go
+++ b/pkg/apis/options/options.go
@@ -52,6 +52,7 @@ type Options struct {
 	GoogleGroups             []string `flag:"google-group" cfg:"google_group"`
 	GoogleAdminEmail         string   `flag:"google-admin-email" cfg:"google_admin_email"`
 	GoogleServiceAccountJSON string   `flag:"google-service-account-json" cfg:"google_service_account_json"`
+	OIDCGroup                string   `flag:"oidc-group" cfg:"oidc_group"`
 	HtpasswdFile             string   `flag:"htpasswd-file" cfg:"htpasswd_file"`
 	DisplayHtpasswdForm      bool     `flag:"display-htpasswd-form" cfg:"display_htpasswd_form"`
 	CustomTemplatesDir       string   `flag:"custom-templates-dir" cfg:"custom_templates_dir"`
@@ -213,6 +214,7 @@ func NewFlagSet() *pflag.FlagSet {
 	flagSet.StringSlice("github-user", []string{}, "allow users with these usernames to login even if they do not belong to the specified org and team or collaborators (may be given multiple times)")
 	flagSet.StringSlice("gitlab-group", []string{}, "restrict logins to members of this group (may be given multiple times)")
 	flagSet.StringSlice("google-group", []string{}, "restrict logins to members of this google group (may be given multiple times).")
+	flagSet.String("oidc-group", "", "restrict logins to members of this group")
 	flagSet.String("google-admin-email", "", "the google admin to impersonate for api calls")
 	flagSet.String("google-service-account-json", "", "the path to the service account json credentials")
 	flagSet.String("client-id", "", "the OAuth Client ID: ie: \"123456.apps.googleusercontent.com\"")

--- a/pkg/validation/options.go
+++ b/pkg/validation/options.go
@@ -279,6 +279,7 @@ func parseProviderInfo(o *options.Options, msgs []string) []string {
 	case *providers.OIDCProvider:
 		p.AllowUnverifiedEmail = o.InsecureOIDCAllowUnverifiedEmail
 		p.UserIDClaim = o.UserIDClaim
+		p.Group = o.OIDCGroup
 		if o.GetOIDCVerifier() == nil {
 			msgs = append(msgs, "oidc provider requires an oidc issuer URL")
 		} else {


### PR DESCRIPTION
Hi,

I've updated oauth2 proxy to allow group membership validation for OIDC providers.

## Description

Validate the groups returned by OIDC provider contain at least one group provided by command line/environment.

## Motivation and Context

We are trying to restrict access based on specific OIDC groups similar to Github teams/groups.

## How Has This Been Tested?

I've added a few tests and tested locally with Dex with LDAP backend.

## Checklist:

I made OIDC Group a string instead of string slice becouse specific implementations can contain comma in group name (for example groups returned by LDAP provider like `cn=Users,domain=example,domain=com`). Group name separation is done using `;`.