### PR TITLE
Add AccessToken as fallback to Authorization header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ## Changes since v6.1.1
 
+- [#875](https://github.com/oauth2-proxy/oauth2-proxy/pull/875) Add AccessToken as fallback to Authorization header (@kvaps)
 - [#825](https://github.com/oauth2-proxy/oauth2-proxy/pull/825) Fix code coverage reporting on GitHub actions(@JoelSpeed)
 - [#796](https://github.com/oauth2-proxy/oauth2-proxy/pull/796) Deprecate GetUserName & GetEmailAdress for EnrichSessionState (@NickMeves)
 - [#705](https://github.com/oauth2-proxy/oauth2-proxy/pull/705) Add generic Header injectors for upstream request and response headers (@JoelSpeed)

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -1051,6 +1051,8 @@ func (p *OAuthProxy) addHeadersForProxying(rw http.ResponseWriter, req *http.Req
 	if p.PassAuthorization {
 		if session.IDToken != "" {
 			req.Header["Authorization"] = []string{fmt.Sprintf("Bearer %s", session.IDToken)}
+		} else if session.AccessToken != "" {
+			req.Header["Authorization"] = []string{fmt.Sprintf("Bearer %s", session.AccessToken)}
 		} else {
 			req.Header.Del("Authorization")
 		}


### PR DESCRIPTION
##  Description

This change allows to map Bearer token to Authorization header required by many applications including but not limited to Kubernetes.

## Motivation and Context

As part of deprecating louketo-proxy (https://github.com/louketo/louketo-proxy/issues/683), formely known as keycloak-gatekeeper, it is suggested to migrate to oauth-proxy.

Keycloak is issuing the tokens with `"typ": "Bearer"`, and louketo-proxy successfully passing them into application, however oauth2-proxy is not doing that.

See https://github.com/oauth2-proxy/oauth2-proxy/issues/843#issuecomment-717212451 for more details.

fixes https://github.com/oauth2-proxy/oauth2-proxy/issues/843
fixes https://github.com/kubeapps/kubeapps/issues/2111

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

- A docker image with this change has been built
  ```
  docker.io/kvaps/oauth2-proxy@sha256:8b022e564717aadfaa31dc53ed4337d4e441fa5e7e73a91954c7bea69e4cb195
  ```
- Successfully deployed and authenticated with Keycloak and kubeapps as a backend


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My change requires a change to the documentation or CHANGELOG.
- [X] I have updated the documentation/CHANGELOG accordingly.
- [X] I have created a feature (non-master) branch for my PR.
