### PR TITLE
Fix log header output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 
 ## Changes since v6.1.1
 
+- [#918](https://github.com/oauth2-proxy/oauth2-proxy/pull/918) Fix log header output (@JoelSpeed)
 - [#911](https://github.com/oauth2-proxy/oauth2-rpoxy/pull/911) Validate provider type on startup.
 - [#906](https://github.com/oauth2-proxy/oauth2-proxy/pull/906) Set up v6.1.x versioned documentation as default documentation (@JoelSpeed)
 - [#905](https://github.com/oauth2-proxy/oauth2-proxy/pull/905) Remove v5 legacy sessions support (@NickMeves)

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -162,7 +162,7 @@ func (l *Logger) Output(lvl Level, calldepth int, message string) {
 	if !l.stdEnabled {
 		return
 	}
-	msg := l.formatLogMessage(calldepth, message)
+	msg := l.formatLogMessage(calldepth+1, message)
 
 	var err error
 	switch lvl {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Increase the log calldepth in `logger.std.Output`

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When #718 was implemented, it extracted the log header formatting into `formatLogMessage`.
This extraction of the logic increased the calldepth by 1, so we need to make sure that the calldepth is increased where `formatLogMessage` is being called.

Fixes #908 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually using the local test environments.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
