### PR TITLE
Use X-Forwarded-{Proto,Host} on redirect as last resort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - [#953](https://github.com/oauth2-proxy/oauth2-proxy/pull/953) Keycloak will now use `--profile-url` if set for the userinfo endpoint
   instead of `--validate-url`. `--validate-url` will still work for backwards compatibility.
+- [#957](https://github.com/oauth2-proxy/oauth2-proxy/pull/957) To use X-Forwarded-{Proto,Host,Uri} on redirect detection, `--reverse-proxy` must be `true`.
 - [#936](https://github.com/oauth2-proxy/oauth2-proxy/pull/936) `--user-id-claim` option is deprecated and replaced by `--oidc-email-claim`
 - [#630](https://github.com/oauth2-proxy/oauth2-proxy/pull/630) Gitlab projects needs a Gitlab application with the extra `read_api` enabled
 - [#849](https://github.com/oauth2-proxy/oauth2-proxy/pull/849) `/oauth2/auth` `allowed_groups` querystring parameter can be paired with the `allowed-groups` configuration option.
@@ -59,6 +60,7 @@
 ## Changes since v6.1.1
 
 - [#953](https://github.com/oauth2-proxy/oauth2-proxy/pull/953) Migrate Keycloak to EnrichSession & support multiple groups for authorization (@NickMeves)
+- [#957](https://github.com/oauth2-proxy/oauth2-proxy/pull/957) Use X-Forwarded-{Proto,Host,Uri} on redirect as last resort (@linuxgemini)
 - [#630](https://github.com/oauth2-proxy/oauth2-proxy/pull/630) Add support for Gitlab project based authentication (@factorysh)
 - [#907](https://github.com/oauth2-proxy/oauth2-proxy/pull/907) Introduce alpha configuration option to enable testing of structured configuration (@JoelSpeed)
 - [#938](https://github.com/oauth2-proxy/oauth2-proxy/pull/938) Cleanup missed provider renaming refactor methods (@NickMeves)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -25,6 +25,15 @@ func GetCertPool(paths []string) (*x509.CertPool, error) {
 	return pool, nil
 }
 
+// GetRequestProto return the request host header or X-Forwarded-Proto if present
+func GetRequestProto(req *http.Request) string {
+	proto := req.Header.Get("X-Forwarded-Proto")
+	if proto == "" {
+		proto = req.URL.Scheme
+	}
+	return proto
+}
+
 // GetRequestHost return the request host header or X-Forwarded-Host if present
 func GetRequestHost(req *http.Request) string {
 	host := req.Header.Get("X-Forwarded-Host")
@@ -32,4 +41,14 @@ func GetRequestHost(req *http.Request) string {
 		host = req.Host
 	}
 	return host
+}
+
+// GetRequestURI return the request host header or X-Forwarded-Uri if present
+func GetRequestURI(req *http.Request) string {
+	uri := req.Header.Get("X-Forwarded-Uri")
+	if uri == "" {
+		// Use RequestURI to preserve ?query
+		uri = req.URL.RequestURI()
+	}
+	return uri
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -110,3 +110,29 @@ func TestGetRequestHost(t *testing.T) {
 	extHost := GetRequestHost(proxyReq)
 	g.Expect(extHost).To(Equal("external.example.com"))
 }
+
+func TestGetRequestProto(t *testing.T) {
+	g := NewWithT(t)
+
+	req := httptest.NewRequest("GET", "https://example.com", nil)
+	proto := GetRequestProto(req)
+	g.Expect(proto).To(Equal("https"))
+
+	proxyReq := httptest.NewRequest("GET", "https://internal.example.com", nil)
+	proxyReq.Header.Add("X-Forwarded-Proto", "http")
+	extProto := GetRequestProto(proxyReq)
+	g.Expect(extProto).To(Equal("http"))
+}
+
+func TestGetRequestURI(t *testing.T) {
+	g := NewWithT(t)
+
+	req := httptest.NewRequest("GET", "https://example.com/ping", nil)
+	uri := GetRequestURI(req)
+	g.Expect(uri).To(Equal("/ping"))
+
+	proxyReq := httptest.NewRequest("GET", "http://internal.example.com/bong", nil)
+	proxyReq.Header.Add("X-Forwarded-Uri", "/ping")
+	extURI := GetRequestURI(proxyReq)
+	g.Expect(extURI).To(Equal("/ping"))
+}


### PR DESCRIPTION
Use X-Forwarded-{Proto,Host} headers in the requests to oauth2-proxy as a last resort to get where to redirect.

## Description

Reverse proxies like Traefik currently don't have a dynamic way to manipulate headers, thus handling redirects is not easy.

On Traefik v1, you could set the `rd` query string _per frontend_, thus allowing more customization. However on Traefik v2, the entire config structure changed and these customizations _has to be general purpose middlewares_; and having no dynamic way to modify headers gives very little chance to configure a central auth environment.

## Motivation and Context

This change hopes to resolve #46 and is code is somewhat based on #762.

## How Has This Been Tested?

On a Traefik v2 host, this File (YAML) config is used:
```yaml
http:
  routers:
    a-service:
      rule: "Host(`a-service.example.com`)"
      service: a-service-backend
      middlewares:
        - oauth-errors
        - oauth-auth
      tls:
        certResolver: default
        domains:
          - main: "example.com"
            sans:
              - "*.example.com"
    oauth:
      rule: "Host(`a-service.example.com`, `oauth.example.com`) && PathPrefix(`/oauth2/`)"
      middlewares:
        - auth-headers
      service: oauth-backend
      tls:
        certResolver: default
        domains:
          - main: "example.com"
            sans:
              - "*.example.com"

  services:
    a-service-backend:
      loadBalancer:
        servers:
          - url: http://172.16.0.2:7555
    oauth-backend:
      loadBalancer:
        servers:
          - url: http://172.16.0.1:4180

  middlewares:
    auth-headers:
      headers:
        sslRedirect: true
        stsSeconds: 315360000
        browserXssFilter: true
        contentTypeNosniff: true
        forceSTSHeader: true
        sslHost: example.com
        stsIncludeSubdomains: true
        stsPreload: true
        frameDeny: true
    oauth-auth:
      forwardAuth:
        address: https://oauth.example.com/oauth2/auth
        trustForwardHeader: true
    oauth-errors:
      errors:
        status:
          - "401-403"
        service: oauth-backend
        query: "/oauth2/sign_in"
```

On oauth2-proxy, the changed config is:
```ini
http_address = "172.16.0.1:4180"

reverse_proxy = true
real_client_ip_header = "X-Forwarded-For"

redirect_url = "https://oauth.example.com/oauth2-proxy/callback"
```

`oauth.example.com` itself does not have a website to host for this example configuration.

## Checklist:

- [X] My change requires a change to the documentation or CHANGELOG.
- [X] I have updated the documentation/CHANGELOG accordingly.
- [X] I have created a feature (non-master) branch for my PR.


**Edited**: Apparently I included a middleware on services accidentally, this has been corrected. I have also redone the example config to be a bit more readable.