### PR TITLE
add --basic-auth-user option to allow overriding username

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ lint: validate-go-version
 build: validate-go-version clean $(BINARY)
 
 $(BINARY):
-	GO111MODULE=on CGO_ENABLED=0 $(GO) build -a -installsuffix cgo -ldflags="-X main.VERSION=${VERSION}" -o $@ github.com/oauth2-proxy/oauth2-proxy
+	GO111MODULE=on CGO_ENABLED=0 $(GO) build -a -installsuffix cgo -ldflags="-X main.VERSION=${VERSION}" -o $@
 
 .PHONY: docker
 docker:

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -28,6 +28,7 @@ An example [oauth2-proxy.cfg]({{ site.gitweb }}/contrib/oauth2-proxy.cfg.example
 | `--auth-logging-format` | string | Template for authentication log lines | see [Logging Configuration](#logging-configuration) |
 | `--authenticated-emails-file` | string | authenticate against emails via file (one per line) | |
 | `--azure-tenant` | string | go to a tenant-specific or common (tenant-independent) endpoint. | `"common"` |
+| `--basic-auth-user` | string | the username to set when passing the HTTP Basic Auth header. Leave unset to use the session username/email. | |
 | `--basic-auth-password` | string | the password to set when passing the HTTP Basic Auth header | |
 | `--client-id` | string | the OAuth Client ID, e.g. `"123456.apps.googleusercontent.com"` | |
 | `--client-secret` | string | the OAuth Client Secret | |

--- a/pkg/apis/options/options.go
+++ b/pkg/apis/options/options.go
@@ -73,6 +73,7 @@ type Options struct {
 	PassBasicAuth         bool     `flag:"pass-basic-auth" cfg:"pass_basic_auth"`
 	SetBasicAuth          bool     `flag:"set-basic-auth" cfg:"set_basic_auth"`
 	PreferEmailToUser     bool     `flag:"prefer-email-to-user" cfg:"prefer_email_to_user"`
+	BasicAuthUser         string   `flag:"basic-auth-user" cfg:"basic_auth_user"`
 	BasicAuthPassword     string   `flag:"basic-auth-password" cfg:"basic_auth_password"`
 	PassAccessToken       bool     `flag:"pass-access-token" cfg:"pass_access_token"`
 	SkipProviderButton    bool     `flag:"skip-provider-button" cfg:"skip_provider_button"`

--- a/pkg/apis/options/options.go
+++ b/pkg/apis/options/options.go
@@ -192,6 +192,7 @@ func NewFlagSet() *pflag.FlagSet {
 	flagSet.Bool("set-basic-auth", false, "set HTTP Basic Auth information in response (useful in Nginx auth_request mode)")
 	flagSet.Bool("prefer-email-to-user", false, "Prefer to use the Email address as the Username when passing information to upstream. Will only use Username if Email is unavailable, eg. htaccess authentication. Used in conjunction with -pass-basic-auth and -pass-user-headers")
 	flagSet.Bool("pass-user-headers", true, "pass X-Forwarded-User and X-Forwarded-Email information to upstream")
+	flagSet.String("basic-auth-user", "", "override the username when passing the HTTP Basic Auth header")
 	flagSet.String("basic-auth-password", "", "the password to set when passing the HTTP Basic Auth header")
 	flagSet.Bool("pass-access-token", false, "pass OAuth access_token to upstream via X-Forwarded-Access-Token header")
 	flagSet.Bool("pass-authorization-header", false, "pass the Authorization Header to upstream")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds a `--basic-auth-user` option, to allow the user to override the username from the provider.

## Motivation and Context

This is useful if you just want to grant a group of people access to a single user in an app, to work around application limitations. For example: Kibana.

## How Has This Been Tested?

Passed built-in tests, will be deploying soon

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
