### PR TITLE
docs: fix Keycloak provider documentation

### DIFF
--- a/docs/2_auth.md
+++ b/docs/2_auth.md
@@ -142,9 +142,9 @@ Make sure you set the following to the appropriate url:
     -provider=keycloak
     -client-id=<client you have created>
     -client-secret=<your client's secret>
-    -login-url="http(s)://<keycloak host>/realms/<your realm>/protocol/openid-connect/auth"
-    -redeem-url="http(s)://<keycloak host>/realms/<your realm>/protocol/openid-connect/token"
-    -validate-url="http(s)://<keycloak host>/realms/<your realm>/protocol/openid-connect/userinfo"
+    -login-url="http(s)://<keycloak host>/auth/realms/<your realm>/protocol/openid-connect/auth"
+    -redeem-url="http(s)://<keycloak host>/auth/realms/<your realm>/protocol/openid-connect/token"
+    -validate-url="http(s)://<keycloak host>/auth/realms/<your realm>/protocol/openid-connect/userinfo"
     -keycloak-group=<user_group>
 
 The group management in keycloak is using a tree. If you create a group named admin in keycloak you should define the 'keycloak-group' value to /admin.


### PR DESCRIPTION
## Description

Corrects `login-url`, `redeem-url` and `validate-url` documentation for Keycloak provider  according to [official guide](https://www.keycloak.org/docs/4.8/authorization_services/)
