### PR TITLE
contrib: Add manifests for Kubernetes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,3 +98,12 @@ validate-go-version:
 .PHONY: local-env-%
 local-env-%:
 	make -C contrib/local-environment $*
+
+.PHONY: set-image
+set-image:
+	cd contrib/manifests/base && kustomize edit set image quay.io/oauth2-proxy/oauth2-proxy=$(REGISTRY)/oauth2-proxy:$(VERSION)
+
+.PHONY: manifests
+manifests: set-image
+	echo '# This is an auto-generated file. DO NOT EDIT' > contrib/manifests/install.yaml
+	kustomize build contrib/manifests/base >> contrib/manifests/install.yaml

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,0 +1,4 @@
+# Kustomize
+
+See [kustomization.yaml](kustomization.yaml.example) example.
+

--- a/contrib/kustomization.yaml.example
+++ b/contrib/kustomization.yaml.example
@@ -1,0 +1,40 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- github.com/oauth2-proxy/oauth2-proxy/contrib/manifests/base?ref=v6.1.0
+
+namespace: oauth2-proxy
+
+configMapGenerator:
+- name: oauth2-proxy
+  files:
+  - oauth2-proxy.toml
+
+secretGenerator:
+- name: oauth2-proxy
+  envs:
+  - oauth2-proxy.secret.properties
+
+patchesStrategicMerge:
+- |-
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: oauth2-proxy
+  spec:
+    template:
+      spec:
+        containers:
+        - name: oauth2-proxy
+          # Set secrets via environment variables
+          env:
+          - name: OAUTH2_PROXY_CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: oauth2-proxy
+                key: clientSecret
+          - name: OAUTH2_PROXY_COOKIE_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: oauth2-proxy
+                key: cookieSecret

--- a/contrib/manifests/base/deployment.yaml
+++ b/contrib/manifests/base/deployment.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: oauth2-proxy
+  labels:
+    app.kubernetes.io/name: oauth2-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: oauth2-proxy
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: oauth2-proxy
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: oauth2-proxy
+              namespaces:
+              - oauth2-proxy
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      containers:
+      - args:
+        - --http-address=0.0.0.0:4180
+        - --config=/etc/oauth2-proxy/oauth2-proxy.toml
+        image: quay.io/oauth2-proxy/oauth2-proxy:latest
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: http
+        name: oauth2-proxy
+        ports:
+        - containerPort: 4180
+          name: http
+        readinessProbe:
+          httpGet:
+            path: /ping
+            port: http
+        volumeMounts:
+        - name: config
+          mountPath: /etc/oauth2-proxy
+          readOnly: true
+      securityContext:
+        fsGroup: 2000
+        runAsNonRoot: true
+        runAsUser: 2000
+      serviceAccountName: oauth2-proxy
+      volumes:
+      - name: config
+        configMap:
+          name: oauth2-proxy

--- a/contrib/manifests/base/kustomization.yaml
+++ b/contrib/manifests/base/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- deployment.yaml
+- poddisruptionbudget.yaml
+- service.yaml
+- serviceaccount.yaml
+
+images:
+- name: quay.io/oauth2-proxy/oauth2-proxy
+  newName: quay.io/oauth2-proxy/oauth2-proxy
+  newTag: v6.1.0

--- a/contrib/manifests/base/poddisruptionbudget.yaml
+++ b/contrib/manifests/base/poddisruptionbudget.yaml
@@ -1,0 +1,11 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/name: oauth2-proxy
+  name: oauth2-proxy
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: oauth2-proxy

--- a/contrib/manifests/base/service.yaml
+++ b/contrib/manifests/base/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: oauth2-proxy
+  labels:
+    app.kubernetes.io/name: oauth2-proxy
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: http
+  selector:
+    app.kubernetes.io/name: oauth2-proxy

--- a/contrib/manifests/base/serviceaccount.yaml
+++ b/contrib/manifests/base/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: oauth2-proxy
+  labels:
+    app.kubernetes.io/name: oauth2-proxy

--- a/contrib/manifests/install.yaml
+++ b/contrib/manifests/install.yaml
@@ -1,0 +1,91 @@
+# This is an auto-generated file. DO NOT EDIT
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: oauth2-proxy
+  name: oauth2-proxy
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: oauth2-proxy
+  name: oauth2-proxy
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: http
+  selector:
+    app.kubernetes.io/name: oauth2-proxy
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: oauth2-proxy
+  name: oauth2-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: oauth2-proxy
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: oauth2-proxy
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: oauth2-proxy
+              namespaces:
+              - oauth2-proxy
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      containers:
+      - args:
+        - --http-address=0.0.0.0:4180
+        - --config=/etc/oauth2-proxy/oauth2-proxy.toml
+        image: quay.io/oauth2-proxy/oauth2-proxy:v6.0.0-117-g3b3cb2b-dirty
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: http
+        name: oauth2-proxy
+        ports:
+        - containerPort: 4180
+          name: http
+        readinessProbe:
+          httpGet:
+            path: /ping
+            port: http
+        volumeMounts:
+        - mountPath: /etc/oauth2-proxy
+          name: config
+          readOnly: true
+      securityContext:
+        fsGroup: 2000
+        runAsNonRoot: true
+        runAsUser: 2000
+      serviceAccountName: oauth2-proxy
+      volumes:
+      - configMap:
+          name: oauth2-proxy
+        name: config
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/name: oauth2-proxy
+  name: oauth2-proxy
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: oauth2-proxy


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add manifests for Kubernetes deployment, this includes:

- a Kustomize base
- an `install.yaml` manifest bundling everything (only misses an `oauth2-proxy` configMap with a valid `oauth2-proxy.toml` configuration)
- Makefile rules to update the image tag and bundle file.

Close #706

## Motivation and Context

Related to #608

## How Has This Been Tested?

I have deployed it in one of our environments.

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
