### PR TITLE
Fix docs: command line options

### DIFF
--- a/docs/2_auth.md
+++ b/docs/2_auth.md
@@ -244,7 +244,7 @@ The `oidc_issuer_url` is based on URL from your **Authorization Server**'s **Iss
 The `client_id` and `client_secret` are configured in the application settings.
 Generate a unique `client_secret` to encrypt the cookie.
 
-Then you can start the oauth2-proxy with `./oauth2-proxy -config /etc/example.cfg`
+Then you can start the oauth2-proxy with `./oauth2-proxy --config /etc/example.cfg`
 
 #### Configuring the OIDC Provider with Okta - localhost
 1. Signup for developer account: https://developer.okta.com/signup/
@@ -278,7 +278,7 @@ Then you can start the oauth2-proxy with `./oauth2-proxy -config /etc/example.cf
    # Note: use the following for testing within a container
    # http_address = "0.0.0.0:4180"
    ```
-7. Then you can start the oauth2-proxy with `./oauth2-proxy -config /etc/localhost.cfg`
+7. Then you can start the oauth2-proxy with `./oauth2-proxy --config /etc/localhost.cfg`
 
 ### login.gov Provider
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixed command line options on 'Auth Configuration'.

`-config` is not supported option in latest version.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Remove incorrect information on official doc.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

nothing

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
