### PR TITLE
Cleanup method name refactors missed in comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 
 ## Changes since v6.1.1
 
+- [#938](https://github.com/oauth2-proxy/oauth2-proxy/pull/938) Cleanup missed provider renaming refactor methods (@NickMeves)
 - [#925](https://github.com/oauth2-proxy/oauth2-proxy/pull/925) Fix basic auth legacy header conversion (@JoelSpeed)
 - [#916](https://github.com/oauth2-proxy/oauth2-proxy/pull/916) Add AlphaOptions struct to prepare for alpha config loading (@JoelSpeed)
 - [#923](https://github.com/oauth2-proxy/oauth2-proxy/pull/923) Support TLS 1.3 (@aajisaka)

--- a/providers/azure.go
+++ b/providers/azure.go
@@ -279,7 +279,7 @@ func (p *AzureProvider) GetLoginURL(redirectURI, state string) string {
 	return a.String()
 }
 
-// ValidateSessionState validates the AccessToken
-func (p *AzureProvider) ValidateSessionState(ctx context.Context, s *sessions.SessionState) bool {
+// ValidateSession validates the AccessToken
+func (p *AzureProvider) ValidateSession(ctx context.Context, s *sessions.SessionState) bool {
 	return validateToken(ctx, p, s.AccessToken, makeAzureHeader(s.AccessToken))
 }

--- a/providers/digitalocean.go
+++ b/providers/digitalocean.go
@@ -82,7 +82,7 @@ func (p *DigitalOceanProvider) GetEmailAddress(ctx context.Context, s *sessions.
 	return email, nil
 }
 
-// ValidateSessionState validates the AccessToken
+// ValidateSession validates the AccessToken
 func (p *DigitalOceanProvider) ValidateSession(ctx context.Context, s *sessions.SessionState) bool {
 	return validateToken(ctx, p, s.AccessToken, makeOIDCHeader(s.AccessToken))
 }

--- a/providers/github.go
+++ b/providers/github.go
@@ -102,7 +102,7 @@ func (p *GitHubProvider) SetUsers(users []string) {
 	p.Users = users
 }
 
-// EnrichSessionState updates the User & Email after the initial Redeem
+// EnrichSession updates the User & Email after the initial Redeem
 func (p *GitHubProvider) EnrichSession(ctx context.Context, s *sessions.SessionState) error {
 	err := p.getEmail(ctx, s)
 	if err != nil {
@@ -111,7 +111,7 @@ func (p *GitHubProvider) EnrichSession(ctx context.Context, s *sessions.SessionS
 	return p.getUser(ctx, s)
 }
 
-// ValidateSessionState validates the AccessToken
+// ValidateSession validates the AccessToken
 func (p *GitHubProvider) ValidateSession(ctx context.Context, s *sessions.SessionState) bool {
 	return validateToken(ctx, p, s.AccessToken, makeGitHubHeader(s.AccessToken))
 }

--- a/providers/gitlab.go
+++ b/providers/gitlab.go
@@ -187,7 +187,7 @@ func (p *GitLabProvider) createSessionState(ctx context.Context, token *oauth2.T
 	}, nil
 }
 
-// ValidateSessionState checks that the session's IDToken is still valid
+// ValidateSession checks that the session's IDToken is still valid
 func (p *GitLabProvider) ValidateSession(ctx context.Context, s *sessions.SessionState) bool {
 	_, err := p.Verifier.Verify(ctx, s.IDToken)
 	return err == nil

--- a/providers/google.go
+++ b/providers/google.go
@@ -177,10 +177,10 @@ func (p *GoogleProvider) Redeem(ctx context.Context, redirectURL, code string) (
 	}, nil
 }
 
-// EnrichSessionState checks the listed Google Groups configured and adds any
+// EnrichSession checks the listed Google Groups configured and adds any
 // that the user is a member of to session.Groups.
 func (p *GoogleProvider) EnrichSession(ctx context.Context, s *sessions.SessionState) error {
-	// TODO (@NickMeves) - Move to pure EnrichSessionState logic and stop
+	// TODO (@NickMeves) - Move to pure EnrichSession logic and stop
 	// reusing legacy `groupValidator`.
 	//
 	// This is called here to get the validator to do the `session.Groups`

--- a/providers/internal_util_test.go
+++ b/providers/internal_util_test.go
@@ -20,30 +20,30 @@ func updateURL(url *url.URL, hostname string) {
 	url.Host = hostname
 }
 
-type ValidateSessionStateTestProvider struct {
+type ValidateSessionTestProvider struct {
 	*ProviderData
 }
 
-var _ Provider = (*ValidateSessionStateTestProvider)(nil)
+var _ Provider = (*ValidateSessionTestProvider)(nil)
 
-func (tp *ValidateSessionStateTestProvider) GetEmailAddress(ctx context.Context, s *sessions.SessionState) (string, error) {
+func (tp *ValidateSessionTestProvider) GetEmailAddress(ctx context.Context, s *sessions.SessionState) (string, error) {
 	return "", errors.New("not implemented")
 }
 
 // Note that we're testing the internal validateToken() used to implement
-// several Provider's ValidateSessionState() implementations
-func (tp *ValidateSessionStateTestProvider) ValidateSession(ctx context.Context, s *sessions.SessionState) bool {
+// several Provider's ValidateSession() implementations
+func (tp *ValidateSessionTestProvider) ValidateSession(ctx context.Context, s *sessions.SessionState) bool {
 	return false
 }
 
 type ValidateSessionStateTest struct {
 	backend      *httptest.Server
 	responseCode int
-	provider     *ValidateSessionStateTestProvider
+	provider     *ValidateSessionTestProvider
 	header       http.Header
 }
 
-func NewValidateSessionStateTest() *ValidateSessionStateTest {
+func NewValidateSessionTest() *ValidateSessionStateTest {
 	var vtTest ValidateSessionStateTest
 
 	vtTest.backend = httptest.NewServer(
@@ -73,7 +73,7 @@ func NewValidateSessionStateTest() *ValidateSessionStateTest {
 
 		}))
 	backendURL, _ := url.Parse(vtTest.backend.URL)
-	vtTest.provider = &ValidateSessionStateTestProvider{
+	vtTest.provider = &ValidateSessionTestProvider{
 		ProviderData: &ProviderData{
 			ValidateURL: &url.URL{
 				Scheme: "http",
@@ -90,14 +90,14 @@ func (vtTest *ValidateSessionStateTest) Close() {
 	vtTest.backend.Close()
 }
 
-func TestValidateSessionStateValidToken(t *testing.T) {
-	vtTest := NewValidateSessionStateTest()
+func TestValidateSessionValidToken(t *testing.T) {
+	vtTest := NewValidateSessionTest()
 	defer vtTest.Close()
 	assert.Equal(t, true, validateToken(context.Background(), vtTest.provider, "foobar", nil))
 }
 
-func TestValidateSessionStateValidTokenWithHeaders(t *testing.T) {
-	vtTest := NewValidateSessionStateTest()
+func TestValidateSessionValidTokenWithHeaders(t *testing.T) {
+	vtTest := NewValidateSessionTest()
 	defer vtTest.Close()
 	vtTest.header = make(http.Header)
 	vtTest.header.Set("Authorization", "Bearer foobar")
@@ -105,28 +105,28 @@ func TestValidateSessionStateValidTokenWithHeaders(t *testing.T) {
 		validateToken(context.Background(), vtTest.provider, "foobar", vtTest.header))
 }
 
-func TestValidateSessionStateEmptyToken(t *testing.T) {
-	vtTest := NewValidateSessionStateTest()
+func TestValidateSessionEmptyToken(t *testing.T) {
+	vtTest := NewValidateSessionTest()
 	defer vtTest.Close()
 	assert.Equal(t, false, validateToken(context.Background(), vtTest.provider, "", nil))
 }
 
-func TestValidateSessionStateEmptyValidateURL(t *testing.T) {
-	vtTest := NewValidateSessionStateTest()
+func TestValidateSessionEmptyValidateURL(t *testing.T) {
+	vtTest := NewValidateSessionTest()
 	defer vtTest.Close()
 	vtTest.provider.Data().ValidateURL = nil
 	assert.Equal(t, false, validateToken(context.Background(), vtTest.provider, "foobar", nil))
 }
 
-func TestValidateSessionStateRequestNetworkFailure(t *testing.T) {
-	vtTest := NewValidateSessionStateTest()
+func TestValidateSessionRequestNetworkFailure(t *testing.T) {
+	vtTest := NewValidateSessionTest()
 	// Close immediately to simulate a network failure
 	vtTest.Close()
 	assert.Equal(t, false, validateToken(context.Background(), vtTest.provider, "foobar", nil))
 }
 
-func TestValidateSessionStateExpiredToken(t *testing.T) {
-	vtTest := NewValidateSessionStateTest()
+func TestValidateSessionExpiredToken(t *testing.T) {
+	vtTest := NewValidateSessionTest()
 	defer vtTest.Close()
 	vtTest.responseCode = 401
 	assert.Equal(t, false, validateToken(context.Background(), vtTest.provider, "foobar", nil))

--- a/providers/provider_default.go
+++ b/providers/provider_default.go
@@ -86,12 +86,12 @@ func (p *ProviderData) GetLoginURL(redirectURI, state string) string {
 }
 
 // GetEmailAddress returns the Account email address
-// DEPRECATED: Migrate to EnrichSessionState
+// DEPRECATED: Migrate to EnrichSession
 func (p *ProviderData) GetEmailAddress(_ context.Context, _ *sessions.SessionState) (string, error) {
 	return "", ErrNotImplemented
 }
 
-// EnrichSessionState is called after Redeem to allow providers to enrich session fields
+// EnrichSession is called after Redeem to allow providers to enrich session fields
 // such as User, Email, Groups with provider specific API calls.
 func (p *ProviderData) EnrichSession(_ context.Context, _ *sessions.SessionState) error {
 	return nil
@@ -113,7 +113,7 @@ func (p *ProviderData) Authorize(_ context.Context, s *sessions.SessionState) (b
 	return false, nil
 }
 
-// ValidateSessionState validates the AccessToken
+// ValidateSession validates the AccessToken
 func (p *ProviderData) ValidateSession(ctx context.Context, s *sessions.SessionState) bool {
 	return validateToken(ctx, p, s.AccessToken, nil)
 }

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -9,7 +9,7 @@ import (
 // Provider represents an upstream identity provider implementation
 type Provider interface {
 	Data() *ProviderData
-	// DEPRECATED: Migrate to EnrichSessionState
+	// DEPRECATED: Migrate to EnrichSession
 	GetEmailAddress(ctx context.Context, s *sessions.SessionState) (string, error)
 	Redeem(ctx context.Context, redirectURI, code string) (*sessions.SessionState, error)
 	EnrichSession(ctx context.Context, s *sessions.SessionState) error


### PR DESCRIPTION
`ValidateSessionState` rename was missed in `azure.go`.

Fixes the missing method name changes in the comments.

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
