### PR TITLE
Add allowed group check on `callback` endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   - Sessions from v6.0.0 or later had a graceful conversion to SHA256 that resulted in no reauthentication
   - Upgrading from v5.1.1 or earlier will result in a reauthentication
 - [#616](https://github.com/oauth2-proxy/oauth2-proxy/pull/616) Ensure you have configured oauth2-proxy to use the `groups` scope. The user may be logged out initially as they may not currently have the `groups` claim however after going back through login process wil be authenticated.
+- [#855](https://github.com/oauth2-proxy/oauth2-proxy/pull/855) Add `groups` validation implemented in [#616](https://github.com/oauth2-proxy/oauth2-proxy/pull/616) also to `callback` endpoint.
 
 ## Breaking Changes
 

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -859,7 +859,7 @@ func (p *OAuthProxy) OAuthCallback(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	// set cookie, or deny
-	if p.Validator(session.Email) && p.provider.ValidateGroup(session.Email) {
+	if p.Validator(session.Email) && p.provider.ValidateGroup(session.Email) && p.validateGroups(session.Groups) {
 		logger.PrintAuthf(session.Email, req, logger.AuthSuccess, "Authenticated via OAuth2: %s", session)
 		err := p.SaveSession(rw, req, session)
 		if err != nil {


### PR DESCRIPTION
Caused by issue https://github.com/oauth2-proxy/oauth2-proxy/issues/854

## Description

Add allowed group check on `callback` endpoint

## Motivation and Context

In case of the following ingress-nginx configuration:

```
nginx.ingress.kubernetes.io/auth-signin: https://oauth2.subdomain.example.net/oauth2/start?rd=https://$host$escaped_request_uri
nginx.ingress.kubernetes.io/auth-url: https://oauth2.subdomain.example.net/oauth2/auth
```

User will never see 403 error is --allowed-group feature is enabled

## How Has This Been Tested?

No new tests were provided. Verified on nginx+auth_request (nginx-ingress) + OIDC provider

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [-] My change requires a change to the documentation or CHANGELOG.
- [+] I have updated the documentation/CHANGELOG accordingly.
- [+] I have created a feature (non-master) branch for my PR.
