### PR TITLE
Clear untrusted input from X-Forwarded-Groups header before passing upstream

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -1001,12 +1001,12 @@ func (p *OAuthProxy) addHeadersForProxying(rw http.ResponseWriter, req *http.Req
 			req.Header.Del("X-Forwarded-Preferred-Username")
 		}
 
+		req.Header.Del("X-Forwarded-Groups")
+
 		if len(session.Groups) > 0 {
 			for _, group := range session.Groups {
 				req.Header.Add("X-Forwarded-Groups", group)
 			}
-		} else {
-			req.Header.Del("X-Forwarded-Groups")
 		}
 	}
 


### PR DESCRIPTION
## Description

Clear contents of "X-Forwarded-Groups" in request header before appending groups from token claim.

## Motivation and Context

#877



## How Has This Been Tested?

`go test -v`

After making the change, upstream no longer receives groups arbitrarily added in `X-Forwarded-Groups` header:

```bash
# User, who is part of 'users' group only, and not 'admin', makes request
$ curl localhost:3000 \
	-H 'x-forwarded-groups: admins'   
	-H "cookie: $(cat cookie)"

# Upstream receives only:
# 'x-forwarded-groups: users'
```





## Checklist:


- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
