### PR TITLE
Fixed links to docs in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ sha256sum -c sha256sum.txt 2>&1 | grep OK
 oauth2-proxy-x.y.z.linux-amd64: OK
 ```
 
-2.  [Select a Provider and Register an OAuth Application with a Provider](https://oauth2-proxy.github.io/oauth2-proxy/auth-configuration)
-3.  [Configure OAuth2 Proxy using config file, command line options, or environment variables](https://oauth2-proxy.github.io/oauth2-proxy/configuration)
-4.  [Configure SSL or Deploy behind a SSL endpoint](https://oauth2-proxy.github.io/oauth2-proxy/tls-configuration) (example provided for Nginx)
+2.  [Select a Provider and Register an OAuth Application with a Provider](https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/oauth_provider)
+3.  [Configure OAuth2 Proxy using config file, command line options, or environment variables](https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/overview)
+4.  [Configure SSL or Deploy behind a SSL endpoint](https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/tls) (example provided for Nginx)
 
 
 ## Security
@@ -48,7 +48,7 @@ See [open redirect vulnverability](https://github.com/oauth2-proxy/oauth2-proxy/
 
 ## Docs
 
-Read the docs on our [Docs site](https://oauth2-proxy.github.io/oauth2-proxy).
+Read the docs on our [Docs site](https://oauth2-proxy.github.io/oauth2-proxy/docs/).
 
 ![OAuth2 Proxy Architecture](https://cloud.githubusercontent.com/assets/45028/8027702/bd040b7a-0d6a-11e5-85b9-f8d953d04f39.png)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![OAuth2 Proxy](/docs/logos/OAuth2_Proxy_horizontal.svg)
+![OAuth2 Proxy](/docs/static/img/logos/OAuth2_Proxy_horizontal.svg)
 
 [![Build Status](https://secure.travis-ci.org/oauth2-proxy/oauth2-proxy.svg?branch=master)](http://travis-ci.org/oauth2-proxy/oauth2-proxy)
 [![Go Report Card](https://goreportcard.com/badge/github.com/oauth2-proxy/oauth2-proxy)](https://goreportcard.com/report/github.com/oauth2-proxy/oauth2-proxy)


### PR DESCRIPTION
## Description

Fixed four links to the docs, three of them were broken, another seemed to be pointing at the wrong address.

## Motivation and Context

It looks like the docs website changed, and some URLs in the readme were pointing to the old version. For example, link to the provider configuration was linking to:
https://oauth2-proxy.github.io/oauth2-proxy/auth-configuration

Which doesn't work anymore, instead of linking to:
https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/oauth_provider

## How Has This Been Tested?

I made sure the new links were working.

## Checklist:

My change is a simple change in the readme and should not require further documentation. It's also not adding any new features:

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
