### PR TITLE
Also support single string groups claim

### DIFF
--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -293,12 +293,10 @@ func (p *OIDCProvider) extractGroupsFromRawClaims(rawClaims map[string]interface
 	case *string:
 		groups = append(groups, *rawGroups)
 	case []interface{}:
-		if rawGroups != nil {
-			for _, rawGroup := range rawGroups {
-				group, ok := rawGroup.(string)
-				if ok {
-					groups = append(groups, group)
-				}
+		for _, rawGroup := range rawGroups {
+			group, ok := rawGroup.(string)
+			if ok {
+				groups = append(groups, group)
 			}
 		}
 	}

--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -286,12 +287,10 @@ func (p *OIDCProvider) extractGroupsFromRawClaims(rawClaims map[string]interface
 	switch rawGroups := rawClaims[p.GroupsClaim].(type) {
 	case []string:
 		groups = append(groups, rawGroups...)
-	case *[]string:
-		groups = append(groups, *rawGroups...)
 	case string:
 		groups = append(groups, rawGroups)
-	case *string:
-		groups = append(groups, *rawGroups)
+	case int:
+		groups = append(groups, strconv.Itoa(rawGroups))
 	case []interface{}:
 		for _, rawGroup := range rawGroups {
 			group, ok := rawGroup.(string)

--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -285,6 +285,9 @@ func (p *OIDCProvider) findClaimsFromIDToken(ctx context.Context, idToken *oidc.
 func (p *OIDCProvider) extractGroupsFromRawClaims(rawClaims map[string]interface{}) []string {
 	groups := []string{}
 
+	if group, ok := rawClaims[p.GroupsClaim].(string); ok {
+		groups = append(groups, group)
+	}
 	rawGroups, ok := rawClaims[p.GroupsClaim].([]interface{})
 	if rawGroups != nil && ok {
 		for _, rawGroup := range rawGroups {

--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -281,13 +281,26 @@ func (p *OIDCProvider) findClaimsFromIDToken(ctx context.Context, idToken *oidc.
 }
 
 func (p *OIDCProvider) extractGroupsFromRawClaims(rawClaims map[string]interface{}) []string {
-	var groups []string
+	groups := []string{}
 
 	switch rawGroups := rawClaims[p.GroupsClaim].(type) {
 	case []string:
 		groups = append(groups, rawGroups...)
+	case *[]string:
+		groups = append(groups, *rawGroups...)
 	case string:
 		groups = append(groups, rawGroups)
+	case *string:
+		groups = append(groups, *rawGroups)
+	case []interface{}:
+		if rawGroups != nil {
+			for _, rawGroup := range rawGroups {
+				group, ok := rawGroup.(string)
+				if ok {
+					groups = append(groups, group)
+				}
+			}
+		}
 	}
 	return groups
 }

--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -5,16 +5,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
-	"strconv"
 	"strings"
 	"time"
-
-	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/logger"
 
 	oidc "github.com/coreos/go-oidc"
 	"golang.org/x/oauth2"
 
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/sessions"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/logger"
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/requests"
 )
 
@@ -292,8 +290,6 @@ func (p *OIDCProvider) extractGroupsFromRawClaims(rawClaims map[string]interface
 		groups = append(groups, rawGroups...)
 	case string:
 		groups = append(groups, rawGroups)
-	case int:
-		groups = append(groups, strconv.Itoa(rawGroups))
 	case []interface{}:
 		for _, rawGroup := range rawGroups {
 			formattedGroup, err := formatGroup(rawGroup)

--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/logger"
 
 	oidc "github.com/coreos/go-oidc"
 	"golang.org/x/oauth2"
@@ -293,10 +296,12 @@ func (p *OIDCProvider) extractGroupsFromRawClaims(rawClaims map[string]interface
 		groups = append(groups, strconv.Itoa(rawGroups))
 	case []interface{}:
 		for _, rawGroup := range rawGroups {
-			group, ok := rawGroup.(string)
-			if ok {
-				groups = append(groups, group)
+			formattedGroup, err := formatGroup(rawGroup)
+			if err != nil {
+				logger.Errorf("unable to format group of type %s with error %s", reflect.TypeOf(rawGroup), err)
+				continue
 			}
+			groups = append(groups, formattedGroup)
 		}
 	}
 	return groups

--- a/providers/oidc_test.go
+++ b/providers/oidc_test.go
@@ -450,10 +450,6 @@ func Test_extractRawGroupsFromClaim(t *testing.T) {
 			RawClaims: map[string]interface{}{"groups": "one_group"},
 			Groups:    []string{"one_group"},
 		},
-		"NumberGroup": {
-			RawClaims: map[string]interface{}{"groups": 42},
-			Groups:    []string{"42"},
-		},
 	}
 
 	for testName, tc := range testCases {

--- a/providers/oidc_test.go
+++ b/providers/oidc_test.go
@@ -404,6 +404,34 @@ func TestOIDCProvider_findVerifiedIdToken(t *testing.T) {
 	assert.Equal(t, true, verifiedIDToken == nil)
 }
 
+func Test_formatGroup(t *testing.T) {
+	testCases := map[string]struct {
+		RawGroup                    interface{}
+		ExpectedFormattedGroupValue string
+	}{
+		"String Group": {
+			RawGroup:                    "group",
+			ExpectedFormattedGroupValue: "group",
+		},
+		"Map Group": {
+			RawGroup:                    map[string]string{"id": "1", "name": "Test"},
+			ExpectedFormattedGroupValue: "{\"id\":\"1\",\"name\":\"Test\"}",
+		},
+		"List Group": {
+			RawGroup:                    []string{"First", "Second"},
+			ExpectedFormattedGroupValue: "[\"First\",\"Second\"]",
+		},
+	}
+
+	for testName, tc := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			formattedGroup, err := formatGroup(tc.RawGroup)
+			assert.Nil(t, err)
+			assert.Equal(t, tc.ExpectedFormattedGroupValue, formattedGroup)
+		})
+	}
+}
+
 func Test_extractRawGroupsFromClaim(t *testing.T) {
 	server, provider := newTestSetup([]byte(""))
 	defer server.Close()

--- a/providers/oidc_test.go
+++ b/providers/oidc_test.go
@@ -404,30 +404,35 @@ func TestOIDCProvider_findVerifiedIdToken(t *testing.T) {
 	assert.Equal(t, true, verifiedIDToken == nil)
 }
 
-func Test_formatGroup(t *testing.T) {
+func TestExtractRawgroupsFromClaim(t *testing.T) {
+	server, provider := newTestSetup([]byte(""))
+	defer server.Close()
+
+	provider.GroupsClaim = "groups"
+
 	testCases := map[string]struct {
-		RawGroup                    interface{}
-		ExpectedFormattedGroupValue string
+		RawClaims map[string]interface{}
+		Groups    []string
 	}{
-		"String Group": {
-			RawGroup:                    "group",
-			ExpectedFormattedGroupValue: "group",
+		"ArrayGroup": {
+			RawClaims: map[string]interface{}{"groups": []string{"one_group", "another_group"}},
+			Groups:    []string{"one_group", "another_group"},
 		},
-		"Map Group": {
-			RawGroup:                    map[string]string{"id": "1", "name": "Test"},
-			ExpectedFormattedGroupValue: "{\"id\":\"1\",\"name\":\"Test\"}",
+		"StringGroup": {
+			RawClaims: map[string]interface{}{"groups": "one_group"},
+			Groups:    []string{"one_group"},
 		},
-		"List Group": {
-			RawGroup:                    []string{"First", "Second"},
-			ExpectedFormattedGroupValue: "[\"First\",\"Second\"]",
+		"NumberGroup": {
+			RawClaims: map[string]interface{}{"groups": 42},
+			Groups:    []string(nil),
 		},
 	}
 
 	for testName, tc := range testCases {
 		t.Run(testName, func(t *testing.T) {
-			formattedGroup, err := formatGroup(tc.RawGroup)
-			assert.Nil(t, err)
-			assert.Equal(t, tc.ExpectedFormattedGroupValue, formattedGroup)
+			groups := provider.extractGroupsFromRawClaims(tc.RawClaims)
+			assert.Equal(t, tc.Groups, groups)
 		})
 	}
+
 }

--- a/providers/oidc_test.go
+++ b/providers/oidc_test.go
@@ -404,7 +404,7 @@ func TestOIDCProvider_findVerifiedIdToken(t *testing.T) {
 	assert.Equal(t, true, verifiedIDToken == nil)
 }
 
-func TestExtractRawgroupsFromClaim(t *testing.T) {
+func Test_extractRawGroupsFromClaim(t *testing.T) {
 	server, provider := newTestSetup([]byte(""))
 	defer server.Close()
 

--- a/providers/oidc_test.go
+++ b/providers/oidc_test.go
@@ -424,7 +424,7 @@ func Test_extractRawGroupsFromClaim(t *testing.T) {
 		},
 		"NumberGroup": {
 			RawClaims: map[string]interface{}{"groups": 42},
-			Groups:    []string{},
+			Groups:    []string{"42"},
 		},
 	}
 

--- a/providers/oidc_test.go
+++ b/providers/oidc_test.go
@@ -424,7 +424,7 @@ func Test_extractRawGroupsFromClaim(t *testing.T) {
 		},
 		"NumberGroup": {
 			RawClaims: map[string]interface{}{"groups": 42},
-			Groups:    []string(nil),
+			Groups:    []string{},
 		},
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Allows single string group claims e.g. when one overrides the default `groups` field to point to a string claim
<!--- Describe your changes in detail -->

## Motivation and Context
We have a use-case where we point to a specific claim that is a string instead of string array. This allows us to validate by adding multiple `--allowed-group` values
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Tested by deploying to our cloud environment and against our OIDC provider and pointing to a string claim
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
