### PR TITLE
Remove provider GetPreferredUsername getter method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 - [#575](https://github.com/oauth2-proxy/oauth2-proxy/pull/575) Stop accepting legacy SHA1 signed cookies (@NickMeves)
 - [#722](https://github.com/oauth2-proxy/oauth2-proxy/pull/722) Validate Redis configuration options at startup (@NickMeves)
+- [#791](https://github.com/oauth2-proxy/oauth2-proxy/pull/791) Remove GetPreferredUsername method from provider interface (@NickMeves)
 - [#764](https://github.com/oauth2-proxy/oauth2-proxy/pull/764) Document bcrypt encryption for htpasswd (and hide SHA) (@lentzi90)
 - [#616](https://github.com/oauth2-proxy/oauth2-proxy/pull/616) Add support to ensure user belongs in required groups when using the OIDC provider (@stefansedich)
 

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -310,13 +310,6 @@ func (p *OAuthProxy) redeemCode(ctx context.Context, host, code string) (s *sess
 		s.Email, err = p.provider.GetEmailAddress(ctx, s)
 	}
 
-	if s.PreferredUsername == "" {
-		s.PreferredUsername, err = p.provider.GetPreferredUsername(ctx, s)
-		if err != nil && err.Error() == "not implemented" {
-			err = nil
-		}
-	}
-
 	if s.User == "" {
 		s.User, err = p.provider.GetUserName(ctx, s)
 		if err != nil && err.Error() == "not implemented" {

--- a/providers/provider_default.go
+++ b/providers/provider_default.go
@@ -104,11 +104,6 @@ func (p *ProviderData) GetUserName(ctx context.Context, s *sessions.SessionState
 	return "", errors.New("not implemented")
 }
 
-// GetPreferredUsername returns the Account preferred username
-func (p *ProviderData) GetPreferredUsername(ctx context.Context, s *sessions.SessionState) (string, error) {
-	return "", errors.New("not implemented")
-}
-
 // ValidateGroup validates that the provided email exists in the configured provider
 // email group(s).
 func (p *ProviderData) ValidateGroup(email string) bool {

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -12,7 +12,6 @@ type Provider interface {
 	Data() *ProviderData
 	GetEmailAddress(ctx context.Context, s *sessions.SessionState) (string, error)
 	GetUserName(ctx context.Context, s *sessions.SessionState) (string, error)
-	GetPreferredUsername(ctx context.Context, s *sessions.SessionState) (string, error)
 	Redeem(ctx context.Context, redirectURI, code string) (*sessions.SessionState, error)
 	ValidateGroup(string) bool
 	ValidateSessionState(ctx context.Context, s *sessions.SessionState) bool


### PR DESCRIPTION
## Description

Removes GetPreferredUsername method from our Provider interface.

## Motivation and Context

It isn't used at all at the moment and the current codepath it consumes is just bloat.

Longer term, we want to support optional session fields from claims (and arbitrary `X-Forwarded-*` headers from those). At that point, we'd consider `PreferredUsername` an optional claim/field and remove it from our mandatory canonical list.

We'd leave only User, Email & Groups as the mandatory session fields.

## How Has This Been Tested?

Unit Tests

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
