### PR TITLE
Use New Stable Chart URL

### DIFF
--- a/contrib/local-environment/kubernetes/Chart.lock
+++ b/contrib/local-environment/kubernetes/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: dex
-  repository: https://kubernetes-charts.storage.googleapis.com
+  repository: https://charts.helm.sh/stable
   version: 2.11.0
 - name: oauth2-proxy
-  repository: https://kubernetes-charts.storage.googleapis.com
+  repository: https://charts.helm.sh/stable
   version: 3.1.0
 - name: httpbin
   repository: https://conservis.github.io/helm-charts
@@ -11,5 +11,5 @@ dependencies:
 - name: hello-world
   repository: https://conservis.github.io/helm-charts
   version: 1.0.1
-digest: sha256:ce64f06102abb551ee23b6de7b4cec3537f4900de89412458e53760781005aac
-generated: "2020-06-16T16:59:19.126187-05:00"
+digest: sha256:e325948ece1706bd9d9e439568985db41e9a0d57623d0f9638249cb0d23821b8
+generated: "2020-11-23T11:45:07.908898-08:00"

--- a/contrib/local-environment/kubernetes/Chart.yaml
+++ b/contrib/local-environment/kubernetes/Chart.yaml
@@ -6,10 +6,10 @@ appVersion: 5.1.1
 dependencies:
   - name: dex
     version: 2.11.0
-    repository: https://kubernetes-charts.storage.googleapis.com
+    repository: https://charts.helm.sh/stable
   - name: oauth2-proxy
     version: 3.1.0
-    repository: https://kubernetes-charts.storage.googleapis.com
+    repository: https://charts.helm.sh/stable
   # https://github.com/postmanlabs/httpbin/issues/549 is still in progress, for now using a non-official chart
   - name: httpbin
     version: 1.0.1


### PR DESCRIPTION
## Description

The existing URL no longer works. This commit updates the Chart
dependencies to use the new Stable chart URL.

This will fix the "Chart not found" errors that occur if these example
resources are used.

Please keep in mind this is only a bandaid, as the repository is still
EOL, and should not be used.

## Motivation and Context

The Kubernetes examples using charts are currently broken.

## How Has This Been Tested?

```
helm dep update
```

This completes without error.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
