### PR TITLE
Support HTTP method based allowlists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@
 
 ## Important Notes
 
-- [#575](https://github.com/oauth2-proxy/oauth2-proxy/pull/575) Sessions from v5.1.1 or earlier will no longer validate since they were not signed with SHA1.
-  - Sessions from v6.0.0 or later had a graceful conversion to SHA256 that resulted in no reauthentication
-  - Upgrading from v5.1.1 or earlier will result in a reauthentication
 - [#789](https://github.com/oauth2-proxy/oauth2-proxy/pull/789) `--skip-auth-route` is (almost) backwards compatible with `--skip-auth-regex`
   - We are marking `--skip-auth-regex` as DEPRECATED and will remove it in the next major version.
   - If your regex contains an `=` and you want it for all methods, you will need to add a leading `=` (this is the area where `--skip-auth-regex` doesn't port perfectly)
+- [#575](https://github.com/oauth2-proxy/oauth2-proxy/pull/575) Sessions from v5.1.1 or earlier will no longer validate since they were not signed with SHA1.
+  - Sessions from v6.0.0 or later had a graceful conversion to SHA256 that resulted in no reauthentication
+  - Upgrading from v5.1.1 or earlier will result in a reauthentication
 - [#616](https://github.com/oauth2-proxy/oauth2-proxy/pull/616) Ensure you have configured oauth2-proxy to use the `groups` scope. The user may be logged out initially as they may not currently have the `groups` claim however after going back through login process wil be authenticated.
 
 ## Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - [#575](https://github.com/oauth2-proxy/oauth2-proxy/pull/575) Sessions from v5.1.1 or earlier will no longer validate since they were not signed with SHA1.
   - Sessions from v6.0.0 or later had a graceful conversion to SHA256 that resulted in no reauthentication
   - Upgrading from v5.1.1 or earlier will result in a reauthentication
+- [#789](https://github.com/oauth2-proxy/oauth2-proxy/pull/789) `--skip-auth-route` is (almost) backwards compatible with `--skip-auth-regex`
+  - We are marking `--skip-auth-regex` as DEPRECATED and will remove it in the next major version.
+  - If your regex contains an `=` and you want it for all methods, you will need to add a leading `=` (this is the area where `--skip-auth-regex` doesn't port perfectly)
 - [#616](https://github.com/oauth2-proxy/oauth2-proxy/pull/616) Ensure you have configured oauth2-proxy to use the `groups` scope. The user may be logged out initially as they may not currently have the `groups` claim however after going back through login process wil be authenticated.
 
 ## Breaking Changes
@@ -23,6 +26,7 @@
 ## Changes since v6.1.1
 
 - [#753](https://github.com/oauth2-proxy/oauth2-proxy/pull/753) Pass resource parameter in login url (@codablock)
+- [#789](https://github.com/oauth2-proxy/oauth2-proxy/pull/789) Add `--skip-auth-route` configuration option for `METHOD=pathRegex` based allowlists (@NickMeves)
 - [#575](https://github.com/oauth2-proxy/oauth2-proxy/pull/575) Stop accepting legacy SHA1 signed cookies (@NickMeves)
 - [#722](https://github.com/oauth2-proxy/oauth2-proxy/pull/722) Validate Redis configuration options at startup (@NickMeves)
 - [#791](https://github.com/oauth2-proxy/oauth2-proxy/pull/791) Remove GetPreferredUsername method from provider interface (@NickMeves)

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -119,8 +119,9 @@ An example [oauth2-proxy.cfg]({{ site.gitweb }}/contrib/oauth2-proxy.cfg.example
 | `--signature-key` | string | GAP-Signature request signature key (algorithm:secretkey) | |
 | `--silence-ping-logging` | bool | disable logging of requests to ping endpoint | false |
 | `--skip-auth-preflight` | bool | will skip authentication for OPTIONS requests | false |
-| `--skip-auth-regex` | string | bypass authentication for requests paths that match (may be given multiple times) | |
-| `--skip-auth-strip-headers` | bool | strips `X-Forwarded-*` style authentication headers & `Authorization` header if they would be set by oauth2-proxy for request paths in `--skip-auth-regex` | false |
+| `--skip-auth-regex` | string \| list | (DEPRECATED for `--skip-auth-route`) bypass authentication for requests paths that match (may be given multiple times) | |
+| `--skip-auth-route` | string \| list | bypass authentication for requests that match the method & path. Format: method=path_regex OR path_regex alone for all methods | |
+| `--skip-auth-strip-headers` | bool | strips `X-Forwarded-*` style authentication headers & `Authorization` header if they would be set by oauth2-proxy for allowlisted requests (`--skip-auth-route`, `--skip-auth-regex`, `--skip-auth-preflight`, `--trusted-ip`) | false |
 | `--skip-jwt-bearer-tokens` | bool | will skip requests that have verified JWT bearer tokens | false |
 | `--skip-oidc-discovery` | bool | bypass OIDC endpoint discovery. `--login-url`, `--redeem-url` and `--oidc-jwks-url` must be configured in this case | false |
 | `--skip-provider-button` | bool | will skip sign-in-page to directly reach the next step: oauth/start | false |

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -293,6 +293,7 @@ func buildRoutesAllowlist(opts *options.Options) ([]*allowedRoute, error) {
 		if err != nil {
 			return nil, err
 		}
+		logger.Printf("Skipping auth - Method: ALL | Path: %s", path)
 		routes = append(routes, &allowedRoute{
 			method:    "",
 			pathRegex: compiledRegex,
@@ -318,6 +319,7 @@ func buildRoutesAllowlist(opts *options.Options) ([]*allowedRoute, error) {
 		if err != nil {
 			return nil, err
 		}
+		logger.Printf("Skipping auth - Method: %s | Path: %s", method, path)
 		routes = append(routes, &allowedRoute{
 			method:    method,
 			pathRegex: compiledRegex,

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -286,7 +286,7 @@ func buildSignInMessage(opts *options.Options) string {
 // SkipAuthRegex option (paths only support) or newer SkipAuthRoutes option
 // (method=path support)
 func buildRoutesAllowlist(opts *options.Options) ([]*allowedRoute, error) {
-	var routes []*allowedRoute
+	routes := make([]*allowedRoute, 0, len(opts.SkipAuthRegex)+len(opts.SkipAuthRoutes))
 
 	for _, path := range opts.SkipAuthRegex {
 		compiledRegex, err := regexp.Compile(path)

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -76,7 +76,7 @@ type OAuthProxy struct {
 	AuthOnlyPath      string
 	UserInfoPath      string
 
-	allowedRoutes           []*allowedRoute
+	allowedRoutes           []allowedRoute
 	redirectURL             *url.URL // the url to receive requests at
 	whitelistDomains        []string
 	provider                providers.Provider
@@ -285,8 +285,8 @@ func buildSignInMessage(opts *options.Options) string {
 // buildRoutesAllowlist builds an []allowedRoute  list from either the legacy
 // SkipAuthRegex option (paths only support) or newer SkipAuthRoutes option
 // (method=path support)
-func buildRoutesAllowlist(opts *options.Options) ([]*allowedRoute, error) {
-	routes := make([]*allowedRoute, 0, len(opts.SkipAuthRegex)+len(opts.SkipAuthRoutes))
+func buildRoutesAllowlist(opts *options.Options) ([]allowedRoute, error) {
+	routes := make([]allowedRoute, 0, len(opts.SkipAuthRegex)+len(opts.SkipAuthRoutes))
 
 	for _, path := range opts.SkipAuthRegex {
 		compiledRegex, err := regexp.Compile(path)
@@ -294,7 +294,7 @@ func buildRoutesAllowlist(opts *options.Options) ([]*allowedRoute, error) {
 			return nil, err
 		}
 		logger.Printf("Skipping auth - Method: ALL | Path: %s", path)
-		routes = append(routes, &allowedRoute{
+		routes = append(routes, allowedRoute{
 			method:    "",
 			pathRegex: compiledRegex,
 		})
@@ -306,13 +306,13 @@ func buildRoutesAllowlist(opts *options.Options) ([]*allowedRoute, error) {
 			path   string
 		)
 
-		parts := strings.Split(methodPath, "=")
+		parts := strings.SplitN(methodPath, "=", 2)
 		if len(parts) == 1 {
 			method = ""
 			path = parts[0]
 		} else {
 			method = strings.ToUpper(parts[0])
-			path = strings.Join(parts[1:], "=")
+			path = parts[1]
 		}
 
 		compiledRegex, err := regexp.Compile(path)
@@ -320,7 +320,7 @@ func buildRoutesAllowlist(opts *options.Options) ([]*allowedRoute, error) {
 			return nil, err
 		}
 		logger.Printf("Skipping auth - Method: %s | Path: %s", method, path)
-		routes = append(routes, &allowedRoute{
+		routes = append(routes, allowedRoute{
 			method:    method,
 			pathRegex: compiledRegex,
 		})

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -2365,9 +2365,9 @@ func Test_buildRoutesAllowlist(t *testing.T) {
 			if tc.shouldError {
 				assert.Error(t, err)
 				return
-			} else {
-				assert.NoError(t, err)
 			}
+			assert.NoError(t, err)
+
 			for i, route := range routes {
 				assert.Greater(t, len(tc.expectedMethods), i)
 				assert.Equal(t, route.method, tc.expectedMethods[i])

--- a/pkg/validation/allowlist.go
+++ b/pkg/validation/allowlist.go
@@ -1,0 +1,70 @@
+package validation
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/oauth2-proxy/oauth2-proxy/pkg/apis/options"
+	"github.com/oauth2-proxy/oauth2-proxy/pkg/ip"
+)
+
+func validateAllowlists(o *options.Options) []string {
+	msgs := []string{}
+
+	msgs = append(msgs, validateRoutes(o)...)
+	msgs = append(msgs, validateRegexes(o)...)
+	msgs = append(msgs, validateTrustedIPs(o)...)
+
+	if len(o.TrustedIPs) > 0 && o.ReverseProxy {
+		_, err := fmt.Fprintln(os.Stderr, "WARNING: mixing --trusted-ip with --reverse-proxy is a potential security vulnerability. An attacker can inject a trusted IP into an X-Real-IP or X-Forwarded-For header if they aren't properly protected outside of oauth2-proxy")
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	return msgs
+}
+
+// validateRoutes validates method=path routes passed with options.SkipAuthRoutes
+func validateRoutes(o *options.Options) []string {
+	msgs := []string{}
+	for _, route := range o.SkipAuthRoutes {
+		var regex string
+		parts := strings.Split(route, "=")
+		if len(parts) == 1 {
+			regex = parts[0]
+		} else {
+			regex = strings.Join(parts[1:], "=")
+		}
+		_, err := regexp.Compile(regex)
+		if err != nil {
+			msgs = append(msgs, fmt.Sprintf("error compiling regex /%s/: %v", regex, err))
+		}
+	}
+	return msgs
+}
+
+// validateRegex validates regex paths passed with options.SkipAuthRegex
+func validateRegexes(o *options.Options) []string {
+	msgs := []string{}
+	for _, regex := range o.SkipAuthRegex {
+		_, err := regexp.Compile(regex)
+		if err != nil {
+			msgs = append(msgs, fmt.Sprintf("error compiling regex /%s/: %v", regex, err))
+		}
+	}
+	return msgs
+}
+
+// validateTrustedIPs validates IP/CIDRs for IP based allowlists
+func validateTrustedIPs(o *options.Options) []string {
+	msgs := []string{}
+	for i, ipStr := range o.TrustedIPs {
+		if nil == ip.ParseIPNet(ipStr) {
+			msgs = append(msgs, fmt.Sprintf("trusted_ips[%d] (%s) could not be recognized", i, ipStr))
+		}
+	}
+	return msgs
+}

--- a/pkg/validation/allowlist.go
+++ b/pkg/validation/allowlist.go
@@ -6,8 +6,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/oauth2-proxy/oauth2-proxy/pkg/apis/options"
-	"github.com/oauth2-proxy/oauth2-proxy/pkg/ip"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/ip"
 )
 
 func validateAllowlists(o *options.Options) []string {
@@ -32,11 +32,11 @@ func validateRoutes(o *options.Options) []string {
 	msgs := []string{}
 	for _, route := range o.SkipAuthRoutes {
 		var regex string
-		parts := strings.Split(route, "=")
+		parts := strings.SplitN(route, "=", 2)
 		if len(parts) == 1 {
 			regex = parts[0]
 		} else {
-			regex = strings.Join(parts[1:], "=")
+			regex = parts[1]
 		}
 		_, err := regexp.Compile(regex)
 		if err != nil {

--- a/pkg/validation/allowlist_test.go
+++ b/pkg/validation/allowlist_test.go
@@ -1,10 +1,11 @@
 package validation
 
 import (
-	"github.com/oauth2-proxy/oauth2-proxy/pkg/apis/options"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
 )
 
 var _ = Describe("Allowlist", func() {

--- a/pkg/validation/allowlist_test.go
+++ b/pkg/validation/allowlist_test.go
@@ -1,0 +1,149 @@
+package validation
+
+import (
+	"testing"
+
+	"github.com/oauth2-proxy/oauth2-proxy/pkg/apis/options"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_validateAllowlists(t *testing.T) {
+	opts := &options.Options{
+		SkipAuthRoutes: []string{
+			"POST=/foo/bar",
+			"PUT=^/foo/bar$",
+		},
+		SkipAuthRegex: []string{"/foo/baz"},
+		TrustedIPs: []string{
+			"10.32.0.1/32",
+			"43.36.201.0/24",
+		},
+	}
+	assert.Equal(t, []string{}, validateAllowlists(opts))
+}
+
+func Test_validateRoutes(t *testing.T) {
+	testCases := map[string]struct {
+		Regexes  []string
+		Expected []string
+	}{
+		"Valid regex routes": {
+			Regexes: []string{
+				"/foo",
+				"POST=/foo/bar",
+				"PUT=^/foo/bar$",
+				"DELETE=/crazy/(?:regex)?/[^/]+/stuff$",
+			},
+			Expected: []string{},
+		},
+		"Bad regexes do not compile": {
+			Regexes: []string{
+				"POST=/(foo",
+				"OPTIONS=/foo/bar)",
+				"GET=^]/foo/bar[$",
+				"GET=^]/foo/bar[$",
+			},
+			Expected: []string{
+				"error compiling regex //(foo/: error parsing regexp: missing closing ): `/(foo`",
+				"error compiling regex //foo/bar)/: error parsing regexp: unexpected ): `/foo/bar)`",
+				"error compiling regex /^]/foo/bar[$/: error parsing regexp: missing closing ]: `[$`",
+				"error compiling regex /^]/foo/bar[$/: error parsing regexp: missing closing ]: `[$`",
+			},
+		},
+	}
+
+	for testName, tc := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			opts := &options.Options{
+				SkipAuthRoutes: tc.Regexes,
+			}
+			msgs := validateRoutes(opts)
+			assert.Equal(t, tc.Expected, msgs)
+		})
+	}
+}
+
+func Test_validateRegexes(t *testing.T) {
+	testCases := map[string]struct {
+		Regexes  []string
+		Expected []string
+	}{
+		"Valid regex routes": {
+			Regexes: []string{
+				"/foo",
+				"/foo/bar",
+				"^/foo/bar$",
+				"/crazy/(?:regex)?/[^/]+/stuff$",
+			},
+			Expected: []string{},
+		},
+		"Bad regexes do not compile": {
+			Regexes: []string{
+				"/(foo",
+				"/foo/bar)",
+				"^]/foo/bar[$",
+				"^]/foo/bar[$",
+			},
+			Expected: []string{
+				"error compiling regex //(foo/: error parsing regexp: missing closing ): `/(foo`",
+				"error compiling regex //foo/bar)/: error parsing regexp: unexpected ): `/foo/bar)`",
+				"error compiling regex /^]/foo/bar[$/: error parsing regexp: missing closing ]: `[$`",
+				"error compiling regex /^]/foo/bar[$/: error parsing regexp: missing closing ]: `[$`",
+			},
+		},
+	}
+
+	for testName, tc := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			opts := &options.Options{
+				SkipAuthRegex: tc.Regexes,
+			}
+			msgs := validateRegexes(opts)
+			assert.Equal(t, tc.Expected, msgs)
+		})
+	}
+}
+
+func Test_validateTrustedIPs(t *testing.T) {
+	testCases := map[string]struct {
+		TrustedIPs []string
+		Expected   []string
+	}{
+		"Non-overlapping valid IPs": {
+			TrustedIPs: []string{
+				"127.0.0.1",
+				"10.32.0.1/32",
+				"43.36.201.0/24",
+				"::1",
+				"2a12:105:ee7:9234:0:0:0:0/64",
+			},
+			Expected: []string{},
+		},
+		"Overlapping valid IPs": {
+			TrustedIPs: []string{
+				"135.180.78.199",
+				"135.180.78.199/32",
+				"d910:a5a1:16f8:ddf5:e5b9:5cef:a65e:41f4",
+				"d910:a5a1:16f8:ddf5:e5b9:5cef:a65e:41f4/128",
+			},
+			Expected: []string{},
+		},
+		"Invalid IPs": {
+			TrustedIPs: []string{"[::1]", "alkwlkbn/32"},
+			Expected: []string{
+				"trusted_ips[0] ([::1]) could not be recognized",
+				"trusted_ips[1] (alkwlkbn/32) could not be recognized",
+			},
+		},
+	}
+
+	for testName, tc := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			opts := &options.Options{
+				TrustedIPs: tc.TrustedIPs,
+			}
+			msgs := validateTrustedIPs(opts)
+			assert.Equal(t, tc.Expected, msgs)
+		})
+	}
+}

--- a/pkg/validation/options_test.go
+++ b/pkg/validation/options_test.go
@@ -2,7 +2,6 @@ package validation
 
 import (
 	"crypto"
-	"errors"
 	"io/ioutil"
 	"net/url"
 	"os"
@@ -78,12 +77,19 @@ func TestClientSecretFileOption(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create temp file: %v", err)
 	}
-	f.WriteString("testcase")
+	_, err = f.WriteString("testcase")
+	if err != nil {
+		t.Fatalf("failed to write to temp file: %v", err)
+	}
 	if err := f.Close(); err != nil {
 		t.Fatalf("failed to close temp file: %v", err)
 	}
 	clientSecretFileName := f.Name()
-	defer os.Remove(clientSecretFileName)
+	defer func(t *testing.T) {
+		if err := os.Remove(clientSecretFileName); err != nil {
+			t.Fatalf("failed to delete temp file: %v", err)
+		}
+	}(t)
 
 	o := options.NewOptions()
 	o.Cookie.Secret = cookieSecret
@@ -142,41 +148,6 @@ func TestRedirectURL(t *testing.T) {
 	expected := &url.URL{
 		Scheme: "https", Host: "myhost.com", Path: "/oauth2/callback"}
 	assert.Equal(t, expected, o.GetRedirectURL())
-}
-
-func TestCompiledRegex(t *testing.T) {
-	o := testOptions()
-	regexps := []string{"/foo/.*", "/ba[rz]/quux"}
-	o.SkipAuthRegex = regexps
-	assert.Equal(t, nil, Validate(o))
-	actual := make([]string, 0)
-	for _, regex := range o.GetCompiledRegex() {
-		actual = append(actual, regex.String())
-	}
-	assert.Equal(t, regexps, actual)
-}
-
-func TestCompiledRegexError(t *testing.T) {
-	o := testOptions()
-	o.SkipAuthRegex = []string{"(foobaz", "barquux)"}
-	err := Validate(o)
-	assert.NotEqual(t, nil, err)
-
-	expected := errorMsg([]string{
-		"error compiling regex=\"(foobaz\" error parsing regexp: " +
-			"missing closing ): `(foobaz`",
-		"error compiling regex=\"barquux)\" error parsing regexp: " +
-			"unexpected ): `barquux)`"})
-	assert.Equal(t, expected, err.Error())
-
-	o.SkipAuthRegex = []string{"foobaz", "barquux)"}
-	err = Validate(o)
-	assert.NotEqual(t, nil, err)
-
-	expected = errorMsg([]string{
-		"error compiling regex=\"barquux)\" error parsing regexp: " +
-			"unexpected ): `barquux)`"})
-	assert.Equal(t, expected, err.Error())
 }
 
 func TestDefaultProviderApiSettings(t *testing.T) {
@@ -335,45 +306,6 @@ func TestRealClientIPHeader(t *testing.T) {
 	})
 	assert.Equal(t, expected, err.Error())
 	assert.Nil(t, o.GetRealClientIPParser())
-}
-
-func TestIPCIDRSetOption(t *testing.T) {
-	tests := []struct {
-		name       string
-		trustedIPs []string
-		err        error
-	}{
-		{
-			"TestSomeIPs",
-			[]string{"127.0.0.1", "10.32.0.1/32", "43.36.201.0/24", "::1", "2a12:105:ee7:9234:0:0:0:0/64"},
-			nil,
-		}, {
-			"TestOverlappingIPs",
-			[]string{"135.180.78.199", "135.180.78.199/32", "d910:a5a1:16f8:ddf5:e5b9:5cef:a65e:41f4", "d910:a5a1:16f8:ddf5:e5b9:5cef:a65e:41f4/128"},
-			nil,
-		}, {
-			"TestInvalidIPs",
-			[]string{"[::1]", "alkwlkbn/32"},
-			errors.New(
-				"invalid configuration:\n" +
-					"  trusted_ips[0] ([::1]) could not be recognized\n" +
-					"  trusted_ips[1] (alkwlkbn/32) could not be recognized",
-			),
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			o := testOptions()
-			o.TrustedIPs = tt.trustedIPs
-			err := Validate(o)
-			if tt.err == nil {
-				assert.Nil(t, err)
-			} else {
-				assert.Equal(t, tt.err.Error(), err.Error())
-			}
-		})
-	}
 }
 
 func TestProviderCAFilesError(t *testing.T) {


### PR DESCRIPTION
Bring over the HTTP Method allowlist & improved validation organization from this defunct PR: https://github.com/oauth2-proxy/oauth2-proxy/pull/685

## Description

Add `--skip-auth-route` option that takes the form `METHOD=PathRegex` or `PathRegex` (for backwards compatible with `--skip-auth-regex` with the eventual intent on deprecating that option).

## Motivation and Context

REST APIs might have very different functionality between a GET vs other HTTP methods that alter state. This supports allowlisting an HTTP method for a given regex path.

E.g. `GET /data/1` can be allowlisted to require no authentication, while `POST /data/1` requires authentication to update the record.

## How Has This Been Tested?

Unit Tests.  TODO - interactive tests

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
