### PR TITLE
CVE-2020-28928: use last alpine as base image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 
 ## Changes since v6.1.1
 
+- [#944](https://github.com/oauth2-proxy/oauth2-proxy/pull/944) Use alpine:3.12.1 as base image to avoid CVE-2020-28928 (@PascalBourdier)
 - [#907](https://github.com/oauth2-proxy/oauth2-proxy/pull/907) Introduce alpha configuration option to enable testing of structured configuration (@JoelSpeed)
 - [#938](https://github.com/oauth2-proxy/oauth2-proxy/pull/938) Cleanup missed provider renaming refactor methods (@NickMeves)
 - [#925](https://github.com/oauth2-proxy/oauth2-proxy/pull/925) Fix basic auth legacy header conversion (@JoelSpeed)

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY . .
 RUN VERSION=${VERSION} make build && touch jwt_signing_key.pem
 
 # Copy binary to alpine
-FROM alpine:3.12
+FROM alpine:3.12.1
 COPY nsswitch.conf /etc/nsswitch.conf
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /go/src/github.com/oauth2-proxy/oauth2-proxy/oauth2-proxy /bin/oauth2-proxy

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -20,7 +20,7 @@ COPY . .
 RUN VERSION=${VERSION} GOARCH=arm64 make build && touch jwt_signing_key.pem
 
 # Copy binary to alpine
-FROM arm64v8/alpine:3.12
+FROM arm64v8/alpine:3.12.1
 COPY nsswitch.conf /etc/nsswitch.conf
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /go/src/github.com/oauth2-proxy/oauth2-proxy/oauth2-proxy /bin/oauth2-proxy

--- a/Dockerfile.armv6
+++ b/Dockerfile.armv6
@@ -20,7 +20,7 @@ COPY . .
 RUN VERSION=${VERSION} GOARCH=arm GOARM=6 make build && touch jwt_signing_key.pem
 
 # Copy binary to alpine
-FROM arm32v6/alpine:3.12
+FROM arm32v6/alpine:3.12.1
 COPY nsswitch.conf /etc/nsswitch.conf
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /go/src/github.com/oauth2-proxy/oauth2-proxy/oauth2-proxy /bin/oauth2-proxy


### PR DESCRIPTION
Affected location: cpe:/o:alpine:alpine_linux:3.11
Package: musl
Version: 1.1.24 r2
Fixed in version: 1.1.24 r3
Note name: projects/goog-vulnz/notes/CVE-2020-28928
Provider: goog-vulnz

more details here: https://www.alpinelinux.org/posts/Alpine-3.12.1-released.html

<!--- Provide a general summary of your changes in the Title above -->

## Description

CVE-2020-28928

## Motivation and Context
security issue

## How Has This Been Tested?

scan with gcr registry

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
