### PR TITLE
Don't use pointers in structured configuration

### DIFF
--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -512,9 +512,9 @@ func TestBasicAuthPassword(t *testing.T) {
 			Name: "Authorization",
 			Values: []options.HeaderValue{
 				{
-					ClaimSource: &options.ClaimSource{
+					ClaimSource: options.ClaimSource{
 						Claim: "email",
-						BasicAuthPassword: &options.SecretSource{
+						BasicAuthPassword: options.SecretSource{
 							Value: []byte(base64.StdEncoding.EncodeToString([]byte(basicAuthPassword))),
 						},
 					},
@@ -567,7 +567,7 @@ func TestPassGroupsHeadersWithGroups(t *testing.T) {
 			Name: "X-Forwarded-Groups",
 			Values: []options.HeaderValue{
 				{
-					ClaimSource: &options.ClaimSource{
+					ClaimSource: options.ClaimSource{
 						Claim: "groups",
 					},
 				},
@@ -665,7 +665,7 @@ func NewPassAccessTokenTest(opts PassAccessTokenTestOptions) (*PassAccessTokenTe
 				Name: "X-Forwarded-Access-Token",
 				Values: []options.HeaderValue{
 					{
-						ClaimSource: &options.ClaimSource{
+						ClaimSource: options.ClaimSource{
 							Claim: "access_token",
 						},
 					},
@@ -1236,7 +1236,7 @@ func TestAuthOnlyEndpointSetXAuthRequestHeaders(t *testing.T) {
 			Name: "X-Auth-Request-User",
 			Values: []options.HeaderValue{
 				{
-					ClaimSource: &options.ClaimSource{
+					ClaimSource: options.ClaimSource{
 						Claim: "user",
 					},
 				},
@@ -1246,7 +1246,7 @@ func TestAuthOnlyEndpointSetXAuthRequestHeaders(t *testing.T) {
 			Name: "X-Auth-Request-Email",
 			Values: []options.HeaderValue{
 				{
-					ClaimSource: &options.ClaimSource{
+					ClaimSource: options.ClaimSource{
 						Claim: "email",
 					},
 				},
@@ -1256,7 +1256,7 @@ func TestAuthOnlyEndpointSetXAuthRequestHeaders(t *testing.T) {
 			Name: "X-Auth-Request-Groups",
 			Values: []options.HeaderValue{
 				{
-					ClaimSource: &options.ClaimSource{
+					ClaimSource: options.ClaimSource{
 						Claim: "groups",
 					},
 				},
@@ -1266,7 +1266,7 @@ func TestAuthOnlyEndpointSetXAuthRequestHeaders(t *testing.T) {
 			Name: "X-Forwarded-Preferred-Username",
 			Values: []options.HeaderValue{
 				{
-					ClaimSource: &options.ClaimSource{
+					ClaimSource: options.ClaimSource{
 						Claim: "preferred_username",
 					},
 				},
@@ -1315,7 +1315,7 @@ func TestAuthOnlyEndpointSetBasicAuthTrueRequestHeaders(t *testing.T) {
 			Name: "X-Auth-Request-User",
 			Values: []options.HeaderValue{
 				{
-					ClaimSource: &options.ClaimSource{
+					ClaimSource: options.ClaimSource{
 						Claim: "user",
 					},
 				},
@@ -1325,7 +1325,7 @@ func TestAuthOnlyEndpointSetBasicAuthTrueRequestHeaders(t *testing.T) {
 			Name: "X-Auth-Request-Email",
 			Values: []options.HeaderValue{
 				{
-					ClaimSource: &options.ClaimSource{
+					ClaimSource: options.ClaimSource{
 						Claim: "email",
 					},
 				},
@@ -1335,7 +1335,7 @@ func TestAuthOnlyEndpointSetBasicAuthTrueRequestHeaders(t *testing.T) {
 			Name: "X-Auth-Request-Groups",
 			Values: []options.HeaderValue{
 				{
-					ClaimSource: &options.ClaimSource{
+					ClaimSource: options.ClaimSource{
 						Claim: "groups",
 					},
 				},
@@ -1345,7 +1345,7 @@ func TestAuthOnlyEndpointSetBasicAuthTrueRequestHeaders(t *testing.T) {
 			Name: "X-Forwarded-Preferred-Username",
 			Values: []options.HeaderValue{
 				{
-					ClaimSource: &options.ClaimSource{
+					ClaimSource: options.ClaimSource{
 						Claim: "preferred_username",
 					},
 				},
@@ -1355,9 +1355,9 @@ func TestAuthOnlyEndpointSetBasicAuthTrueRequestHeaders(t *testing.T) {
 			Name: "Authorization",
 			Values: []options.HeaderValue{
 				{
-					ClaimSource: &options.ClaimSource{
+					ClaimSource: options.ClaimSource{
 						Claim: "user",
-						BasicAuthPassword: &options.SecretSource{
+						BasicAuthPassword: options.SecretSource{
 							Value: []byte(base64.StdEncoding.EncodeToString([]byte("This is a secure password"))),
 						},
 					},
@@ -1408,7 +1408,7 @@ func TestAuthOnlyEndpointSetBasicAuthFalseRequestHeaders(t *testing.T) {
 			Name: "X-Auth-Request-User",
 			Values: []options.HeaderValue{
 				{
-					ClaimSource: &options.ClaimSource{
+					ClaimSource: options.ClaimSource{
 						Claim: "user",
 					},
 				},
@@ -1418,7 +1418,7 @@ func TestAuthOnlyEndpointSetBasicAuthFalseRequestHeaders(t *testing.T) {
 			Name: "X-Auth-Request-Email",
 			Values: []options.HeaderValue{
 				{
-					ClaimSource: &options.ClaimSource{
+					ClaimSource: options.ClaimSource{
 						Claim: "email",
 					},
 				},
@@ -1428,7 +1428,7 @@ func TestAuthOnlyEndpointSetBasicAuthFalseRequestHeaders(t *testing.T) {
 			Name: "X-Auth-Request-Groups",
 			Values: []options.HeaderValue{
 				{
-					ClaimSource: &options.ClaimSource{
+					ClaimSource: options.ClaimSource{
 						Claim: "groups",
 					},
 				},
@@ -1438,7 +1438,7 @@ func TestAuthOnlyEndpointSetBasicAuthFalseRequestHeaders(t *testing.T) {
 			Name: "X-Forwarded-Preferred-Username",
 			Values: []options.HeaderValue{
 				{
-					ClaimSource: &options.ClaimSource{
+					ClaimSource: options.ClaimSource{
 						Claim: "preferred_username",
 					},
 				},
@@ -1914,7 +1914,7 @@ func TestGetJwtSession(t *testing.T) {
 				Name: "Authorization",
 				Values: []options.HeaderValue{
 					{
-						ClaimSource: &options.ClaimSource{
+						ClaimSource: options.ClaimSource{
 							Claim:  "id_token",
 							Prefix: "Bearer ",
 						},
@@ -1925,7 +1925,7 @@ func TestGetJwtSession(t *testing.T) {
 				Name: "X-Forwarded-User",
 				Values: []options.HeaderValue{
 					{
-						ClaimSource: &options.ClaimSource{
+						ClaimSource: options.ClaimSource{
 							Claim: "user",
 						},
 					},
@@ -1935,7 +1935,7 @@ func TestGetJwtSession(t *testing.T) {
 				Name: "X-Forwarded-Email",
 				Values: []options.HeaderValue{
 					{
-						ClaimSource: &options.ClaimSource{
+						ClaimSource: options.ClaimSource{
 							Claim: "email",
 						},
 					},
@@ -1948,7 +1948,7 @@ func TestGetJwtSession(t *testing.T) {
 				Name: "Authorization",
 				Values: []options.HeaderValue{
 					{
-						ClaimSource: &options.ClaimSource{
+						ClaimSource: options.ClaimSource{
 							Claim:  "id_token",
 							Prefix: "Bearer ",
 						},
@@ -1959,7 +1959,7 @@ func TestGetJwtSession(t *testing.T) {
 				Name: "X-Auth-Request-User",
 				Values: []options.HeaderValue{
 					{
-						ClaimSource: &options.ClaimSource{
+						ClaimSource: options.ClaimSource{
 							Claim: "user",
 						},
 					},
@@ -1969,7 +1969,7 @@ func TestGetJwtSession(t *testing.T) {
 				Name: "X-Auth-Request-Email",
 				Values: []options.HeaderValue{
 					{
-						ClaimSource: &options.ClaimSource{
+						ClaimSource: options.ClaimSource{
 							Claim: "email",
 						},
 					},
@@ -2127,9 +2127,9 @@ func baseTestOptions() *options.Options {
 			Name: "Authorization",
 			Values: []options.HeaderValue{
 				{
-					ClaimSource: &options.ClaimSource{
+					ClaimSource: options.ClaimSource{
 						Claim: "user",
-						BasicAuthPassword: &options.SecretSource{
+						BasicAuthPassword: options.SecretSource{
 							Value: []byte(base64.StdEncoding.EncodeToString([]byte("This is a secure password"))),
 						},
 					},
@@ -2140,7 +2140,7 @@ func baseTestOptions() *options.Options {
 			Name: "X-Forwarded-User",
 			Values: []options.HeaderValue{
 				{
-					ClaimSource: &options.ClaimSource{
+					ClaimSource: options.ClaimSource{
 						Claim: "user",
 					},
 				},
@@ -2150,7 +2150,7 @@ func baseTestOptions() *options.Options {
 			Name: "X-Forwarded-Email",
 			Values: []options.HeaderValue{
 				{
-					ClaimSource: &options.ClaimSource{
+					ClaimSource: options.ClaimSource{
 						Claim: "email",
 					},
 				},

--- a/pkg/apis/options/common.go
+++ b/pkg/apis/options/common.go
@@ -12,3 +12,9 @@ type SecretSource struct {
 	// FromFile expects a path to a file containing the secret value.
 	FromFile string
 }
+
+// IsZero determines if the SecretSource is empty.
+// Returns false if any field in the struct is not its zero value.
+func (s SecretSource) IsZero() bool {
+	return len(s.Value) == 0 && s.FromEnv == "" && s.FromFile == ""
+}

--- a/pkg/apis/options/common_test.go
+++ b/pkg/apis/options/common_test.go
@@ -1,0 +1,42 @@
+package options
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Common", func() {
+	type isZeroTableInput struct {
+		source       SecretSource
+		expectIsZero bool
+	}
+
+	DescribeTable("SecretSource.IsZero",
+		func(in isZeroTableInput) {
+			Expect(in.source.IsZero()).To(Equal(in.expectIsZero))
+		},
+		Entry("with no entries", isZeroTableInput{
+			source:       SecretSource{},
+			expectIsZero: true,
+		}),
+		Entry("with a value", isZeroTableInput{
+			source: SecretSource{
+				Value: []byte("secret"),
+			},
+			expectIsZero: false,
+		}),
+		Entry("with a fromEnv", isZeroTableInput{
+			source: SecretSource{
+				FromEnv: "secret",
+			},
+			expectIsZero: false,
+		}),
+		Entry("with a fromFile", isZeroTableInput{
+			source: SecretSource{
+				FromEnv: "secret",
+			},
+			expectIsZero: false,
+		}),
+	)
+})

--- a/pkg/apis/options/header.go
+++ b/pkg/apis/options/header.go
@@ -21,10 +21,10 @@ type Header struct {
 // make up the header value
 type HeaderValue struct {
 	// Allow users to load the value from a secret source
-	*SecretSource
+	SecretSource
 
 	// Allow users to load the value from a session claim
-	*ClaimSource
+	ClaimSource
 }
 
 // ClaimSource allows loading a header value from a claim within the session
@@ -40,5 +40,11 @@ type ClaimSource struct {
 	// BasicAuthPassword converts this claim into a basic auth header.
 	// Note the value of claim will become the basic auth username and the
 	// basicAuthPassword will be used as the password value.
-	BasicAuthPassword *SecretSource
+	BasicAuthPassword SecretSource
+}
+
+// IsZero determines if the ClaimSource is empty.
+// Returns false if any field in the struct is not its zero value.
+func (c ClaimSource) IsZero() bool {
+	return c.Claim == "" && c.Prefix == "" && c.BasicAuthPassword.IsZero()
 }

--- a/pkg/apis/options/header_test.go
+++ b/pkg/apis/options/header_test.go
@@ -1,0 +1,50 @@
+package options
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Header", func() {
+	type isZeroTableInput struct {
+		source       ClaimSource
+		expectIsZero bool
+	}
+
+	DescribeTable("ClaimSource.IsZero",
+		func(in isZeroTableInput) {
+			Expect(in.source.IsZero()).To(Equal(in.expectIsZero))
+		},
+		Entry("with no entries", isZeroTableInput{
+			source:       ClaimSource{},
+			expectIsZero: true,
+		}),
+		Entry("with a claim", isZeroTableInput{
+			source: ClaimSource{
+				Claim: "claim",
+			},
+			expectIsZero: false,
+		}),
+		Entry("with a prefix", isZeroTableInput{
+			source: ClaimSource{
+				Prefix: "prefix",
+			},
+			expectIsZero: false,
+		}),
+		Entry("with a BasicAuthPassword", isZeroTableInput{
+			source: ClaimSource{
+				BasicAuthPassword: SecretSource{
+					FromEnv: "secret",
+				},
+			},
+			expectIsZero: false,
+		}),
+		Entry("with an empty BasicAuthPassword", isZeroTableInput{
+			source: ClaimSource{
+				BasicAuthPassword: SecretSource{},
+			},
+			expectIsZero: true,
+		}),
+	)
+})

--- a/pkg/apis/options/legacy_options.go
+++ b/pkg/apis/options/legacy_options.go
@@ -230,9 +230,9 @@ func getBasicAuthHeader(preferEmailToUser bool, basicAuthPassword string) Header
 		Name: "Authorization",
 		Values: []HeaderValue{
 			{
-				ClaimSource: &ClaimSource{
+				ClaimSource: ClaimSource{
 					Claim: claim,
-					BasicAuthPassword: &SecretSource{
+					BasicAuthPassword: SecretSource{
 						Value: []byte(base64.StdEncoding.EncodeToString([]byte(basicAuthPassword))),
 					},
 				},
@@ -247,7 +247,7 @@ func getPassUserHeaders(preferEmailToUser bool) []Header {
 			Name: "X-Forwarded-Groups",
 			Values: []HeaderValue{
 				{
-					ClaimSource: &ClaimSource{
+					ClaimSource: ClaimSource{
 						Claim: "groups",
 					},
 				},
@@ -261,7 +261,7 @@ func getPassUserHeaders(preferEmailToUser bool) []Header {
 				Name: "X-Forwarded-User",
 				Values: []HeaderValue{
 					{
-						ClaimSource: &ClaimSource{
+						ClaimSource: ClaimSource{
 							Claim: "email",
 						},
 					},
@@ -275,7 +275,7 @@ func getPassUserHeaders(preferEmailToUser bool) []Header {
 			Name: "X-Forwarded-User",
 			Values: []HeaderValue{
 				{
-					ClaimSource: &ClaimSource{
+					ClaimSource: ClaimSource{
 						Claim: "user",
 					},
 				},
@@ -285,7 +285,7 @@ func getPassUserHeaders(preferEmailToUser bool) []Header {
 			Name: "X-Forwarded-Email",
 			Values: []HeaderValue{
 				{
-					ClaimSource: &ClaimSource{
+					ClaimSource: ClaimSource{
 						Claim: "email",
 					},
 				},
@@ -299,7 +299,7 @@ func getPassAccessTokenHeader() Header {
 		Name: "X-Forwarded-Access-Token",
 		Values: []HeaderValue{
 			{
-				ClaimSource: &ClaimSource{
+				ClaimSource: ClaimSource{
 					Claim: "access_token",
 				},
 			},
@@ -312,7 +312,7 @@ func getAuthorizationHeader() Header {
 		Name: "Authorization",
 		Values: []HeaderValue{
 			{
-				ClaimSource: &ClaimSource{
+				ClaimSource: ClaimSource{
 					Claim:  "id_token",
 					Prefix: "Bearer ",
 				},
@@ -326,7 +326,7 @@ func getPreferredUsernameHeader() Header {
 		Name: "X-Forwarded-Preferred-Username",
 		Values: []HeaderValue{
 			{
-				ClaimSource: &ClaimSource{
+				ClaimSource: ClaimSource{
 					Claim: "preferred_username",
 				},
 			},
@@ -340,7 +340,7 @@ func getXAuthRequestHeaders() []Header {
 			Name: "X-Auth-Request-User",
 			Values: []HeaderValue{
 				{
-					ClaimSource: &ClaimSource{
+					ClaimSource: ClaimSource{
 						Claim: "user",
 					},
 				},
@@ -350,7 +350,7 @@ func getXAuthRequestHeaders() []Header {
 			Name: "X-Auth-Request-Email",
 			Values: []HeaderValue{
 				{
-					ClaimSource: &ClaimSource{
+					ClaimSource: ClaimSource{
 						Claim: "email",
 					},
 				},
@@ -360,7 +360,7 @@ func getXAuthRequestHeaders() []Header {
 			Name: "X-Auth-Request-Preferred-Username",
 			Values: []HeaderValue{
 				{
-					ClaimSource: &ClaimSource{
+					ClaimSource: ClaimSource{
 						Claim: "preferred_username",
 					},
 				},
@@ -370,7 +370,7 @@ func getXAuthRequestHeaders() []Header {
 			Name: "X-Auth-Request-Groups",
 			Values: []HeaderValue{
 				{
-					ClaimSource: &ClaimSource{
+					ClaimSource: ClaimSource{
 						Claim: "groups",
 					},
 				},
@@ -386,7 +386,7 @@ func getXAuthRequestAccessTokenHeader() Header {
 		Name: "X-Auth-Request-Access-Token",
 		Values: []HeaderValue{
 			{
-				ClaimSource: &ClaimSource{
+				ClaimSource: ClaimSource{
 					Claim: "access_token",
 				},
 			},

--- a/pkg/apis/options/legacy_options_test.go
+++ b/pkg/apis/options/legacy_options_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Legacy Options", func() {
 					PreserveRequestValue: false,
 					Values: []HeaderValue{
 						{
-							ClaimSource: &ClaimSource{
+							ClaimSource: ClaimSource{
 								Claim: "groups",
 							},
 						},
@@ -75,7 +75,7 @@ var _ = Describe("Legacy Options", func() {
 					PreserveRequestValue: false,
 					Values: []HeaderValue{
 						{
-							ClaimSource: &ClaimSource{
+							ClaimSource: ClaimSource{
 								Claim: "user",
 							},
 						},
@@ -86,7 +86,7 @@ var _ = Describe("Legacy Options", func() {
 					PreserveRequestValue: false,
 					Values: []HeaderValue{
 						{
-							ClaimSource: &ClaimSource{
+							ClaimSource: ClaimSource{
 								Claim: "email",
 							},
 						},
@@ -97,7 +97,7 @@ var _ = Describe("Legacy Options", func() {
 					PreserveRequestValue: false,
 					Values: []HeaderValue{
 						{
-							ClaimSource: &ClaimSource{
+							ClaimSource: ClaimSource{
 								Claim: "preferred_username",
 							},
 						},
@@ -280,7 +280,7 @@ var _ = Describe("Legacy Options", func() {
 			PreserveRequestValue: false,
 			Values: []HeaderValue{
 				{
-					ClaimSource: &ClaimSource{
+					ClaimSource: ClaimSource{
 						Claim: "user",
 					},
 				},
@@ -292,7 +292,7 @@ var _ = Describe("Legacy Options", func() {
 			PreserveRequestValue: false,
 			Values: []HeaderValue{
 				{
-					ClaimSource: &ClaimSource{
+					ClaimSource: ClaimSource{
 						Claim: "email",
 					},
 				},
@@ -304,7 +304,7 @@ var _ = Describe("Legacy Options", func() {
 			PreserveRequestValue: false,
 			Values: []HeaderValue{
 				{
-					ClaimSource: &ClaimSource{
+					ClaimSource: ClaimSource{
 						Claim: "groups",
 					},
 				},
@@ -316,7 +316,7 @@ var _ = Describe("Legacy Options", func() {
 			PreserveRequestValue: false,
 			Values: []HeaderValue{
 				{
-					ClaimSource: &ClaimSource{
+					ClaimSource: ClaimSource{
 						Claim: "preferred_username",
 					},
 				},
@@ -328,9 +328,9 @@ var _ = Describe("Legacy Options", func() {
 			PreserveRequestValue: false,
 			Values: []HeaderValue{
 				{
-					ClaimSource: &ClaimSource{
+					ClaimSource: ClaimSource{
 						Claim: "user",
-						BasicAuthPassword: &SecretSource{
+						BasicAuthPassword: SecretSource{
 							Value: []byte(base64.StdEncoding.EncodeToString([]byte(basicAuthSecret))),
 						},
 					},
@@ -343,7 +343,7 @@ var _ = Describe("Legacy Options", func() {
 			PreserveRequestValue: false,
 			Values: []HeaderValue{
 				{
-					ClaimSource: &ClaimSource{
+					ClaimSource: ClaimSource{
 						Claim: "email",
 					},
 				},
@@ -355,7 +355,7 @@ var _ = Describe("Legacy Options", func() {
 			PreserveRequestValue: false,
 			Values: []HeaderValue{
 				{
-					ClaimSource: &ClaimSource{
+					ClaimSource: ClaimSource{
 						Claim: "access_token",
 					},
 				},
@@ -367,9 +367,9 @@ var _ = Describe("Legacy Options", func() {
 			PreserveRequestValue: false,
 			Values: []HeaderValue{
 				{
-					ClaimSource: &ClaimSource{
+					ClaimSource: ClaimSource{
 						Claim: "email",
-						BasicAuthPassword: &SecretSource{
+						BasicAuthPassword: SecretSource{
 							Value: []byte(base64.StdEncoding.EncodeToString([]byte(basicAuthSecret))),
 						},
 					},
@@ -382,7 +382,7 @@ var _ = Describe("Legacy Options", func() {
 			PreserveRequestValue: false,
 			Values: []HeaderValue{
 				{
-					ClaimSource: &ClaimSource{
+					ClaimSource: ClaimSource{
 						Claim: "user",
 					},
 				},
@@ -394,7 +394,7 @@ var _ = Describe("Legacy Options", func() {
 			PreserveRequestValue: false,
 			Values: []HeaderValue{
 				{
-					ClaimSource: &ClaimSource{
+					ClaimSource: ClaimSource{
 						Claim: "email",
 					},
 				},
@@ -406,7 +406,7 @@ var _ = Describe("Legacy Options", func() {
 			PreserveRequestValue: false,
 			Values: []HeaderValue{
 				{
-					ClaimSource: &ClaimSource{
+					ClaimSource: ClaimSource{
 						Claim: "groups",
 					},
 				},
@@ -418,7 +418,7 @@ var _ = Describe("Legacy Options", func() {
 			PreserveRequestValue: false,
 			Values: []HeaderValue{
 				{
-					ClaimSource: &ClaimSource{
+					ClaimSource: ClaimSource{
 						Claim: "preferred_username",
 					},
 				},
@@ -430,7 +430,7 @@ var _ = Describe("Legacy Options", func() {
 			PreserveRequestValue: false,
 			Values: []HeaderValue{
 				{
-					ClaimSource: &ClaimSource{
+					ClaimSource: ClaimSource{
 						Claim: "access_token",
 					},
 				},
@@ -442,7 +442,7 @@ var _ = Describe("Legacy Options", func() {
 			PreserveRequestValue: false,
 			Values: []HeaderValue{
 				{
-					ClaimSource: &ClaimSource{
+					ClaimSource: ClaimSource{
 						Claim:  "id_token",
 						Prefix: "Bearer ",
 					},

--- a/pkg/apis/options/util/util.go
+++ b/pkg/apis/options/util/util.go
@@ -10,7 +10,7 @@ import (
 )
 
 // GetSecretValue returns the value of the Secret from its source
-func GetSecretValue(source *options.SecretSource) ([]byte, error) {
+func GetSecretValue(source options.SecretSource) ([]byte, error) {
 	switch {
 	case len(source.Value) > 0 && source.FromEnv == "" && source.FromFile == "":
 		value := make([]byte, base64.StdEncoding.DecodedLen(len(source.Value)))

--- a/pkg/apis/options/util/util_test.go
+++ b/pkg/apis/options/util/util_test.go
@@ -40,7 +40,7 @@ var _ = Describe("GetSecretValue", func() {
 		// This assertion ensures we are testing the triming
 		Expect(len(originalValue)).To(BeNumerically("<", base64.StdEncoding.DecodedLen(len(b64Value))))
 
-		value, err := GetSecretValue(&options.SecretSource{
+		value, err := GetSecretValue(options.SecretSource{
 			Value: []byte(b64Value),
 		})
 		Expect(err).ToNot(HaveOccurred())
@@ -48,7 +48,7 @@ var _ = Describe("GetSecretValue", func() {
 	})
 
 	It("returns the correct value from the environment", func() {
-		value, err := GetSecretValue(&options.SecretSource{
+		value, err := GetSecretValue(options.SecretSource{
 			FromEnv: secretEnvKey,
 		})
 		Expect(err).ToNot(HaveOccurred())
@@ -56,7 +56,7 @@ var _ = Describe("GetSecretValue", func() {
 	})
 
 	It("returns the correct value from a file", func() {
-		value, err := GetSecretValue(&options.SecretSource{
+		value, err := GetSecretValue(options.SecretSource{
 			FromFile: path.Join(fileDir, "secret-file"),
 		})
 		Expect(err).ToNot(HaveOccurred())
@@ -64,7 +64,7 @@ var _ = Describe("GetSecretValue", func() {
 	})
 
 	It("when the file does not exist", func() {
-		value, err := GetSecretValue(&options.SecretSource{
+		value, err := GetSecretValue(options.SecretSource{
 			FromFile: path.Join(fileDir, "not-exist"),
 		})
 		Expect(err).To(HaveOccurred())
@@ -72,13 +72,13 @@ var _ = Describe("GetSecretValue", func() {
 	})
 
 	It("with no source set", func() {
-		value, err := GetSecretValue(&options.SecretSource{})
+		value, err := GetSecretValue(options.SecretSource{})
 		Expect(err).To(MatchError("secret source is invalid: exactly one entry required, specify either value, fromEnv or fromFile"))
 		Expect(value).To(BeEmpty())
 	})
 
 	It("with multiple sources set", func() {
-		value, err := GetSecretValue(&options.SecretSource{
+		value, err := GetSecretValue(options.SecretSource{
 			FromEnv:  secretEnvKey,
 			FromFile: path.Join(fileDir, "secret-file"),
 		})

--- a/pkg/header/injector_test.go
+++ b/pkg/header/injector_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Injector Suite", func() {
 						Name: "Secret",
 						Values: []options.HeaderValue{
 							{
-								SecretSource: &options.SecretSource{
+								SecretSource: options.SecretSource{
 									Value: []byte(base64.StdEncoding.EncodeToString([]byte("super-secret"))),
 								},
 							},
@@ -78,7 +78,7 @@ var _ = Describe("Injector Suite", func() {
 						Name: "Secret",
 						Values: []options.HeaderValue{
 							{
-								SecretSource: &options.SecretSource{
+								SecretSource: options.SecretSource{
 									FromEnv: "SECRET_ENV",
 								},
 							},
@@ -101,7 +101,7 @@ var _ = Describe("Injector Suite", func() {
 						Name: "Claim",
 						Values: []options.HeaderValue{
 							{
-								ClaimSource: &options.ClaimSource{
+								ClaimSource: options.ClaimSource{
 									Claim: "id_token",
 								},
 							},
@@ -126,7 +126,7 @@ var _ = Describe("Injector Suite", func() {
 						Name: "Claim",
 						Values: []options.HeaderValue{
 							{
-								ClaimSource: &options.ClaimSource{
+								ClaimSource: options.ClaimSource{
 									Claim: "id_token",
 								},
 							},
@@ -148,7 +148,7 @@ var _ = Describe("Injector Suite", func() {
 						Name: "Claim",
 						Values: []options.HeaderValue{
 							{
-								ClaimSource: &options.ClaimSource{
+								ClaimSource: options.ClaimSource{
 									Claim:  "id_token",
 									Prefix: "Bearer ",
 								},
@@ -174,7 +174,7 @@ var _ = Describe("Injector Suite", func() {
 						Name: "Claim",
 						Values: []options.HeaderValue{
 							{
-								ClaimSource: &options.ClaimSource{
+								ClaimSource: options.ClaimSource{
 									Claim:  "idToken",
 									Prefix: "Bearer ",
 								},
@@ -197,9 +197,9 @@ var _ = Describe("Injector Suite", func() {
 						Name: "X-Auth-Request-Authorization",
 						Values: []options.HeaderValue{
 							{
-								ClaimSource: &options.ClaimSource{
+								ClaimSource: options.ClaimSource{
 									Claim: "user",
-									BasicAuthPassword: &options.SecretSource{
+									BasicAuthPassword: options.SecretSource{
 										Value: []byte(base64.StdEncoding.EncodeToString([]byte("basic-password"))),
 									},
 								},
@@ -225,9 +225,9 @@ var _ = Describe("Injector Suite", func() {
 						Name: "X-Auth-Request-Authorization",
 						Values: []options.HeaderValue{
 							{
-								ClaimSource: &options.ClaimSource{
+								ClaimSource: options.ClaimSource{
 									Claim: "user",
-									BasicAuthPassword: &options.SecretSource{
+									BasicAuthPassword: options.SecretSource{
 										Value: []byte(base64.StdEncoding.EncodeToString([]byte("basic-password"))),
 									},
 								},
@@ -250,7 +250,7 @@ var _ = Describe("Injector Suite", func() {
 						Name: "X-Auth-Request-User",
 						Values: []options.HeaderValue{
 							{
-								ClaimSource: &options.ClaimSource{
+								ClaimSource: options.ClaimSource{
 									Claim: "user",
 								},
 							},
@@ -274,10 +274,10 @@ var _ = Describe("Injector Suite", func() {
 						Name: "Claim",
 						Values: []options.HeaderValue{
 							{
-								ClaimSource: &options.ClaimSource{
+								ClaimSource: options.ClaimSource{
 									Claim: "id_token",
 								},
-								SecretSource: &options.SecretSource{
+								SecretSource: options.SecretSource{
 									FromEnv: "SECRET_ENV",
 								},
 							},
@@ -299,7 +299,7 @@ var _ = Describe("Injector Suite", func() {
 						Name: "Secret",
 						Values: []options.HeaderValue{
 							{
-								SecretSource: &options.SecretSource{
+								SecretSource: options.SecretSource{
 									FromEnv:  "SECRET_ENV",
 									FromFile: "secret-file",
 								},
@@ -320,9 +320,9 @@ var _ = Describe("Injector Suite", func() {
 						Name: "X-Auth-Request-Authorization",
 						Values: []options.HeaderValue{
 							{
-								ClaimSource: &options.ClaimSource{
+								ClaimSource: options.ClaimSource{
 									Claim: "user",
-									BasicAuthPassword: &options.SecretSource{
+									BasicAuthPassword: options.SecretSource{
 										Value:   []byte(base64.StdEncoding.EncodeToString([]byte("basic-password"))),
 										FromEnv: "SECRET_ENV",
 									},
@@ -346,9 +346,9 @@ var _ = Describe("Injector Suite", func() {
 						Name: "X-Auth-Request-Authorization",
 						Values: []options.HeaderValue{
 							{
-								ClaimSource: &options.ClaimSource{
+								ClaimSource: options.ClaimSource{
 									Claim: "user",
-									BasicAuthPassword: &options.SecretSource{
+									BasicAuthPassword: options.SecretSource{
 										Value: []byte(base64.StdEncoding.EncodeToString([]byte("basic-password"))),
 									},
 								},
@@ -359,7 +359,7 @@ var _ = Describe("Injector Suite", func() {
 						Name: "X-Auth-Request-User",
 						Values: []options.HeaderValue{
 							{
-								ClaimSource: &options.ClaimSource{
+								ClaimSource: options.ClaimSource{
 									Claim: "user",
 								},
 							},
@@ -369,7 +369,7 @@ var _ = Describe("Injector Suite", func() {
 						Name: "X-Auth-Request-Email",
 						Values: []options.HeaderValue{
 							{
-								ClaimSource: &options.ClaimSource{
+								ClaimSource: options.ClaimSource{
 									Claim: "email",
 								},
 							},
@@ -379,17 +379,17 @@ var _ = Describe("Injector Suite", func() {
 						Name: "X-Auth-Request-Version-Info",
 						Values: []options.HeaderValue{
 							{
-								SecretSource: &options.SecretSource{
+								SecretSource: options.SecretSource{
 									Value: []byte(base64.StdEncoding.EncodeToString([]byte("major=1"))),
 								},
 							},
 							{
-								SecretSource: &options.SecretSource{
+								SecretSource: options.SecretSource{
 									Value: []byte(base64.StdEncoding.EncodeToString([]byte("minor=2"))),
 								},
 							},
 							{
-								SecretSource: &options.SecretSource{
+								SecretSource: options.SecretSource{
 									Value: []byte(base64.StdEncoding.EncodeToString([]byte("patch=3"))),
 								},
 							},

--- a/pkg/middleware/headers_test.go
+++ b/pkg/middleware/headers_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Headers Suite", func() {
 					Name: "Claim",
 					Values: []options.HeaderValue{
 						{
-							ClaimSource: &options.ClaimSource{
+							ClaimSource: options.ClaimSource{
 								Claim: "id_token",
 							},
 						},
@@ -96,7 +96,7 @@ var _ = Describe("Headers Suite", func() {
 					Name: "Claim",
 					Values: []options.HeaderValue{
 						{
-							ClaimSource: &options.ClaimSource{
+							ClaimSource: options.ClaimSource{
 								Claim: "id_token",
 							},
 						},
@@ -121,7 +121,7 @@ var _ = Describe("Headers Suite", func() {
 					PreserveRequestValue: true,
 					Values: []options.HeaderValue{
 						{
-							ClaimSource: &options.ClaimSource{
+							ClaimSource: options.ClaimSource{
 								Claim: "id_token",
 							},
 						},
@@ -145,7 +145,7 @@ var _ = Describe("Headers Suite", func() {
 					Name: "Claim",
 					Values: []options.HeaderValue{
 						{
-							ClaimSource: &options.ClaimSource{
+							ClaimSource: options.ClaimSource{
 								Claim: "id_token",
 							},
 						},
@@ -166,7 +166,7 @@ var _ = Describe("Headers Suite", func() {
 					PreserveRequestValue: true,
 					Values: []options.HeaderValue{
 						{
-							ClaimSource: &options.ClaimSource{
+							ClaimSource: options.ClaimSource{
 								Claim: "id_token",
 							},
 						},
@@ -188,9 +188,9 @@ var _ = Describe("Headers Suite", func() {
 					Name: "X-Auth-Request-Authorization",
 					Values: []options.HeaderValue{
 						{
-							ClaimSource: &options.ClaimSource{
+							ClaimSource: options.ClaimSource{
 								Claim: "user",
-								BasicAuthPassword: &options.SecretSource{
+								BasicAuthPassword: options.SecretSource{
 									Value:   []byte(base64.StdEncoding.EncodeToString([]byte("basic-password"))),
 									FromEnv: "SECRET_ENV",
 								},
@@ -262,7 +262,7 @@ var _ = Describe("Headers Suite", func() {
 					Name: "Claim",
 					Values: []options.HeaderValue{
 						{
-							ClaimSource: &options.ClaimSource{
+							ClaimSource: options.ClaimSource{
 								Claim: "id_token",
 							},
 						},
@@ -287,7 +287,7 @@ var _ = Describe("Headers Suite", func() {
 					Name: "Claim",
 					Values: []options.HeaderValue{
 						{
-							ClaimSource: &options.ClaimSource{
+							ClaimSource: options.ClaimSource{
 								Claim: "id_token",
 							},
 						},
@@ -312,7 +312,7 @@ var _ = Describe("Headers Suite", func() {
 					PreserveRequestValue: true,
 					Values: []options.HeaderValue{
 						{
-							ClaimSource: &options.ClaimSource{
+							ClaimSource: options.ClaimSource{
 								Claim: "id_token",
 							},
 						},
@@ -336,7 +336,7 @@ var _ = Describe("Headers Suite", func() {
 					Name: "Claim",
 					Values: []options.HeaderValue{
 						{
-							ClaimSource: &options.ClaimSource{
+							ClaimSource: options.ClaimSource{
 								Claim: "id_token",
 							},
 						},
@@ -359,7 +359,7 @@ var _ = Describe("Headers Suite", func() {
 					PreserveRequestValue: true,
 					Values: []options.HeaderValue{
 						{
-							ClaimSource: &options.ClaimSource{
+							ClaimSource: options.ClaimSource{
 								Claim: "id_token",
 							},
 						},
@@ -381,9 +381,9 @@ var _ = Describe("Headers Suite", func() {
 					Name: "X-Auth-Request-Authorization",
 					Values: []options.HeaderValue{
 						{
-							ClaimSource: &options.ClaimSource{
+							ClaimSource: options.ClaimSource{
 								Claim: "user",
-								BasicAuthPassword: &options.SecretSource{
+								BasicAuthPassword: options.SecretSource{
 									Value:   []byte(base64.StdEncoding.EncodeToString([]byte("basic-password"))),
 									FromEnv: "SECRET_ENV",
 								},

--- a/pkg/validation/header.go
+++ b/pkg/validation/header.go
@@ -40,10 +40,10 @@ func validateHeader(header options.Header, names map[string]struct{}) []string {
 
 func validateHeaderValue(name string, value options.HeaderValue) []string {
 	switch {
-	case value.SecretSource != nil && value.ClaimSource == nil:
-		return []string{validateSecretSource(*value.SecretSource)}
-	case value.SecretSource == nil && value.ClaimSource != nil:
-		return validateHeaderValueClaimSource(*value.ClaimSource)
+	case !value.SecretSource.IsZero() && value.ClaimSource.IsZero():
+		return []string{validateSecretSource(value.SecretSource)}
+	case value.SecretSource.IsZero() && !value.ClaimSource.IsZero():
+		return validateHeaderValueClaimSource(value.ClaimSource)
 	default:
 		return []string{"header value has multiple entries: only one entry per value is allowed"}
 	}
@@ -56,8 +56,8 @@ func validateHeaderValueClaimSource(claim options.ClaimSource) []string {
 		msgs = append(msgs, "claim should not be empty")
 	}
 
-	if claim.BasicAuthPassword != nil {
-		msgs = append(msgs, prefixValues("invalid basicAuthPassword: ", validateSecretSource(*claim.BasicAuthPassword))...)
+	if !claim.BasicAuthPassword.IsZero() {
+		msgs = append(msgs, prefixValues("invalid basicAuthPassword: ", validateSecretSource(claim.BasicAuthPassword))...)
 	}
 	return msgs
 }

--- a/pkg/validation/header_test.go
+++ b/pkg/validation/header_test.go
@@ -19,7 +19,7 @@ var _ = Describe("Headers", func() {
 		Name: "X-Email",
 		Values: []options.HeaderValue{
 			{
-				ClaimSource: &options.ClaimSource{
+				ClaimSource: options.ClaimSource{
 					Claim: "email",
 				},
 			},
@@ -30,7 +30,7 @@ var _ = Describe("Headers", func() {
 		Name: "X-Forwarded-Auth",
 		Values: []options.HeaderValue{
 			{
-				SecretSource: &options.SecretSource{
+				SecretSource: options.SecretSource{
 					Value: []byte(base64.StdEncoding.EncodeToString([]byte("secret"))),
 				},
 			},
@@ -41,9 +41,9 @@ var _ = Describe("Headers", func() {
 		Name: "Authorization",
 		Values: []options.HeaderValue{
 			{
-				ClaimSource: &options.ClaimSource{
+				ClaimSource: options.ClaimSource{
 					Claim: "email",
-					BasicAuthPassword: &options.SecretSource{
+					BasicAuthPassword: options.SecretSource{
 						Value: []byte(base64.StdEncoding.EncodeToString([]byte("secret"))),
 					},
 				},
@@ -94,8 +94,12 @@ var _ = Describe("Headers", func() {
 					Name: "With-Claim-And-Secret",
 					Values: []options.HeaderValue{
 						{
-							ClaimSource:  &options.ClaimSource{},
-							SecretSource: &options.SecretSource{},
+							ClaimSource: options.ClaimSource{
+								Claim: "foo",
+							},
+							SecretSource: options.SecretSource{
+								Value: []byte("bar"),
+							},
 						},
 					},
 				},
@@ -111,7 +115,7 @@ var _ = Describe("Headers", func() {
 					Name: "Without-Claim",
 					Values: []options.HeaderValue{
 						{
-							ClaimSource: &options.ClaimSource{
+							ClaimSource: options.ClaimSource{
 								Prefix: "prefix",
 							},
 						},
@@ -129,7 +133,10 @@ var _ = Describe("Headers", func() {
 					Name: "With-Invalid-Secret",
 					Values: []options.HeaderValue{
 						{
-							SecretSource: &options.SecretSource{},
+							SecretSource: options.SecretSource{
+								FromEnv:  "ENV_ONE",
+								FromFile: "FILE_ONE",
+							},
 						},
 					},
 				},
@@ -145,9 +152,9 @@ var _ = Describe("Headers", func() {
 					Name: "With-Invalid-Basic-Auth",
 					Values: []options.HeaderValue{
 						{
-							ClaimSource: &options.ClaimSource{
+							ClaimSource: options.ClaimSource{
 								Claim: "user",
-								BasicAuthPassword: &options.SecretSource{
+								BasicAuthPassword: options.SecretSource{
 									Value: []byte("secret"),
 								},
 							},

--- a/pkg/validation/sessions.go
+++ b/pkg/validation/sessions.go
@@ -18,15 +18,13 @@ func validateSessionCookieMinimal(o *options.Options) []string {
 	msgs := []string{}
 	for _, header := range append(o.InjectRequestHeaders, o.InjectResponseHeaders...) {
 		for _, value := range header.Values {
-			if value.ClaimSource != nil {
-				if value.ClaimSource.Claim == "access_token" {
-					msgs = append(msgs,
-						fmt.Sprintf("access_token claim for header %q requires oauth tokens in sessions. session_cookie_minimal cannot be set", header.Name))
-				}
-				if value.ClaimSource.Claim == "id_token" {
-					msgs = append(msgs,
-						fmt.Sprintf("id_token claim for header %q requires oauth tokens in sessions. session_cookie_minimal cannot be set", header.Name))
-				}
+			if value.ClaimSource.Claim == "access_token" {
+				msgs = append(msgs,
+					fmt.Sprintf("access_token claim for header %q requires oauth tokens in sessions. session_cookie_minimal cannot be set", header.Name))
+			}
+			if value.ClaimSource.Claim == "id_token" {
+				msgs = append(msgs,
+					fmt.Sprintf("id_token claim for header %q requires oauth tokens in sessions. session_cookie_minimal cannot be set", header.Name))
 			}
 		}
 	}

--- a/pkg/validation/sessions_test.go
+++ b/pkg/validation/sessions_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Sessions", func() {
 						Name: "X-Access-Token",
 						Values: []options.HeaderValue{
 							{
-								ClaimSource: &options.ClaimSource{
+								ClaimSource: options.ClaimSource{
 									Claim: "access_token",
 								},
 							},
@@ -81,7 +81,7 @@ var _ = Describe("Sessions", func() {
 						Name: "X-ID-Token",
 						Values: []options.HeaderValue{
 							{
-								ClaimSource: &options.ClaimSource{
+								ClaimSource: options.ClaimSource{
 									Claim: "id_token",
 								},
 							},
@@ -103,7 +103,7 @@ var _ = Describe("Sessions", func() {
 						Name: "X-ID-Token",
 						Values: []options.HeaderValue{
 							{
-								ClaimSource: &options.ClaimSource{
+								ClaimSource: options.ClaimSource{
 									Claim: "id_token",
 								},
 							},
@@ -125,7 +125,7 @@ var _ = Describe("Sessions", func() {
 						Name: "X-Access-Token",
 						Values: []options.HeaderValue{
 							{
-								ClaimSource: &options.ClaimSource{
+								ClaimSource: options.ClaimSource{
 									Claim: "access_token",
 								},
 							},
@@ -160,7 +160,7 @@ var _ = Describe("Sessions", func() {
 						Name: "X-ID-Token",
 						Values: []options.HeaderValue{
 							{
-								ClaimSource: &options.ClaimSource{
+								ClaimSource: options.ClaimSource{
 									Claim: "id_token",
 								},
 							},
@@ -172,7 +172,7 @@ var _ = Describe("Sessions", func() {
 						Name: "X-Access-Token",
 						Values: []options.HeaderValue{
 							{
-								ClaimSource: &options.ClaimSource{
+								ClaimSource: options.ClaimSource{
 									Claim: "access_token",
 								},
 							},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
This replaces the pointer embdedded structs with literal embedded structs and adds `IsZero` helpers to them to replace where we were checking for nil (since this was what we were looking for anyway).

There is no functional change in this PR, it's purely a refactor that paves the way for #907 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It makes it impossible to "squash" the structure down when unmarshalling from YAML.
By using literals rather than pointers we can allow users to omit specifying the names of the embedded structs and promote the members to the parent struct.

eg
```
headers: 
- name: foo
  values:
  - claim: name
```
vs
```
headers: 
- name: foo
  values:
  - claimSource: 
      claim: name
```

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests, it's a refactor with no logical changes.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
