### PR TITLE
fix: backward compatible with non cipher token

### DIFF
--- a/pkg/apis/sessions/session_state.go
+++ b/pkg/apis/sessions/session_state.go
@@ -145,6 +145,29 @@ func LegacyV5DecodeSessionState(v string, c encryption.Cipher) (*SessionState, e
 	return &ss, nil
 }
 
+// LegacyV5DecodeSessionState decodes a legacy JSON session cookie string into a SessionState
+func LegacyV5EncodeSessionState(v string, c encryption.Cipher) ([]byte, error) {
+	var ss SessionState
+	err := json.Unmarshal([]byte(v), &ss)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshalling in Encode session: %w", err)
+	}
+	for _, s := range []*string{
+		&ss.User,
+		&ss.Email,
+		&ss.PreferredUsername,
+		&ss.AccessToken,
+		&ss.IDToken,
+		&ss.RefreshToken,
+	} {
+		err := into(s, c.Encrypt)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return json.Marshal(&ss)
+}
+
 // codecFunc is a function that takes a []byte and encodes/decodes it
 type codecFunc func([]byte) ([]byte, error)
 

--- a/pkg/sessions/cookie/session_store.go
+++ b/pkg/sessions/cookie/session_store.go
@@ -107,7 +107,14 @@ func sessionFromCookie(v []byte, c encryption.Cipher) (s *sessions.SessionState,
 	if err != nil {
 		// Legacy used Base64 + AES CFB
 		legacyCipher := encryption.NewBase64Cipher(c)
-		return sessions.LegacyV5DecodeSessionState(string(v), legacyCipher)
+		ss, err = sessions.LegacyV5DecodeSessionState(string(v), legacyCipher)
+		if err != nil {
+			tempVal, err := sessions.LegacyV5EncodeSessionState(string(v), legacyCipher)
+			if err != nil {
+				logger.Printf("encrypt with legacy fail :%s", err)
+			}
+			return sessions.LegacyV5DecodeSessionState(string(tempVal), legacyCipher)
+		}
 	}
 	return ss, nil
 }


### PR DESCRIPTION
Backward compatible non cipher token to let keep user login session

## Description

I try to encrypt the old version token for the the legacy decrypt function. Try to keep user session until cookie expired instead of kill user session due to service update version.

## Motivation and Context

I am using bitly/OAuth2_Proxy in many internal service and want to migrate to new version, but I found an issue of new version don't support backward compatible the old token, it will force user logout immediately. 

I try to add a fallback function to resolve this problem, but I think this is not a best solution.
Will maintainers provide an option or config for support the old version issue? 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I use 3.1.1 version to build service and login with google, then change to use 6.1.0 to build service with same config. The upstream set to an echo server to print out request info.
If don't apply my code changes user require to login again.
If applied the changes the user login session will keep and redirect to upstream service

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
