### PR TITLE
Support TLS 1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 
 ## Changes since v6.1.1
 
+- [#923](https://github.com/oauth2-proxy/oauth2-proxy/pull/923) Support TLS 1.3 (@aajisaka)
 - [#911](https://github.com/oauth2-proxy/oauth2-rpoxy/pull/911) Validate provider type on startup.
 - [#906](https://github.com/oauth2-proxy/oauth2-proxy/pull/906) Set up v6.1.x versioned documentation as default documentation (@JoelSpeed)
 - [#905](https://github.com/oauth2-proxy/oauth2-proxy/pull/905) Remove v5 legacy sessions support (@NickMeves)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 ## Breaking Changes
 
-- [#911](https://github.com/oauth2-proxy/oauth2-rpoxy/pull/911) Specifying a non-existent provider will cause OAuth2-Proxy to fail on startup instead of defaulting to "google".
+- [#911](https://github.com/oauth2-proxy/oauth2-proxy/pull/911) Specifying a non-existent provider will cause OAuth2-Proxy to fail on startup instead of defaulting to "google".
 - [#797](https://github.com/oauth2-proxy/oauth2-proxy/pull/797) Security changes to Google provider group authorization flow
   - If you change the list of allowed groups, existing sessions that now don't have a valid group will be logged out immediately.
     - Previously, group membership was only checked on session creation and refresh.
@@ -44,7 +44,7 @@
 ## Changes since v6.1.1
 
 - [#923](https://github.com/oauth2-proxy/oauth2-proxy/pull/923) Support TLS 1.3 (@aajisaka)
-- [#911](https://github.com/oauth2-proxy/oauth2-rpoxy/pull/911) Validate provider type on startup.
+- [#911](https://github.com/oauth2-proxy/oauth2-proxy/pull/911) Validate provider type on startup.
 - [#906](https://github.com/oauth2-proxy/oauth2-proxy/pull/906) Set up v6.1.x versioned documentation as default documentation (@JoelSpeed)
 - [#905](https://github.com/oauth2-proxy/oauth2-proxy/pull/905) Remove v5 legacy sessions support (@NickMeves)
 - [#904](https://github.com/oauth2-proxy/oauth2-proxy/pull/904) Set `skip-auth-strip-headers` to `true` by default (@NickMeves)

--- a/http.go
+++ b/http.go
@@ -64,7 +64,7 @@ func (s *Server) ServeHTTPS() {
 	addr := s.Opts.HTTPSAddress
 	config := &tls.Config{
 		MinVersion: tls.VersionTLS12,
-		MaxVersion: tls.VersionTLS12,
+		MaxVersion: 0,
 	}
 	if config.NextProtos == nil {
 		config.NextProtos = []string{"http/1.1"}

--- a/http.go
+++ b/http.go
@@ -64,7 +64,7 @@ func (s *Server) ServeHTTPS() {
 	addr := s.Opts.HTTPSAddress
 	config := &tls.Config{
 		MinVersion: tls.VersionTLS12,
-		MaxVersion: 0,
+		MaxVersion: tls.VersionTLS13,
 	}
 	if config.NextProtos == nil {
 		config.NextProtos = []string{"http/1.1"}


### PR DESCRIPTION
## Description

Set "tls.MaxVersion = tls.VersionTLS13" to use TLS 1.3 if possible.

## Motivation and Context

Now the TLS version is hard-coded and it does not support TLS 1.3.

## How Has This Been Tested?

Manually tested. I compiled and deployed in CentOS 7 and ran curl command.

```
% curl -i -v https://<hostname>:<port> --tlsv1.3
```

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
