### PR TITLE
Pass resource parameter in login url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 ## Breaking Changes
 
 - [#722](https://github.com/oauth2-proxy/oauth2-proxy/pull/722) When a Redis session store is configured, OAuth2-Proxy will fail to start up unless connection and health checks to Redis pass
-- A bug in the Azure provider prevented it from properly passing the configured protected `--resource`
+- [#753](https://github.com/oauth2-proxy/oauth2-proxy/pull/753) A bug in the Azure provider prevented it from properly passing the configured protected `--resource`
   via the login url. If this option was used in the past, behavior will change with this release as it will
   affect the tokens returned by Azure. In the past, the tokens were always for `https://graph.microsoft.com` (the default)
   and will now be for the configured resource (if it exists, otherwise it will run into errors)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,14 @@
 ## Breaking Changes
 
 - [#722](https://github.com/oauth2-proxy/oauth2-proxy/pull/722) When a Redis session store is configured, OAuth2-Proxy will fail to start up unless connection and health checks to Redis pass
+- A bug in the Azure provider prevented it from properly passing the configured protected `--resource`
+  via the login url. If this option was used in the past, behavior will change with this release as it will
+  affect the tokens returned by Azure. In the past, the tokens were always for `https://graph.microsoft.com` (the default)
+  and will now be for the configured resource (if it exists, otherwise it will run into errors)
 
 ## Changes since v6.1.1
 
+- [#753](https://github.com/oauth2-proxy/oauth2-proxy/pull/753) Pass resource parameter in login url (@codablock)
 - [#575](https://github.com/oauth2-proxy/oauth2-proxy/pull/575) Stop accepting legacy SHA1 signed cookies (@NickMeves)
 - [#722](https://github.com/oauth2-proxy/oauth2-proxy/pull/722) Validate Redis configuration options at startup (@NickMeves)
 - [#791](https://github.com/oauth2-proxy/oauth2-proxy/pull/791) Remove GetPreferredUsername method from provider interface (@NickMeves)

--- a/providers/azure.go
+++ b/providers/azure.go
@@ -210,3 +210,12 @@ func (p *AzureProvider) GetEmailAddress(ctx context.Context, s *sessions.Session
 
 	return email, err
 }
+
+func (p *AzureProvider) GetLoginURL(redirectURI, state string) string {
+	a, params := DefaultGetLoginURL(p.ProviderData, redirectURI, state)
+	if p.ProtectedResource != nil && p.ProtectedResource.String() != "" {
+		params.Add("resource", p.ProtectedResource.String())
+	}
+	a.RawQuery = params.Encode()
+	return a.String()
+}

--- a/providers/azure.go
+++ b/providers/azure.go
@@ -212,7 +212,7 @@ func (p *AzureProvider) GetEmailAddress(ctx context.Context, s *sessions.Session
 }
 
 func (p *AzureProvider) GetLoginURL(redirectURI, state string) string {
-	a, params := DefaultGetLoginURL(p.ProviderData, redirectURI, state)
+	a, params := makeLoginURL(p.ProviderData, redirectURI, state)
 	if p.ProtectedResource != nil && p.ProtectedResource.String() != "" {
 		params.Add("resource", p.ProtectedResource.String())
 	}

--- a/providers/azure.go
+++ b/providers/azure.go
@@ -212,10 +212,10 @@ func (p *AzureProvider) GetEmailAddress(ctx context.Context, s *sessions.Session
 }
 
 func (p *AzureProvider) GetLoginURL(redirectURI, state string) string {
-	a, params := makeLoginURL(p.ProviderData, redirectURI, state)
+	extraParams := url.Values{}
 	if p.ProtectedResource != nil && p.ProtectedResource.String() != "" {
-		params.Add("resource", p.ProtectedResource.String())
+		extraParams.Add("resource", p.ProtectedResource.String())
 	}
-	a.RawQuery = params.Encode()
+	a := makeLoginURL(p.ProviderData, redirectURI, state, extraParams)
 	return a.String()
 }

--- a/providers/azure_test.go
+++ b/providers/azure_test.go
@@ -213,3 +213,10 @@ func TestAzureProviderRedeemReturnsIdToken(t *testing.T) {
 	assert.Equal(t, timestamp, s.ExpiresOn.UTC())
 	assert.Equal(t, "refresh1234", s.RefreshToken)
 }
+
+func TestAzureProviderProtectedResourceConfigured(t *testing.T) {
+	p := testAzureProvider("")
+	p.ProtectedResource, _ = url.Parse("http://my.resource.test")
+	result := p.GetLoginURL("https://my.test.app/oauth", "")
+	assert.Contains(t, result, "resource="+url.QueryEscape("http://my.resource.test"))
+}

--- a/providers/logingov.go
+++ b/providers/logingov.go
@@ -225,19 +225,11 @@ func (p *LoginGovProvider) Redeem(ctx context.Context, redirectURL, code string)
 
 // GetLoginURL overrides GetLoginURL to add login.gov parameters
 func (p *LoginGovProvider) GetLoginURL(redirectURI, state string) string {
-	a := *p.LoginURL
-	params, _ := url.ParseQuery(a.RawQuery)
-	params.Set("redirect_uri", redirectURI)
-	params.Set("approval_prompt", p.ApprovalPrompt)
-	params.Add("scope", p.Scope)
-	params.Set("client_id", p.ClientID)
-	params.Set("response_type", "code")
-	params.Add("state", state)
-	acr := p.AcrValues
-	if acr == "" {
-		acr = "http://idmanagement.gov/ns/assurance/loa/1"
+	a, params := DefaultGetLoginURL(p.ProviderData, redirectURI, state)
+	if p.AcrValues == "" {
+		acr := "http://idmanagement.gov/ns/assurance/loa/1"
+		params.Add("acr_values", acr)
 	}
-	params.Add("acr_values", acr)
 	params.Add("nonce", p.Nonce)
 	a.RawQuery = params.Encode()
 	return a.String()

--- a/providers/logingov.go
+++ b/providers/logingov.go
@@ -225,7 +225,7 @@ func (p *LoginGovProvider) Redeem(ctx context.Context, redirectURL, code string)
 
 // GetLoginURL overrides GetLoginURL to add login.gov parameters
 func (p *LoginGovProvider) GetLoginURL(redirectURI, state string) string {
-	a, params := DefaultGetLoginURL(p.ProviderData, redirectURI, state)
+	a, params := makeLoginURL(p.ProviderData, redirectURI, state)
 	if p.AcrValues == "" {
 		acr := "http://idmanagement.gov/ns/assurance/loa/1"
 		params.Add("acr_values", acr)

--- a/providers/logingov.go
+++ b/providers/logingov.go
@@ -225,12 +225,12 @@ func (p *LoginGovProvider) Redeem(ctx context.Context, redirectURL, code string)
 
 // GetLoginURL overrides GetLoginURL to add login.gov parameters
 func (p *LoginGovProvider) GetLoginURL(redirectURI, state string) string {
-	a, params := makeLoginURL(p.ProviderData, redirectURI, state)
+	extraParams := url.Values{}
 	if p.AcrValues == "" {
 		acr := "http://idmanagement.gov/ns/assurance/loa/1"
-		params.Add("acr_values", acr)
+		extraParams.Add("acr_values", acr)
 	}
-	params.Add("nonce", p.Nonce)
-	a.RawQuery = params.Encode()
+	extraParams.Add("nonce", p.Nonce)
+	a := makeLoginURL(p.ProviderData, redirectURI, state, extraParams)
 	return a.String()
 }

--- a/providers/logingov_test.go
+++ b/providers/logingov_test.go
@@ -289,3 +289,10 @@ func TestLoginGovProviderBadNonce(t *testing.T) {
 	// The "badfakenonce" in the idtoken above should cause this to error out
 	assert.Error(t, err)
 }
+
+func TestLoginGovProviderGetLoginURL(t *testing.T) {
+	p, _, _ := newLoginGovProvider()
+	result := p.GetLoginURL("http://redirect/", "")
+	assert.Contains(t, result, "acr_values="+url.QueryEscape("http://idmanagement.gov/ns/assurance/loa/1"))
+	assert.Contains(t, result, "nonce=fakenonce")
+}

--- a/providers/provider_default.go
+++ b/providers/provider_default.go
@@ -73,8 +73,7 @@ func (p *ProviderData) Redeem(ctx context.Context, redirectURL, code string) (s 
 	return
 }
 
-// GetLoginURL with typical oauth parameters
-func (p *ProviderData) GetLoginURL(redirectURI, state string) string {
+func DefaultGetLoginURL(p *ProviderData, redirectURI, state string) (url.URL, url.Values) {
 	a := *p.LoginURL
 	params, _ := url.ParseQuery(a.RawQuery)
 	params.Set("redirect_uri", redirectURI)
@@ -93,6 +92,12 @@ func (p *ProviderData) GetLoginURL(redirectURI, state string) string {
 	if p.ProtectedResource != nil && p.ProtectedResource.String() != "" {
 		params.Add("resource", p.ProtectedResource.String())
 	}
+	return a, params
+}
+
+// GetLoginURL with typical oauth parameters
+func (p *ProviderData) GetLoginURL(redirectURI, state string) string {
+	a, params := DefaultGetLoginURL(p, redirectURI, state)
 	a.RawQuery = params.Encode()
 	return a.String()
 }

--- a/providers/provider_default.go
+++ b/providers/provider_default.go
@@ -89,9 +89,6 @@ func DefaultGetLoginURL(p *ProviderData, redirectURI, state string) (url.URL, ur
 	params.Set("client_id", p.ClientID)
 	params.Set("response_type", "code")
 	params.Add("state", state)
-	if p.ProtectedResource != nil && p.ProtectedResource.String() != "" {
-		params.Add("resource", p.ProtectedResource.String())
-	}
 	return a, params
 }
 

--- a/providers/provider_default.go
+++ b/providers/provider_default.go
@@ -90,6 +90,9 @@ func (p *ProviderData) GetLoginURL(redirectURI, state string) string {
 	params.Set("client_id", p.ClientID)
 	params.Set("response_type", "code")
 	params.Add("state", state)
+	if p.ProtectedResource != nil && p.ProtectedResource.String() != "" {
+		params.Add("resource", p.ProtectedResource.String())
+	}
 	a.RawQuery = params.Encode()
 	return a.String()
 }

--- a/providers/provider_default.go
+++ b/providers/provider_default.go
@@ -73,28 +73,9 @@ func (p *ProviderData) Redeem(ctx context.Context, redirectURL, code string) (s 
 	return
 }
 
-func DefaultGetLoginURL(p *ProviderData, redirectURI, state string) (url.URL, url.Values) {
-	a := *p.LoginURL
-	params, _ := url.ParseQuery(a.RawQuery)
-	params.Set("redirect_uri", redirectURI)
-	if p.AcrValues != "" {
-		params.Add("acr_values", p.AcrValues)
-	}
-	if p.Prompt != "" {
-		params.Set("prompt", p.Prompt)
-	} else { // Legacy variant of the prompt param:
-		params.Set("approval_prompt", p.ApprovalPrompt)
-	}
-	params.Add("scope", p.Scope)
-	params.Set("client_id", p.ClientID)
-	params.Set("response_type", "code")
-	params.Add("state", state)
-	return a, params
-}
-
 // GetLoginURL with typical oauth parameters
 func (p *ProviderData) GetLoginURL(redirectURI, state string) string {
-	a, params := DefaultGetLoginURL(p, redirectURI, state)
+	a, params := makeLoginURL(p, redirectURI, state)
 	a.RawQuery = params.Encode()
 	return a.String()
 }

--- a/providers/provider_default.go
+++ b/providers/provider_default.go
@@ -75,8 +75,8 @@ func (p *ProviderData) Redeem(ctx context.Context, redirectURL, code string) (s 
 
 // GetLoginURL with typical oauth parameters
 func (p *ProviderData) GetLoginURL(redirectURI, state string) string {
-	a, params := makeLoginURL(p, redirectURI, state)
-	a.RawQuery = params.Encode()
+	extraParams := url.Values{}
+	a := makeLoginURL(p, redirectURI, state, extraParams)
 	return a.String()
 }
 

--- a/providers/provider_default_test.go
+++ b/providers/provider_default_test.go
@@ -47,21 +47,3 @@ func TestAcrValuesConfigured(t *testing.T) {
 	result := p.GetLoginURL("https://my.test.app/oauth", "")
 	assert.Contains(t, result, "acr_values=testValue")
 }
-
-func TestProtectedResourceConfigured(t *testing.T) {
-	p := &ProviderData{
-		LoginURL: &url.URL{
-			Scheme: "http",
-			Host:   "my.test.idp",
-			Path:   "/oauth/authorize",
-		},
-		AcrValues: "testValue",
-		ProtectedResource: &url.URL{
-			Scheme: "http",
-			Host:   "my.resource.test",
-		},
-	}
-
-	result := p.GetLoginURL("https://my.test.app/oauth", "")
-	assert.Contains(t, result, "resource="+url.QueryEscape("http://my.resource.test"))
-}

--- a/providers/provider_default_test.go
+++ b/providers/provider_default_test.go
@@ -47,3 +47,21 @@ func TestAcrValuesConfigured(t *testing.T) {
 	result := p.GetLoginURL("https://my.test.app/oauth", "")
 	assert.Contains(t, result, "acr_values=testValue")
 }
+
+func TestProtectedResourceConfigured(t *testing.T) {
+	p := &ProviderData{
+		LoginURL: &url.URL{
+			Scheme: "http",
+			Host:   "my.test.idp",
+			Path:   "/oauth/authorize",
+		},
+		AcrValues: "testValue",
+		ProtectedResource: &url.URL{
+			Scheme: "http",
+			Host:   "my.resource.test",
+		},
+	}
+
+	result := p.GetLoginURL("https://my.test.app/oauth", "")
+	assert.Contains(t, result, "resource="+url.QueryEscape("http://my.resource.test"))
+}

--- a/providers/util.go
+++ b/providers/util.go
@@ -3,6 +3,7 @@ package providers
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 )
 
 const (
@@ -28,4 +29,23 @@ func makeOIDCHeader(accessToken string) http.Header {
 		acceptHeader: acceptApplicationJSON,
 	}
 	return makeAuthorizationHeader(tokenTypeBearer, accessToken, extraHeaders)
+}
+
+func makeLoginURL(p *ProviderData, redirectURI, state string) (url.URL, url.Values) {
+	a := *p.LoginURL
+	params, _ := url.ParseQuery(a.RawQuery)
+	params.Set("redirect_uri", redirectURI)
+	if p.AcrValues != "" {
+		params.Add("acr_values", p.AcrValues)
+	}
+	if p.Prompt != "" {
+		params.Set("prompt", p.Prompt)
+	} else { // Legacy variant of the prompt param:
+		params.Set("approval_prompt", p.ApprovalPrompt)
+	}
+	params.Add("scope", p.Scope)
+	params.Set("client_id", p.ClientID)
+	params.Set("response_type", "code")
+	params.Add("state", state)
+	return a, params
 }

--- a/providers/util.go
+++ b/providers/util.go
@@ -31,7 +31,7 @@ func makeOIDCHeader(accessToken string) http.Header {
 	return makeAuthorizationHeader(tokenTypeBearer, accessToken, extraHeaders)
 }
 
-func makeLoginURL(p *ProviderData, redirectURI, state string) (url.URL, url.Values) {
+func makeLoginURL(p *ProviderData, redirectURI, state string, extraParams url.Values) url.URL {
 	a := *p.LoginURL
 	params, _ := url.ParseQuery(a.RawQuery)
 	params.Set("redirect_uri", redirectURI)
@@ -47,5 +47,11 @@ func makeLoginURL(p *ProviderData, redirectURI, state string) (url.URL, url.Valu
 	params.Set("client_id", p.ClientID)
 	params.Set("response_type", "code")
 	params.Add("state", state)
-	return a, params
+	for n, p := range extraParams {
+		for _, v := range p {
+			params.Add(n, v)
+		}
+	}
+	a.RawQuery = params.Encode()
+	return a
 }


### PR DESCRIPTION
## Description

This passes the value given by `--resource=<my-resource>` to the login url.

## Motivation and Context

Without this, Azure will always return access tokens for graph.microsoft.com, which is not what one would expect when `--resource` is used. The modified method is not Azure specific, but I would assume that the resource parameter should also be present in other providers.

## How Has This Been Tested?

We have this code (based on a [master](cfa1160) version shortly after 6.0.0 was released) running in production since a few weeks.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
