### PR TITLE
Fix basic auth legacy header conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 
 ## Changes since v6.1.1
 
+- [#925](https://github.com/oauth2-proxy/oauth2-rpoxy/pull/925) Fix basic auth legacy header conversion (@JoelSpeed)
 - [#916](https://github.com/oauth2-proxy/oauth2-rpoxy/pull/916) Add AlphaOptions struct to prepare for alpha config loading (@JoelSpeed)
 - [#923](https://github.com/oauth2-proxy/oauth2-proxy/pull/923) Support TLS 1.3 (@aajisaka)
 - [#918](https://github.com/oauth2-proxy/oauth2-proxy/pull/918) Fix log header output (@JoelSpeed)

--- a/pkg/apis/options/legacy_options.go
+++ b/pkg/apis/options/legacy_options.go
@@ -232,7 +232,8 @@ func getBasicAuthHeader(preferEmailToUser bool, basicAuthPassword string) Header
 		Values: []HeaderValue{
 			{
 				ClaimSource: &ClaimSource{
-					Claim: claim,
+					Claim:  claim,
+					Prefix: "Basic ",
 					BasicAuthPassword: &SecretSource{
 						Value: []byte(base64.StdEncoding.EncodeToString([]byte(basicAuthPassword))),
 					},

--- a/pkg/apis/options/legacy_options_test.go
+++ b/pkg/apis/options/legacy_options_test.go
@@ -329,7 +329,8 @@ var _ = Describe("Legacy Options", func() {
 			Values: []HeaderValue{
 				{
 					ClaimSource: &ClaimSource{
-						Claim: "user",
+						Claim:  "user",
+						Prefix: "Basic ",
 						BasicAuthPassword: &SecretSource{
 							Value: []byte(base64.StdEncoding.EncodeToString([]byte(basicAuthSecret))),
 						},
@@ -368,7 +369,8 @@ var _ = Describe("Legacy Options", func() {
 			Values: []HeaderValue{
 				{
 					ClaimSource: &ClaimSource{
-						Claim: "email",
+						Claim:  "email",
+						Prefix: "Basic ",
 						BasicAuthPassword: &SecretSource{
 							Value: []byte(base64.StdEncoding.EncodeToString([]byte(basicAuthSecret))),
 						},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Ensure that the `Basic` prefix is included on basic auth headers

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We recently changed how headers are being set and in that PR I forgot that basic auth headers need the basic prefix!

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually using the local testing environment.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
