### PR TITLE
gosec 2.4 compliancy

### DIFF
--- a/http.go
+++ b/http.go
@@ -64,7 +64,7 @@ func (s *Server) ServeHTTPS() {
 	addr := s.Opts.HTTPSAddress
 	config := &tls.Config{
 		MinVersion: tls.VersionTLS12,
-		MaxVersion: tls.VersionTLS12,
+		MaxVersion: tls.VersionTLS13,
 	}
 	if config.NextProtos == nil {
 		config.NextProtos = []string{"http/1.1"}

--- a/pkg/validation/options.go
+++ b/pkg/validation/options.go
@@ -41,7 +41,8 @@ func Validate(o *options.Options) error {
 		if err == nil {
 			transport := &http.Transport{
 				TLSClientConfig: &tls.Config{
-					RootCAs: pool,
+					RootCAs:    pool,
+					MaxVersion: tls.VersionTLS13,
 				},
 			}
 

--- a/providers/logingov.go
+++ b/providers/logingov.go
@@ -3,10 +3,11 @@ package providers
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"crypto/rsa"
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/big"
 	"net/url"
 	"time"
 
@@ -34,8 +35,15 @@ var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 
 func randSeq(n int) string {
 	b := make([]rune, n)
+	var length = &big.Int{}
+	length = length.SetInt64(int64(len(letters)))
 	for i := range b {
-		b[i] = letters[rand.Intn(len(letters))]
+		randomNum, err := rand.Int(rand.Reader, length)
+		if err != nil {
+			panic(err)
+		}
+		index := randomNum.Int64()
+		b[i] = letters[index]
 	}
 	return string(b)
 }


### PR DESCRIPTION
## Description

Fixing problems indicated by gosec v2.4

## Motivation and Context

gosec v2.4 complains about the following:

```
Results:
[/home/travis/gopath/src/github.ibm.com/alchemy-containers/armada-oauth2-proxy-build/oauth2-proxy/providers/logingov.go:38] - G404 (CWE-338): Use of weak random number generator (math/rand instead of crypto/rand) (Confidence: MEDIUM, Severity: HIGH)
    37: 	for i := range b {
  > 38: 		b[i] = letters[rand.Intn(len(letters))]
    39: 	}
[/home/travis/gopath/src/github.ibm.com/alchemy-containers/armada-oauth2-proxy-build/oauth2-proxy/http.go:65-68] - G402 (CWE-295): TLS MaxVersion too low. (Confidence: HIGH, Severity: HIGH)
    64: 	addr := s.Opts.HTTPSAddress
  > 65: 	config := &tls.Config{
  > 66: 		MinVersion: tls.VersionTLS12,
  > 67: 		MaxVersion: tls.VersionTLS12,
  > 68: 	}
    69: 	if config.NextProtos == nil {
[/home/travis/gopath/src/github.ibm.com/alchemy-containers/armada-oauth2-proxy-build/oauth2-proxy/pkg/validation/options.go:44-46] - G402 (CWE-295): TLS MaxVersion too low. (Confidence: HIGH, Severity: HIGH)
    43: 			transport := &http.Transport{
  > 44: 				TLSClientConfig: &tls.Config{
  > 45: 					RootCAs: pool,
  > 46: 				},
    47: 			}
Summary:
   Files: 76
   Lines: 10323
   Nosec: 11
  Issues: 3


```

## How Has This Been Tested?

I could test only the oidc provider with the "nginx subrequest" config. That one works.
Unfortunately I do not have access to a logingov provider. 

## Checklist:

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
