### PR TITLE
Support traefik forwardAuth

### DIFF
--- a/docs/5_endpoints.md
+++ b/docs/5_endpoints.md
@@ -17,6 +17,7 @@ OAuth2 Proxy responds directly to the following endpoints. All other endpoints w
 - /oauth2/callback - the URL used at the end of the OAuth cycle. The oauth app will be configured with this as the callback url.
 - /oauth2/userinfo - the URL is used to return user's email from the session in JSON format.
 - /oauth2/auth - only returns a 202 Accepted response or a 401 Unauthorized response; for use with the [Nginx `auth_request` directive](#nginx-auth-request)
+- /oauth2/auth_or_start - verify whether there is a valid session or else start the OAuth cycle
 
 ### Sign out
 

--- a/docs/5_endpoints.md
+++ b/docs/5_endpoints.md
@@ -17,7 +17,6 @@ OAuth2 Proxy responds directly to the following endpoints. All other endpoints w
 - /oauth2/callback - the URL used at the end of the OAuth cycle. The oauth app will be configured with this as the callback url.
 - /oauth2/userinfo - the URL is used to return user's email from the session in JSON format.
 - /oauth2/auth - only returns a 202 Accepted response or a 401 Unauthorized response; for use with the [Nginx `auth_request` directive](#nginx-auth-request)
-- /oauth2/auth_or_start - verify whether there is a valid session or else start the OAuth cycle
 
 ### Sign out
 

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -24,6 +24,7 @@ An example [oauth2-proxy.cfg]({{ site.gitweb }}/contrib/oauth2-proxy.cfg.example
 | ------ | ---- | ----------- | ------- |
 | `--acr-values` | string | optional, see [docs](https://openid.net/specs/openid-connect-eap-acr-values-1_0.html#acrValues) | `""` |
 | `--approval-prompt` | string | OAuth approval_prompt | `"force"` |
+| `--auth-endpoint-sign-in` | bool | Show sign in page, when request to /oauth2/auth is not authorized | `false` |
 | `--auth-logging` | bool | Log authentication attempts | true |
 | `--auth-logging-format` | string | Template for authentication log lines | see [Logging Configuration](#logging-configuration) |
 | `--authenticated-emails-file` | string | authenticate against emails via file (one per line) | |

--- a/pkg/apis/options/options.go
+++ b/pkg/apis/options/options.go
@@ -80,6 +80,7 @@ type Options struct {
 	SSLInsecureSkipVerify bool     `flag:"ssl-insecure-skip-verify" cfg:"ssl_insecure_skip_verify"`
 	SetXAuthRequest       bool     `flag:"set-xauthrequest" cfg:"set_xauthrequest"`
 	SetAuthorization      bool     `flag:"set-authorization-header" cfg:"set_authorization_header"`
+	AuthEndpointSignIn    bool     `flag:"auth-endpoint-sign-in" cfg:"auth_endpoint_sign_in"`
 	PassAuthorization     bool     `flag:"pass-authorization-header" cfg:"pass_authorization_header"`
 	SkipAuthPreflight     bool     `flag:"skip-auth-preflight" cfg:"skip_auth_preflight"`
 
@@ -162,6 +163,7 @@ func NewOptions() *Options {
 		PassAccessToken:                  false,
 		SetAuthorization:                 false,
 		PassAuthorization:                false,
+		AuthEndpointSignIn:               false,
 		PreferEmailToUser:                false,
 		Prompt:                           "", // Change to "login" when ApprovalPrompt officially deprecated
 		ApprovalPrompt:                   "force",
@@ -193,6 +195,7 @@ func NewFlagSet() *pflag.FlagSet {
 	flagSet.Bool("pass-user-headers", true, "pass X-Forwarded-User and X-Forwarded-Email information to upstream")
 	flagSet.String("basic-auth-password", "", "the password to set when passing the HTTP Basic Auth header")
 	flagSet.Bool("pass-access-token", false, "pass OAuth access_token to upstream via X-Forwarded-Access-Token header")
+	flagSet.Bool("auth-endpoint-sign-in", false, "show sign in page, when request to /oauth2/auth is not authorized")
 	flagSet.Bool("pass-authorization-header", false, "pass the Authorization Header to upstream")
 	flagSet.Bool("set-authorization-header", false, "set Authorization response headers (useful in Nginx auth_request mode)")
 	flagSet.StringSlice("skip-auth-regex", []string{}, "bypass authentication for requests path's that match (may be given multiple times)")

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -33,3 +33,21 @@ func GetRequestHost(req *http.Request) string {
 	}
 	return host
 }
+
+// GetRequestProto return the request host header or X-Forwarded-Proto if present
+func GetRequestProto(req *http.Request) string {
+	proto := req.Header.Get("X-Forwarded-Proto")
+	if proto == "" {
+		proto = req.URL.Scheme
+	}
+	return proto
+}
+
+// GetRequestUri return the request host header or X-Forwarded-Uri if present
+func GetRequestURI(req *http.Request) string {
+	uri := req.Header.Get("X-Forwarded-Uri")
+	if uri == "" {
+		uri = req.URL.Path
+	}
+	return uri
+}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -110,3 +110,29 @@ func TestGetRequestHost(t *testing.T) {
 	extHost := GetRequestHost(proxyReq)
 	g.Expect(extHost).To(Equal("external.example.com"))
 }
+
+func TestGetRequestProto(t *testing.T) {
+	g := NewWithT(t)
+
+	req := httptest.NewRequest("GET", "https://example.com", nil)
+	proto := GetRequestProto(req)
+	g.Expect(proto).To(Equal("https"))
+
+	proxyReq := httptest.NewRequest("GET", "http://internal.example.com", nil)
+	proxyReq.Header.Add("X-Forwarded-Proto", "http")
+	extProto := GetRequestProto(proxyReq)
+	g.Expect(extProto).To(Equal("http"))
+}
+
+func TestGetRequestURI(t *testing.T) {
+	g := NewWithT(t)
+
+	req := httptest.NewRequest("GET", "https://example.com/ping", nil)
+	uri := GetRequestURI(req)
+	g.Expect(uri).To(Equal("/ping"))
+
+	proxyReq := httptest.NewRequest("GET", "http://internal.example.com/ping", nil)
+	proxyReq.Header.Add("X-Forwarded-Uri", "/ping")
+	extURI := GetRequestURI(proxyReq)
+	g.Expect(extURI).To(Equal("/ping"))
+}


### PR DESCRIPTION
Add support for traefiks X-Forwarded headers:
- X-Forwarded-Proto
- X-Forwarded-Host
- X-Forwarded-Uri
Use them to construct a redirect uri, when X-Auth-Request-Redirect
is not present or valid.

Use one endpoint for auth and sign_in, which is the way
thomseddon/traefik-forward-auth works.
This also allows to skip the auth provider button.

Fixes #46

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
