### PR TITLE
Change Keycloak config to support multiple groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - [#750](https://github.com/oauth2-proxy/oauth2-proxy/pull/750) ci: Migrate to Github Actions (@shinebayar-g)
 - [#829](https://github.com/oauth2-proxy/oauth2-proxy/pull/820) Rename test directory to testdata (@johejo)
 - [#819](https://github.com/oauth2-proxy/oauth2-proxy/pull/819) Improve CI (@johejo)
+- [#861](https://github.com/oauth2-proxy/oauth2-proxy/pull/861) Change Keycloak config to support multiple groups
 
 # v6.1.1
 

--- a/pkg/apis/options/options.go
+++ b/pkg/apis/options/options.go
@@ -36,7 +36,7 @@ type Options struct {
 	TLSKeyFile         string   `flag:"tls-key-file" cfg:"tls_key_file"`
 
 	AuthenticatedEmailsFile  string   `flag:"authenticated-emails-file" cfg:"authenticated_emails_file"`
-	KeycloakGroup            string   `flag:"keycloak-group" cfg:"keycloak_group"`
+	KeycloakGroups           []string `flag:"keycloak-groups" cfg:"keycloak_groups"`
 	AzureTenant              string   `flag:"azure-tenant" cfg:"azure_tenant"`
 	BitbucketTeam            string   `flag:"bitbucket-team" cfg:"bitbucket_team"`
 	BitbucketRepository      string   `flag:"bitbucket-repository" cfg:"bitbucket_repository"`
@@ -203,7 +203,7 @@ func NewFlagSet() *pflag.FlagSet {
 
 	flagSet.StringSlice("email-domain", []string{}, "authenticate emails with the specified domain (may be given multiple times). Use * to authenticate any email")
 	flagSet.StringSlice("whitelist-domain", []string{}, "allowed domains for redirection after authentication. Prefix domain with a . to allow subdomains (eg .example.com)")
-	flagSet.String("keycloak-group", "", "restrict login to members of this group.")
+	flagSet.StringSlice("keycloak-groups", []string{}, "restrict login to members of this list of groups.")
 	flagSet.String("azure-tenant", "common", "go to a tenant-specific or common (tenant-independent) endpoint.")
 	flagSet.String("bitbucket-team", "", "restrict logins to members of this team")
 	flagSet.String("bitbucket-repository", "", "restrict logins to user with access to this repository")

--- a/pkg/validation/options.go
+++ b/pkg/validation/options.go
@@ -248,7 +248,7 @@ func parseProviderInfo(o *options.Options, msgs []string) []string {
 		p.SetRepo(o.GitHubRepo, o.GitHubToken)
 		p.SetUsers(o.GitHubUsers)
 	case *providers.KeycloakProvider:
-		p.SetGroup(o.KeycloakGroup)
+		p.SetGroups(o.KeycloakGroups)
 	case *providers.GoogleProvider:
 		if o.GoogleServiceAccountJSON != "" {
 			file, err := os.Open(o.GoogleServiceAccountJSON)

--- a/providers/keycloak.go
+++ b/providers/keycloak.go
@@ -11,7 +11,7 @@ import (
 
 type KeycloakProvider struct {
 	*ProviderData
-	Group string
+	Groups []string
 }
 
 var _ Provider = (*KeycloakProvider)(nil)
@@ -59,8 +59,8 @@ func NewKeycloakProvider(p *ProviderData) *KeycloakProvider {
 	return &KeycloakProvider{ProviderData: p}
 }
 
-func (p *KeycloakProvider) SetGroup(group string) {
-	p.Group = group
+func (p *KeycloakProvider) SetGroups(groups []string) {
+	p.Groups = groups
 }
 
 func (p *KeycloakProvider) GetEmailAddress(ctx context.Context, s *sessions.SessionState) (string, error) {
@@ -74,7 +74,7 @@ func (p *KeycloakProvider) GetEmailAddress(ctx context.Context, s *sessions.Sess
 		return "", err
 	}
 
-	if p.Group != "" {
+	if p.Groups != nil {
 		var groups, err = json.Get("groups").Array()
 		if err != nil {
 			logger.Printf("groups not found %s", err)
@@ -83,7 +83,7 @@ func (p *KeycloakProvider) GetEmailAddress(ctx context.Context, s *sessions.Sess
 
 		var found = false
 		for i := range groups {
-			if groups[i].(string) == p.Group {
+			if contains(p.Groups, groups[i].(string)) {
 				found = true
 				break
 			}
@@ -96,4 +96,13 @@ func (p *KeycloakProvider) GetEmailAddress(ctx context.Context, s *sessions.Sess
 	}
 
 	return json.Get("email").String()
+}
+
+func contains(list []string, s string) bool {
+	for _, v := range list {
+		if v == s {
+			return true
+		}
+	}
+	return false
 }

--- a/providers/keycloak_test.go
+++ b/providers/keycloak_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func testKeycloakProvider(hostname, group string) *KeycloakProvider {
+func testKeycloakProvider(hostname string, groups []string) *KeycloakProvider {
 	p := NewKeycloakProvider(
 		&ProviderData{
 			ProviderName: "",
@@ -22,8 +22,8 @@ func testKeycloakProvider(hostname, group string) *KeycloakProvider {
 			ValidateURL:  &url.URL{},
 			Scope:        ""})
 
-	if group != "" {
-		p.SetGroup(group)
+	if groups != nil {
+		p.SetGroups(groups)
 	}
 
 	if hostname != "" {
@@ -53,7 +53,7 @@ func testKeycloakBackend(payload string) *httptest.Server {
 }
 
 func TestKeycloakProviderDefaults(t *testing.T) {
-	p := testKeycloakProvider("", "")
+	p := testKeycloakProvider("", []string{})
 	assert.NotEqual(t, nil, p)
 	assert.Equal(t, "Keycloak", p.Data().ProviderName)
 	assert.Equal(t, "https://keycloak.org/oauth/authorize",
@@ -110,7 +110,7 @@ func TestKeycloakProviderGetEmailAddress(t *testing.T) {
 	defer b.Close()
 
 	bURL, _ := url.Parse(b.URL)
-	p := testKeycloakProvider(bURL.Host, "")
+	p := testKeycloakProvider(bURL.Host, nil)
 
 	session := CreateAuthorizedSession()
 	email, err := p.GetEmailAddress(context.Background(), session)
@@ -123,7 +123,7 @@ func TestKeycloakProviderGetEmailAddressAndGroup(t *testing.T) {
 	defer b.Close()
 
 	bURL, _ := url.Parse(b.URL)
-	p := testKeycloakProvider(bURL.Host, "test-grp1")
+	p := testKeycloakProvider(bURL.Host, []string{"test-grp1"})
 
 	session := CreateAuthorizedSession()
 	email, err := p.GetEmailAddress(context.Background(), session)
@@ -138,7 +138,7 @@ func TestKeycloakProviderGetEmailAddressFailedRequest(t *testing.T) {
 	defer b.Close()
 
 	bURL, _ := url.Parse(b.URL)
-	p := testKeycloakProvider(bURL.Host, "")
+	p := testKeycloakProvider(bURL.Host, []string{})
 
 	// We'll trigger a request failure by using an unexpected access
 	// token. Alternatively, we could allow the parsing of the payload as
@@ -154,7 +154,7 @@ func TestKeycloakProviderGetEmailAddressEmailNotPresentInPayload(t *testing.T) {
 	defer b.Close()
 
 	bURL, _ := url.Parse(b.URL)
-	p := testKeycloakProvider(bURL.Host, "")
+	p := testKeycloakProvider(bURL.Host, []string{})
 
 	session := CreateAuthorizedSession()
 	email, err := p.GetEmailAddress(context.Background(), session)


### PR DESCRIPTION
## Description

Changed Keycloak config option to be an array supporting multiple
groups.

## Motivation and Context

Give more options to the configuration allowing multiple groups to be used to allow access to the application.

## How Has This Been Tested?

Adjusted the tests for the Keycloak provider to use the group array. All test passes.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
