### PR TITLE
#724 Respect X-Forwarded-Host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ## Changes since v6.0.0
 
+- [#737](https://github.com/oauth2-proxy/oauth2-proxy/pull/737) Use X-Forwarded-Host instead of Host when available (@holyjak)
 - [#562](https://github.com/oauth2-proxy/oauth2-proxy/pull/562) Create generic Authorization Header constructor (@JoelSpeed)
 - [#715](https://github.com/oauth2-proxy/oauth2-proxy/pull/715) Ensure session times are not nil before printing them (@JoelSpeed)
 - [#714](https://github.com/oauth2-proxy/oauth2-proxy/pull/714) Support passwords with Redis session stores (@NickMeves)

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -747,7 +747,8 @@ func (p *OAuthProxy) OAuthStart(rw http.ResponseWriter, req *http.Request) {
 		p.ErrorPage(rw, http.StatusInternalServerError, "Internal Server Error", err.Error())
 		return
 	}
-	redirectURI := p.GetRedirectURI(req.Host)
+	domain := cookies.GetRequestHost(req)
+	redirectURI := p.GetRedirectURI(domain)
 	http.Redirect(rw, req, p.provider.GetLoginURL(redirectURI, fmt.Sprintf("%v:%v", nonce, redirect)), http.StatusFound)
 }
 
@@ -770,7 +771,7 @@ func (p *OAuthProxy) OAuthCallback(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	session, err := p.redeemCode(req.Context(), req.Host, req.Form.Get("code"))
+	session, err := p.redeemCode(req.Context(), cookies.GetRequestHost(req), req.Form.Get("code"))
 	if err != nil {
 		logger.Errorf("Error redeeming code during OAuth2 callback: %v", err)
 		p.ErrorPage(rw, http.StatusInternalServerError, "Internal Server Error", "Internal Error")

--- a/pkg/middleware/redirect_to_https.go
+++ b/pkg/middleware/redirect_to_https.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/justinas/alice"
+	"github.com/oauth2-proxy/oauth2-proxy/pkg/cookies"
 )
 
 const httpsScheme = "https"
@@ -40,7 +41,7 @@ func redirectToHTTPS(httpsPort string, next http.Handler) http.Handler {
 
 		// Set the req.Host when the targetURL still does not have one
 		if targetURL.Host == "" {
-			targetURL.Host = req.Host
+			targetURL.Host = cookies.GetRequestHost(req)
 		}
 
 		// Overwrite the port if the original request was to a non-standard port


### PR DESCRIPTION
Use X-Forwarded-Host instead of Host if available so that we use public-visible URLs instead some internal ones, when running behind some kind of gateway (such as AWS CloudFront).

**I am not sure wheter replacing req.Host with GetRequestHost in redirectToHTTPS and redeemCode is correct** - I do not have enough understanding of the code to be sure what is right. Also, I could not find any unit test that I could extend/copy to test this behavior, is there any?

## Description

Replace `req.Host` with `cookies.GetRequestHost(req)` (which checks x-forwarded-for first) at all the relevant places.

## Motivation and Context

Fixes #724 

## How Has This Been Tested?

Manually, while running the service behind a proxy that sets X-Forwarded-Host:

1. Access the service => get sent to authentication and then back
2. Verified the redirect url is correct and based on the X-Forwarded-Host (and on the Host if this is not set)
3. Verified that I am actually redirected to the correct domain and url at the end
4. Verified the cookie domain is the same as the X-Forwarded-Host

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
