### PR TITLE
dist.sh: remove go version from asset links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - [#649](https://github.com/oauth2-proxy/oauth2-proxy/pull/650) Resolve an issue where an empty healthcheck URL and ping-user-agent returns the healthcheck response (@jordancrawfordnz)
 - [#662](https://github.com/oauth2-proxy/oauth2-proxy/pull/662) Do not add Cache-Control header to response from auth only endpoint (@johejo)
 - [#552](https://github.com/oauth2-proxy/oauth2-proxy/pull/522) Implements --trusted-ip option to allow clients behind specified IPs or CIDR ranges to bypass authentication (@Izzette)
+- [#733](https://github.com/oauth2-proxy/oauth2-proxy/pull/733) dist.sh: remove go version from asset links (@syscll)
 
 # v6.0.0
 

--- a/dist.sh
+++ b/dist.sh
@@ -20,7 +20,7 @@ mkdir -p release
 
 # Create architecture specific release dirs
 for ARCH in "${ARCHS[@]}"; do
-	mkdir -p release/${BINARY}-${VERSION}.${ARCH}.${GO_VERSION}
+	mkdir -p release/${BINARY}-${VERSION}.${ARCH}
 
 	GO_OS=$(echo $ARCH | awk -F- '{print $1}')
 	GO_ARCH=$(echo $ARCH | awk -F- '{print $2}')
@@ -28,19 +28,19 @@ for ARCH in "${ARCHS[@]}"; do
 	# Create architecture specific binaries
 	if [[ ${GO_ARCH} == "armv6" ]]; then
 		GO111MODULE=on GOOS=${GO_OS} GOARCH=arm GOARM=6 CGO_ENABLED=0 go build -ldflags="-X main.VERSION=${VERSION}" \
-			-o release/${BINARY}-${VERSION}.${ARCH}.${GO_VERSION}/${BINARY} github.com/oauth2-proxy/oauth2-proxy
+			-o release/${BINARY}-${VERSION}.${ARCH}/${BINARY} github.com/oauth2-proxy/oauth2-proxy
 	else
 		GO111MODULE=on GOOS=${GO_OS} GOARCH=${GO_ARCH} CGO_ENABLED=0 go build -ldflags="-X main.VERSION=${VERSION}" \
-			-o release/${BINARY}-${VERSION}.${ARCH}.${GO_VERSION}/${BINARY} github.com/oauth2-proxy/oauth2-proxy
+			-o release/${BINARY}-${VERSION}.${ARCH}/${BINARY} github.com/oauth2-proxy/oauth2-proxy
 	fi
 
 	cd release
 
 	# Create sha256sum for architecture specific binary
-	sha256sum ${BINARY}-${VERSION}.${ARCH}.${GO_VERSION}/${BINARY} > ${BINARY}-${VERSION}.${ARCH}-sha256sum.txt
+	sha256sum ${BINARY}-${VERSION}.${ARCH}/${BINARY} > ${BINARY}-${VERSION}.${ARCH}-sha256sum.txt
 
 	# Create tar file for architecture specific binary
-	tar -czvf ${BINARY}-${VERSION}.${ARCH}.${GO_VERSION}.tar.gz ${BINARY}-${VERSION}.${ARCH}.${GO_VERSION}
+	tar -czvf ${BINARY}-${VERSION}.${ARCH}.tar.gz ${BINARY}-${VERSION}.${ARCH}
 
 	cd ..
 done


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We do not need to include the Go version in asset links as it makes automation easier and the end-user doesn't really care.

## Motivation and Context

https://github.com/oauth2-proxy/oauth2-proxy/issues/634

## How Has This Been Tested?

Manually ran `./dist.sh` on my machine.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
