### PR TITLE
Updated Gitlab docs

### DIFF
--- a/docs/2_auth.md
+++ b/docs/2_auth.md
@@ -151,15 +151,25 @@ The group management in keycloak is using a tree. If you create a group named ad
 
 ### GitLab Auth Provider
 
-Whether you are using GitLab.com or self-hosting GitLab, follow [these steps to add an application](https://docs.gitlab.com/ce/integration/oauth_provider.html). Make sure to enable at least the `openid`, `profile` and `email` scopes.
+Whether you are using GitLab.com or self-hosting GitLab, follow [these steps to add an application](https://docs.gitlab.com/ce/integration/oauth_provider.html). Make sure to enable at least the `openid`, `profile` and `email` scopes, and set the redirect url to your application url e.g. https://myapp.com/oauth2/callback.
 
+The following config should be set to ensure that the oauth will work properly. To get a cookie secret follow [these steps](https://github.com/oauth2-proxy/oauth2-proxy/blob/master/docs/configuration/configuration.md#configuration)
+
+```
+    --provider="gitlab"
+    --redirect-url="https://myapp.com/oauth2/callback" // Should be the same as the redirect url for the application in gitlab
+    --client-id=GITLAB_CLIENT_ID
+    --client-secret=GITLAB_CLIENT_SECRET
+    --cookie-secret=COOKIE_SECRET
+```
+    
 Restricting by group membership is possible with the following option:
 
-    -gitlab-group="": restrict logins to members of any of these groups (slug), separated by a comma
+    --gitlab-group="mygroup,myothergroup": restrict logins to members of any of these groups (slug), separated by a comma
 
 If you are using self-hosted GitLab, make sure you set the following to the appropriate URL:
 
-    -oidc-issuer-url="<your gitlab url>"
+    --oidc-issuer-url="<your gitlab url>"
 
 ### LinkedIn Auth Provider
 


### PR DESCRIPTION
Updated docs to represent current GitLab config.

## Description

Added minimal example for config needed to make the GitLab provider work on v6.1.1.

## Motivation and Context

This change is needed for new users who are not familiar with oauth2 proxy and wants to use GitLab as their provider. Currently, it is difficult to figure out which options to use to make this work, and one has to dig through old pr's to figure out the needed settings. This PR will fix this.

Closes #857 

## How Has This Been Tested?

It has been tested on my personal project which uses the Adminer docker image as base, and it works for me. Currently, my repo is private, but if it is useful and/or requested I can make a fork with obfuscated settings to provide a real world example.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

I assume I have to tick them all since I change the docs, but let me know if I should remove a tick.

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
