### PR TITLE
Azure token refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 - [#754](https://github.com/oauth2-proxy/oauth2-proxy/pull/754) The Azure provider now has token refresh functionality implemented. This means that there won't
   be any redirects in the browser anymore when tokens expire, but instead a token refresh is initiated
   in the background, which leads to new tokens being returned in the cookies.
-- [#754](https://github.com/oauth2-proxy/oauth2-proxy/pull/754) Pleas note that `--cookie-refresh` must be 0 (the default) or equal to the token lifespan configured in Azure AD to make
+  - Please note that `--cookie-refresh` must be 0 (the default) or equal to the token lifespan configured in Azure AD to make
   Azure token refresh reliable. Setting this value to 0 means that it relies on the provider implementation
   to decide if a refresh is required.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,16 @@
   via the login url. If this option was used in the past, behavior will change with this release as it will
   affect the tokens returned by Azure. In the past, the tokens were always for `https://graph.microsoft.com` (the default)
   and will now be for the configured resource (if it exists, otherwise it will run into errors)
+- [#754](https://github.com/oauth2-proxy/oauth2-proxy/pull/754) The Azure provider now has token refresh functionality implemented. This means that there won't
+  be any redirects in the browser anymore when tokens expire, but instead a token refresh is initiated
+  in the background, which leads to new tokens being returned in the cookies.
+- [#754](https://github.com/oauth2-proxy/oauth2-proxy/pull/754) Pleas note that `--cookie-refresh` must be 0 (the default) or equal to the token lifespan configured in Azure AD to make
+  Azure token refresh reliable. Setting this value to 0 means that it relies on the provider implementation
+  to decide if a refresh is required.
 
 ## Changes since v6.1.1
 
+- [#754](https://github.com/oauth2-proxy/oauth2-proxy/pull/754) Azure token refresh (@codablock)
 - [#825](https://github.com/oauth2-proxy/oauth2-proxy/pull/825) Fix code coverage reporting on GitHub actions(@JoelSpeed)
 - [#796](https://github.com/oauth2-proxy/oauth2-proxy/pull/796) Deprecate GetUserName & GetEmailAdress for EnrichSessionState (@NickMeves)
 - [#705](https://github.com/oauth2-proxy/oauth2-proxy/pull/705) Add generic Header injectors for upstream request and response headers (@JoelSpeed)

--- a/providers/azure.go
+++ b/providers/azure.go
@@ -170,7 +170,6 @@ func (p *AzureProvider) RefreshSessionIfNeeded(ctx context.Context, s *sessions.
 	origExpiration := s.ExpiresOn
 
 	err := p.redeemRefreshToken(ctx, s)
-
 	if err != nil {
 		return false, fmt.Errorf("unable to redeem refresh token: %v", err)
 	}

--- a/providers/azure.go
+++ b/providers/azure.go
@@ -204,10 +204,12 @@ func (p *AzureProvider) redeemRefreshToken(ctx context.Context, s *sessions.Sess
 		return
 	}
 
+	now := time.Now()
 	expires := time.Unix(jsonResponse.ExpiresOn, 0)
 	s.AccessToken = jsonResponse.AccessToken
 	s.IDToken = jsonResponse.IDToken
 	s.RefreshToken = jsonResponse.RefreshToken
+	s.CreatedAt = &now
 	s.ExpiresOn = &expires
 	return
 }

--- a/providers/azure_test.go
+++ b/providers/azure_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/sessions"
+
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
 )
@@ -42,7 +44,7 @@ func TestNewAzureProvider(t *testing.T) {
 	g.Expect(providerData.LoginURL.String()).To(Equal("https://login.microsoftonline.com/common/oauth2/authorize"))
 	g.Expect(providerData.RedeemURL.String()).To(Equal("https://login.microsoftonline.com/common/oauth2/token"))
 	g.Expect(providerData.ProfileURL.String()).To(Equal("https://graph.microsoft.com/v1.0/me"))
-	g.Expect(providerData.ValidateURL.String()).To(Equal(""))
+	g.Expect(providerData.ValidateURL.String()).To(Equal("https://graph.microsoft.com/v1.0/me"))
 	g.Expect(providerData.Scope).To(Equal("openid"))
 }
 
@@ -97,7 +99,7 @@ func TestAzureSetTenant(t *testing.T) {
 		p.Data().ProfileURL.String())
 	assert.Equal(t, "https://graph.microsoft.com",
 		p.Data().ProtectedResource.String())
-	assert.Equal(t, "", p.Data().ValidateURL.String())
+	assert.Equal(t, "https://graph.microsoft.com/v1.0/me", p.Data().ValidateURL.String())
 	assert.Equal(t, "openid", p.Data().Scope)
 }
 
@@ -219,4 +221,48 @@ func TestAzureProviderProtectedResourceConfigured(t *testing.T) {
 	p.ProtectedResource, _ = url.Parse("http://my.resource.test")
 	result := p.GetLoginURL("https://my.test.app/oauth", "")
 	assert.Contains(t, result, "resource="+url.QueryEscape("http://my.resource.test"))
+}
+
+func TestAzureProviderGetsTokensInRedeem(t *testing.T) {
+	b := testAzureBackend(`{ "access_token": "some_access_token", "refresh_token": "some_refresh_token", "expires_on": "1136239445", "id_token": "some_id_token" }`)
+	defer b.Close()
+	timestamp, _ := time.Parse(time.RFC3339, "2006-01-02T22:04:05Z")
+	bURL, _ := url.Parse(b.URL)
+	p := testAzureProvider(bURL.Host)
+
+	session, err := p.Redeem(context.Background(), "http://redirect/", "code1234")
+	assert.Equal(t, nil, err)
+	assert.NotEqual(t, session, nil)
+	assert.Equal(t, "some_access_token", session.AccessToken)
+	assert.Equal(t, "some_refresh_token", session.RefreshToken)
+	assert.Equal(t, "some_id_token", session.IDToken)
+	assert.Equal(t, timestamp, session.ExpiresOn.UTC())
+}
+
+func TestAzureProviderNotRefreshWhenNotExpired(t *testing.T) {
+	p := testAzureProvider("")
+
+	expires := time.Now().Add(time.Duration(1) * time.Hour)
+	session := &sessions.SessionState{AccessToken: "some_access_token", RefreshToken: "some_refresh_token", IDToken: "some_id_token", ExpiresOn: &expires}
+	refreshNeeded, err := p.RefreshSessionIfNeeded(context.Background(), session)
+	assert.Equal(t, nil, err)
+	assert.False(t, refreshNeeded)
+}
+
+func TestAzureProviderRefreshWhenExpired(t *testing.T) {
+	b := testAzureBackend(`{ "access_token": "new_some_access_token", "refresh_token": "new_some_refresh_token", "expires_on": "32693148245", "id_token": "new_some_id_token" }`)
+	defer b.Close()
+	timestamp, _ := time.Parse(time.RFC3339, "3006-01-02T22:04:05Z")
+	bURL, _ := url.Parse(b.URL)
+	p := testAzureProvider(bURL.Host)
+
+	expires := time.Now().Add(time.Duration(-1) * time.Hour)
+	session := &sessions.SessionState{AccessToken: "some_access_token", RefreshToken: "some_refresh_token", IDToken: "some_id_token", ExpiresOn: &expires}
+	_, err := p.RefreshSessionIfNeeded(context.Background(), session)
+	assert.Equal(t, nil, err)
+	assert.NotEqual(t, session, nil)
+	assert.Equal(t, "new_some_access_token", session.AccessToken)
+	assert.Equal(t, "new_some_refresh_token", session.RefreshToken)
+	assert.Equal(t, "new_some_id_token", session.IDToken)
+	assert.Equal(t, timestamp, session.ExpiresOn.UTC())
 }


### PR DESCRIPTION
## Description

This is a re-submit of https://github.com/oauth2-proxy/oauth2-proxy/pull/278 after rebasing on the current master and applying necessary fixes needed due to changes in master since the original PR was created.

2 Additional changes were needed to fix issues we encountered with refresh tokens:
1. ~091727b09c49c19744e4ef46c21ca6a1c35d1a28~: This ensures that a refresh is performed early enough and that there is no chance of not refreshing and then running into an expired token a second later.
2. ~7505b020684d2f46bcc2afd01b926dca7880b10b: Tokens redeemed through a refresh token do not contain email addresses anymore. This behavior was quite strange and I can't really say what is going on. I figured out the easiest and still safe solution would be to allow empty emails when `--email-domain=*` is used.~ EDIT: This is obsolete due to https://github.com/oauth2-proxy/oauth2-proxy/pull/770

## Motivation and Context

This PR implements Azure token refreshs, as requested in https://github.com/oauth2-proxy/oauth2-proxy/issues/260

## How Has This Been Tested?

We have this code (based on a [master](cfa1160) version shortly after 6.0.0 was released) running in production since a few weeks. The original [PR](https://github.com/oauth2-proxy/oauth2-proxy/pull/278) also contained test cases for the new functionality, these tests are also present in this PR.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
