### PR TITLE
Support nonce checks in OIDC Provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@
 
 ## Important Notes
 
+- [#967](https://github.com/oauth2-proxy/oauth2-proxy/pull/967) `--insecure-oidc-skip-nonce` is currently `true` by default in case
+  any existing OIDC Identity Providers don't support it. The default will switch to `false` in a future version.
+
 ## Breaking Changes
 
 ## Changes since v7.1.2
 
+- [#967](https://github.com/oauth2-proxy/oauth2-proxy/pull/967) Set & verify a nonce with OIDC providers (@NickMeves)
 - [#1136](https://github.com/oauth2-proxy/oauth2-proxy/pull/1136) Add clock package for better time mocking in tests (@NickMeves)
 - [#947](https://github.com/oauth2-proxy/oauth2-proxy/pull/947) Multiple provider ingestion and validation in alpha options (first stage: [#926](https://github.com/oauth2-proxy/oauth2-proxy/issues/926)) (@yanasega)
 

--- a/docs/docs/configuration/alpha_config.md
+++ b/docs/docs/configuration/alpha_config.md
@@ -264,6 +264,7 @@ make up the header value
 | `issuerURL` | _string_ | IssuerURL is the OpenID Connect issuer URL<br/>eg: https://accounts.google.com |
 | `insecureAllowUnverifiedEmail` | _bool_ | InsecureAllowUnverifiedEmail prevents failures if an email address in an id_token is not verified<br/>default set to 'false' |
 | `insecureSkipIssuerVerification` | _bool_ | InsecureSkipIssuerVerification skips verification of ID token issuers. When false, ID Token Issuers must match the OIDC discovery URL<br/>default set to 'false' |
+| `insecureSkipNonce` | _bool_ | InsecureSkipNonce skips verifying the ID Token's nonce claim |
 | `skipDiscovery` | _bool_ | SkipDiscovery allows to skip OIDC discovery and use manually supplied Endpoints<br/>default set to 'false' |
 | `jwksURL` | _string_ | JwksURL is the OpenID Connect JWKS URL<br/>eg: https://www.googleapis.com/oauth2/v3/certs |
 | `emailClaim` | _string_ | EmailClaim indicates which claim contains the user email,<br/>default set to 'email' |

--- a/docs/docs/configuration/alpha_config.md
+++ b/docs/docs/configuration/alpha_config.md
@@ -264,7 +264,7 @@ make up the header value
 | `issuerURL` | _string_ | IssuerURL is the OpenID Connect issuer URL<br/>eg: https://accounts.google.com |
 | `insecureAllowUnverifiedEmail` | _bool_ | InsecureAllowUnverifiedEmail prevents failures if an email address in an id_token is not verified<br/>default set to 'false' |
 | `insecureSkipIssuerVerification` | _bool_ | InsecureSkipIssuerVerification skips verification of ID token issuers. When false, ID Token Issuers must match the OIDC discovery URL<br/>default set to 'false' |
-| `insecureSkipNonce` | _bool_ | InsecureSkipNonce skips verifying the ID Token's nonce claim |
+| `insecureSkipNonce` | _bool_ | InsecureSkipNonce skips verifying the ID Token's nonce claim that must match<br/>the random nonce sent in the initial OAuth flow. Otherwise, the nonce is checked<br/>after the initial OAuth redeem & subsequent token refreshes.<br/>default set to 'true'<br/>Warning: In a future release, this will change to 'false' by default for enhanced security. |
 | `skipDiscovery` | _bool_ | SkipDiscovery allows to skip OIDC discovery and use manually supplied Endpoints<br/>default set to 'false' |
 | `jwksURL` | _string_ | JwksURL is the OpenID Connect JWKS URL<br/>eg: https://www.googleapis.com/oauth2/v3/certs |
 | `emailClaim` | _string_ | EmailClaim indicates which claim contains the user email,<br/>default set to 'email' |

--- a/docs/docs/configuration/overview.md
+++ b/docs/docs/configuration/overview.md
@@ -75,6 +75,7 @@ An example [oauth2-proxy.cfg](https://github.com/oauth2-proxy/oauth2-proxy/blob/
 | `--login-url` | string | Authentication endpoint | |
 | `--insecure-oidc-allow-unverified-email` | bool | don't fail if an email address in an id_token is not verified | false |
 | `--insecure-oidc-skip-issuer-verification` | bool | allow the OIDC issuer URL to differ from the expected (currently required for Azure multi-tenant compatibility) | false |
+| `--insecure-oidc-skip-nonce` | bool | skip verifying the OIDC ID Token's nonce claim | true |
 | `--oidc-issuer-url` | string | the OpenID Connect issuer URL, e.g. `"https://accounts.google.com"` | |
 | `--oidc-jwks-url` | string | OIDC JWKS URI for token verification; required if OIDC discovery is disabled | |
 | `--oidc-email-claim` | string | which OIDC claim contains the user's email | `"email"` |

--- a/main_test.go
+++ b/main_test.go
@@ -71,6 +71,7 @@ providers:
     groupsClaim: groups
     emailClaim: email
     userIDClaim: email
+    insecureSkipNonce: true
 `
 
 	const testCoreConfig = `
@@ -138,9 +139,10 @@ redirect_url="http://localhost:4180/oauth2/callback"
 					Tenant: "common",
 				},
 				OIDCConfig: options.OIDCOptions{
-					GroupsClaim: "groups",
-					EmailClaim:  "email",
-					UserIDClaim: "email",
+					GroupsClaim:       "groups",
+					EmailClaim:        "email",
+					UserIDClaim:       "email",
+					InsecureSkipNonce: true,
 				},
 				ApprovalPrompt: "force",
 			},
@@ -228,7 +230,7 @@ redirect_url="http://localhost:4180/oauth2/callback"
 			configContent:      testCoreConfig,
 			alphaConfigContent: testAlphaConfig + ":",
 			expectedOptions:    func() *options.Options { return nil },
-			expectedErr:        errors.New("failed to load alpha options: error unmarshalling config: error converting YAML to JSON: yaml: line 48: did not find expected key"),
+			expectedErr:        errors.New("failed to load alpha options: error unmarshalling config: error converting YAML to JSON: yaml: line 49: did not find expected key"),
 		}),
 		Entry("with alpha configuration and bad core configuration", loadConfigurationTableInput{
 			configContent:      testCoreConfig + "unknown_field=\"something\"",

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -707,7 +707,7 @@ func (p *OAuthProxy) OAuthStart(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	redirectURI := p.getOAuthRedirectURI(req)
-	loginURL := p.provider.GetLoginURL(redirectURI, fmt.Sprintf("%v:%v", csrf.State, redirect), csrf.Nonce)
+	loginURL := p.provider.GetLoginURL(redirectURI, fmt.Sprintf("%v:%v", csrf.HashState(), redirect), csrf.HashNonce())
 
 	err = csrf.SetCookie(rw, req)
 	if err != nil {
@@ -770,10 +770,10 @@ func (p *OAuthProxy) OAuthCallback(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	nonce := state[0]
+	hashedState := state[0]
 	redirect := state[1]
 
-	if !csrf.CheckState(nonce) {
+	if !csrf.CheckState(hashedState) {
 		logger.PrintAuthf(session.Email, req, logger.AuthFailure, "Invalid authentication via OAuth2: CSRF token mismatch, potential attack")
 		p.ErrorPage(rw, req, http.StatusForbidden, "CSRF token mismatch, potential attack", "Login Failed: Unable to find a valid CSRF token. Please try again.")
 		return

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -713,7 +713,7 @@ func (p *OAuthProxy) OAuthStart(rw http.ResponseWriter, req *http.Request) {
 		csrf.HashOIDCNonce(),
 	)
 
-	if err := csrf.SetCookie(rw, req); err != nil {
+	if _, err := csrf.SetCookie(rw, req); err != nil {
 		logger.Errorf("Error setting CSRF cookie: %v", err)
 		p.ErrorPage(rw, req, http.StatusInternalServerError, err.Error())
 		return
@@ -779,7 +779,7 @@ func (p *OAuthProxy) OAuthCallback(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	session.Nonce = csrf.OIDCNonce
+	csrf.SetSessionNonce(session)
 	p.provider.ValidateSession(req.Context(), session)
 
 	if !p.IsValidRedirect(appRedirect) {
@@ -1174,7 +1174,7 @@ func extractAllowedGroups(req *http.Request) map[string]struct{} {
 
 // encodedState builds the OAuth state param out of our nonce and
 // original application redirect
-func encodeState(csrf *cookies.CSRF, redirect string) string {
+func encodeState(csrf cookies.CSRF, redirect string) string {
 	return fmt.Sprintf("%v:%v", csrf.HashOAuthState(), redirect)
 }
 

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -709,7 +709,7 @@ func (p *OAuthProxy) OAuthStart(rw http.ResponseWriter, req *http.Request) {
 	callbackRedirect := p.getOAuthRedirectURI(req)
 	loginURL := p.provider.GetLoginURL(
 		callbackRedirect,
-		encodeState(csrf, appRedirect),
+		encodeState(csrf.HashOAuthState(), appRedirect),
 		csrf.HashOIDCNonce(),
 	)
 
@@ -1174,8 +1174,8 @@ func extractAllowedGroups(req *http.Request) map[string]struct{} {
 
 // encodedState builds the OAuth state param out of our nonce and
 // original application redirect
-func encodeState(csrf cookies.CSRF, redirect string) string {
-	return fmt.Sprintf("%v:%v", csrf.HashOAuthState(), redirect)
+func encodeState(nonce string, redirect string) string {
+	return fmt.Sprintf("%v:%v", nonce, redirect)
 }
 
 // decodeState splits the reflected OAuth state response back into

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -709,7 +709,10 @@ func (patTest *PassAccessTokenTest) getCallbackEndpoint() (httpCode int, cookie 
 
 	req, err := http.NewRequest(
 		http.MethodGet,
-		fmt.Sprintf("/oauth2/callback?code=callback_code&state=%s", encodeState(csrf, "%2F")),
+		fmt.Sprintf(
+			"/oauth2/callback?code=callback_code&state=%s",
+			encodeState(csrf.HashOAuthState(), "%2F"),
+		),
 		strings.NewReader(""),
 	)
 	if err != nil {

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/middleware"
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/sessions"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/cookies"
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/logger"
 	sessionscookie "github.com/oauth2-proxy/oauth2-proxy/v7/pkg/sessions/cookie"
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/upstream"
@@ -698,23 +699,37 @@ func (patTest *PassAccessTokenTest) Close() {
 	patTest.providerServer.Close()
 }
 
-func (patTest *PassAccessTokenTest) getCallbackEndpoint() (httpCode int,
-	cookie string) {
+func (patTest *PassAccessTokenTest) getCallbackEndpoint() (httpCode int, cookie string) {
 	rw := httptest.NewRecorder()
 	req, err := http.NewRequest("GET", "/oauth2/callback?code=callback_code&state=nonce:",
 		strings.NewReader(""))
 	if err != nil {
 		return 0, ""
 	}
-	req.AddCookie(patTest.proxy.MakeCSRFCookie(req, "nonce", time.Hour, time.Now()))
+
+	csrf, err := cookies.NewCSRF(patTest.proxy.CookieOptions)
+	if err != nil {
+		panic(err)
+	}
+	csrf.State = "nonce"
+	val, err := csrf.EncodeCookie()
+	if err != nil {
+		panic(err)
+	}
+	req.AddCookie(&http.Cookie{
+		Name:  csrf.CookieName(),
+		Value: val,
+	})
+
 	patTest.proxy.ServeHTTP(rw, req)
+
 	return rw.Code, rw.Header().Values("Set-Cookie")[1]
 }
 
 // getEndpointWithCookie makes a requests againt the oauthproxy with passed requestPath
 // and cookie and returns body and status code.
 func (patTest *PassAccessTokenTest) getEndpointWithCookie(cookie string, endpoint string) (httpCode int, accessToken string) {
-	cookieName := patTest.opts.Cookie.Name
+	cookieName := patTest.proxy.CookieOptions.Name
 	var value string
 	keyPrefix := cookieName + "="
 
@@ -983,6 +998,9 @@ func NewProcessCookieTest(opts ProcessCookieTestOpts, modifiers ...OptionsModifi
 	}
 	pcTest.proxy.provider.(*TestProvider).SetAllowedGroups(pcTest.opts.Providers[0].AllowedGroups)
 
+	// Now, zero-out proxy.CookieRefresh for the cases that don't involve
+	// access_token validation.
+	pcTest.proxy.CookieOptions.Refresh = time.Duration(0)
 	pcTest.rw = httptest.NewRecorder()
 	pcTest.req, _ = http.NewRequest("GET", "/", strings.NewReader(""))
 	pcTest.validateUser = true
@@ -1104,6 +1122,7 @@ func TestProcessCookieFailIfRefreshSetAndCookieExpired(t *testing.T) {
 	err = pcTest.SaveSession(startSession)
 	assert.NoError(t, err)
 
+	pcTest.proxy.CookieOptions.Refresh = time.Hour
 	session, err := pcTest.LoadCookiedSession()
 	assert.NotEqual(t, nil, err)
 	if session != nil {
@@ -1999,7 +2018,7 @@ func TestClearSplitCookie(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	p := OAuthProxy{sessionStore: store}
+	p := OAuthProxy{CookieOptions: &opts.Cookie, sessionStore: store}
 	var rw = httptest.NewRecorder()
 	req := httptest.NewRequest("get", "/", nil)
 
@@ -2032,7 +2051,7 @@ func TestClearSingleCookie(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	p := OAuthProxy{sessionStore: store}
+	p := OAuthProxy{CookieOptions: &opts.Cookie, sessionStore: store}
 	var rw = httptest.NewRecorder()
 	req := httptest.NewRequest("get", "/", nil)
 

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -717,7 +717,7 @@ func (patTest *PassAccessTokenTest) getCallbackEndpoint() (httpCode int, cookie 
 	if err != nil {
 		panic(err)
 	}
-	csrf.State = state
+	csrf.OAuthState = state
 	val, err := csrf.EncodeCookie()
 	if err != nil {
 		panic(err)

--- a/pkg/apis/options/legacy_options.go
+++ b/pkg/apis/options/legacy_options.go
@@ -48,12 +48,13 @@ func NewLegacyOptions() *LegacyOptions {
 		},
 
 		LegacyProvider: LegacyProvider{
-			ProviderType:    "google",
-			AzureTenant:     "common",
-			ApprovalPrompt:  "force",
-			UserIDClaim:     "email",
-			OIDCEmailClaim:  "email",
-			OIDCGroupsClaim: "groups",
+			ProviderType:          "google",
+			AzureTenant:           "common",
+			ApprovalPrompt:        "force",
+			UserIDClaim:           "email",
+			OIDCEmailClaim:        "email",
+			OIDCGroupsClaim:       "groups",
+			InsecureOIDCSkipNonce: true,
 		},
 
 		Options: *NewOptions(),
@@ -492,6 +493,7 @@ type LegacyProvider struct {
 	OIDCIssuerURL                      string   `flag:"oidc-issuer-url" cfg:"oidc_issuer_url"`
 	InsecureOIDCAllowUnverifiedEmail   bool     `flag:"insecure-oidc-allow-unverified-email" cfg:"insecure_oidc_allow_unverified_email"`
 	InsecureOIDCSkipIssuerVerification bool     `flag:"insecure-oidc-skip-issuer-verification" cfg:"insecure_oidc_skip_issuer_verification"`
+	InsecureOIDCSkipNonce              bool     `flag:"insecure-oidc-skip-nonce" cfg:"insecure_oidc_skip_nonce"`
 	SkipOIDCDiscovery                  bool     `flag:"skip-oidc-discovery" cfg:"skip_oidc_discovery"`
 	OIDCJwksURL                        string   `flag:"oidc-jwks-url" cfg:"oidc_jwks_url"`
 	OIDCEmailClaim                     string   `flag:"oidc-email-claim" cfg:"oidc_email_claim"`
@@ -540,6 +542,7 @@ func legacyProviderFlagSet() *pflag.FlagSet {
 	flagSet.String("oidc-issuer-url", "", "OpenID Connect issuer URL (ie: https://accounts.google.com)")
 	flagSet.Bool("insecure-oidc-allow-unverified-email", false, "Don't fail if an email address in an id_token is not verified")
 	flagSet.Bool("insecure-oidc-skip-issuer-verification", false, "Do not verify if issuer matches OIDC discovery URL")
+	flagSet.Bool("insecure-oidc-skip-nonce", true, "skip verifying the OIDC ID Token's nonce claim")
 	flagSet.Bool("skip-oidc-discovery", false, "Skip OIDC discovery and use manually supplied Endpoints")
 	flagSet.String("oidc-jwks-url", "", "OpenID Connect JWKS URL (ie: https://www.googleapis.com/oauth2/v3/certs)")
 	flagSet.String("oidc-groups-claim", providers.OIDCGroupsClaim, "which OIDC claim contains the user groups")
@@ -630,6 +633,7 @@ func (l *LegacyProvider) convert() (Providers, error) {
 		IssuerURL:                      l.OIDCIssuerURL,
 		InsecureAllowUnverifiedEmail:   l.InsecureOIDCAllowUnverifiedEmail,
 		InsecureSkipIssuerVerification: l.InsecureOIDCSkipIssuerVerification,
+		InsecureSkipNonce:              l.InsecureOIDCSkipNonce,
 		SkipDiscovery:                  l.SkipOIDCDiscovery,
 		JwksURL:                        l.OIDCJwksURL,
 		UserIDClaim:                    l.UserIDClaim,

--- a/pkg/apis/options/legacy_options_test.go
+++ b/pkg/apis/options/legacy_options_test.go
@@ -113,6 +113,7 @@ var _ = Describe("Legacy Options", func() {
 
 			opts.Providers[0].ClientID = "oauth-proxy"
 			opts.Providers[0].ID = "google=oauth-proxy"
+			opts.Providers[0].OIDCConfig.InsecureSkipNonce = true
 
 			converted, err := legacyOpts.ToOptions()
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/apis/options/load_test.go
+++ b/pkg/apis/options/load_test.go
@@ -36,12 +36,13 @@ var _ = Describe("Load", func() {
 		},
 
 		LegacyProvider: LegacyProvider{
-			ProviderType:    "google",
-			AzureTenant:     "common",
-			ApprovalPrompt:  "force",
-			UserIDClaim:     "email",
-			OIDCEmailClaim:  "email",
-			OIDCGroupsClaim: "groups",
+			ProviderType:          "google",
+			AzureTenant:           "common",
+			ApprovalPrompt:        "force",
+			UserIDClaim:           "email",
+			OIDCEmailClaim:        "email",
+			OIDCGroupsClaim:       "groups",
+			InsecureOIDCSkipNonce: true,
 		},
 
 		Options: Options{

--- a/pkg/apis/options/providers.go
+++ b/pkg/apis/options/providers.go
@@ -132,6 +132,8 @@ type OIDCOptions struct {
 	// InsecureSkipIssuerVerification skips verification of ID token issuers. When false, ID Token Issuers must match the OIDC discovery URL
 	// default set to 'false'
 	InsecureSkipIssuerVerification bool `json:"insecureSkipIssuerVerification,omitempty"`
+	// InsecureSkipNonce skips verifying the ID Token's nonce claim
+	InsecureSkipNonce bool `json:"insecureSkipNonce,omitempty"`
 	// SkipDiscovery allows to skip OIDC discovery and use manually supplied Endpoints
 	// default set to 'false'
 	SkipDiscovery bool `json:"skipDiscovery,omitempty"`
@@ -169,6 +171,7 @@ func providerDefaults() Providers {
 			},
 			OIDCConfig: OIDCOptions{
 				InsecureAllowUnverifiedEmail: false,
+				InsecureSkipNonce:            true,
 				SkipDiscovery:                false,
 				UserIDClaim:                  providers.OIDCEmailClaim, // Deprecated: Use OIDCEmailClaim
 				EmailClaim:                   providers.OIDCEmailClaim,

--- a/pkg/apis/options/providers.go
+++ b/pkg/apis/options/providers.go
@@ -132,7 +132,11 @@ type OIDCOptions struct {
 	// InsecureSkipIssuerVerification skips verification of ID token issuers. When false, ID Token Issuers must match the OIDC discovery URL
 	// default set to 'false'
 	InsecureSkipIssuerVerification bool `json:"insecureSkipIssuerVerification,omitempty"`
-	// InsecureSkipNonce skips verifying the ID Token's nonce claim
+	// InsecureSkipNonce skips verifying the ID Token's nonce claim that must match
+	// the random nonce sent in the initial OAuth flow. Otherwise, the nonce is checked
+	// after the initial OAuth redeem & subsequent token refreshes.
+	// default set to 'true'
+	// Warning: In a future release, this will change to 'false' by default for enhanced security.
 	InsecureSkipNonce bool `json:"insecureSkipNonce,omitempty"`
 	// SkipDiscovery allows to skip OIDC discovery and use manually supplied Endpoints
 	// default set to 'false'

--- a/pkg/apis/sessions/session_state.go
+++ b/pkg/apis/sessions/session_state.go
@@ -24,6 +24,8 @@ type SessionState struct {
 	IDToken      string `msgpack:"it,omitempty"`
 	RefreshToken string `msgpack:"rt,omitempty"`
 
+	Nonce string `msgpack:"n,omitempty"`
+
 	Email             string   `msgpack:"e,omitempty"`
 	User              string   `msgpack:"u,omitempty"`
 	Groups            []string `msgpack:"g,omitempty"`

--- a/pkg/apis/sessions/session_state.go
+++ b/pkg/apis/sessions/session_state.go
@@ -24,7 +24,7 @@ type SessionState struct {
 	IDToken      string `msgpack:"it,omitempty"`
 	RefreshToken string `msgpack:"rt,omitempty"`
 
-	Nonce string `msgpack:"n,omitempty"`
+	Nonce []byte `msgpack:"n,omitempty"`
 
 	Email             string   `msgpack:"e,omitempty"`
 	User              string   `msgpack:"u,omitempty"`
@@ -100,6 +100,11 @@ func (s *SessionState) GetClaim(claim string) []string {
 	default:
 		return []string{}
 	}
+}
+
+// CheckNonce compares the Nonce against a potential hash of it
+func (s *SessionState) CheckNonce(hashed string) bool {
+	return encryption.CheckNonce(s.Nonce, hashed)
 }
 
 // EncodeSessionState returns an encrypted, lz4 compressed, MessagePack encoded session

--- a/pkg/apis/sessions/session_state_test.go
+++ b/pkg/apis/sessions/session_state_test.go
@@ -153,6 +153,7 @@ func TestEncodeAndDecodeSessionState(t *testing.T) {
 			CreatedAt:         &created,
 			ExpiresOn:         &expires,
 			RefreshToken:      "RefreshToken.12349871293847fdsaihf9238h4f91h8fr.1349f831y98fd7",
+			Nonce:             "abcdef1234567890abcdef1234567890",
 		},
 		"No ExpiresOn": {
 			Email:             "username@example.com",
@@ -162,6 +163,7 @@ func TestEncodeAndDecodeSessionState(t *testing.T) {
 			IDToken:           "IDToken.12349871293847fdsaihf9238h4f91h8fr.1349f831y98fd7",
 			CreatedAt:         &created,
 			RefreshToken:      "RefreshToken.12349871293847fdsaihf9238h4f91h8fr.1349f831y98fd7",
+			Nonce:             "abcdef1234567890abcdef1234567890",
 		},
 		"No PreferredUsername": {
 			Email:        "username@example.com",
@@ -171,6 +173,7 @@ func TestEncodeAndDecodeSessionState(t *testing.T) {
 			CreatedAt:    &created,
 			ExpiresOn:    &expires,
 			RefreshToken: "RefreshToken.12349871293847fdsaihf9238h4f91h8fr.1349f831y98fd7",
+			Nonce:        "abcdef1234567890abcdef1234567890",
 		},
 		"Minimal session": {
 			User:         "username",
@@ -194,6 +197,7 @@ func TestEncodeAndDecodeSessionState(t *testing.T) {
 			CreatedAt:         &created,
 			ExpiresOn:         &expires,
 			RefreshToken:      "RefreshToken.12349871293847fdsaihf9238h4f91h8fr.1349f831y98fd7",
+			Nonce:             "abcdef1234567890abcdef1234567890",
 			Groups:            []string{"group-a", "group-b"},
 		},
 	}

--- a/pkg/apis/sessions/session_state_test.go
+++ b/pkg/apis/sessions/session_state_test.go
@@ -153,7 +153,7 @@ func TestEncodeAndDecodeSessionState(t *testing.T) {
 			CreatedAt:         &created,
 			ExpiresOn:         &expires,
 			RefreshToken:      "RefreshToken.12349871293847fdsaihf9238h4f91h8fr.1349f831y98fd7",
-			Nonce:             "abcdef1234567890abcdef1234567890",
+			Nonce:             []byte("abcdef1234567890abcdef1234567890"),
 		},
 		"No ExpiresOn": {
 			Email:             "username@example.com",
@@ -163,7 +163,7 @@ func TestEncodeAndDecodeSessionState(t *testing.T) {
 			IDToken:           "IDToken.12349871293847fdsaihf9238h4f91h8fr.1349f831y98fd7",
 			CreatedAt:         &created,
 			RefreshToken:      "RefreshToken.12349871293847fdsaihf9238h4f91h8fr.1349f831y98fd7",
-			Nonce:             "abcdef1234567890abcdef1234567890",
+			Nonce:             []byte("abcdef1234567890abcdef1234567890"),
 		},
 		"No PreferredUsername": {
 			Email:        "username@example.com",
@@ -173,7 +173,7 @@ func TestEncodeAndDecodeSessionState(t *testing.T) {
 			CreatedAt:    &created,
 			ExpiresOn:    &expires,
 			RefreshToken: "RefreshToken.12349871293847fdsaihf9238h4f91h8fr.1349f831y98fd7",
-			Nonce:        "abcdef1234567890abcdef1234567890",
+			Nonce:        []byte("abcdef1234567890abcdef1234567890"),
 		},
 		"Minimal session": {
 			User:         "username",
@@ -197,7 +197,7 @@ func TestEncodeAndDecodeSessionState(t *testing.T) {
 			CreatedAt:         &created,
 			ExpiresOn:         &expires,
 			RefreshToken:      "RefreshToken.12349871293847fdsaihf9238h4f91h8fr.1349f831y98fd7",
-			Nonce:             "abcdef1234567890abcdef1234567890",
+			Nonce:             []byte("abcdef1234567890abcdef1234567890"),
 			Groups:            []string{"group-a", "group-b"},
 		},
 	}

--- a/pkg/cookies/cookies.go
+++ b/pkg/cookies/cookies.go
@@ -36,7 +36,7 @@ func MakeCookieFromOptions(req *http.Request, name string, value string, opts *o
 		SameSite: ParseSameSite(opts.SameSite),
 	}
 
-	WarnInvalidDomain(c, req)
+	warnInvalidDomain(c, req)
 
 	return c
 }
@@ -69,9 +69,9 @@ func ParseSameSite(v string) http.SameSite {
 	}
 }
 
-// WarnInvalidDomain logs a warning if the request host and cookie domain are
+// warnInvalidDomain logs a warning if the request host and cookie domain are
 // mismatched.
-func WarnInvalidDomain(c *http.Cookie, req *http.Request) {
+func warnInvalidDomain(c *http.Cookie, req *http.Request) {
 	if c.Domain == "" {
 		return
 	}

--- a/pkg/cookies/cookies.go
+++ b/pkg/cookies/cookies.go
@@ -12,46 +12,33 @@ import (
 	requestutil "github.com/oauth2-proxy/oauth2-proxy/v7/pkg/requests/util"
 )
 
-// MakeCookie constructs a cookie from the given parameters,
-// discovering the domain from the request if not specified.
-func MakeCookie(req *http.Request, name string, value string, path string, domain string, httpOnly bool, secure bool, expiration time.Duration, now time.Time, sameSite http.SameSite) *http.Cookie {
-	if domain != "" {
-		host := requestutil.GetRequestHost(req)
-		if h, _, err := net.SplitHostPort(host); err == nil {
-			host = h
-		}
-		if !strings.HasSuffix(host, domain) {
-			logger.Errorf("Warning: request host is %q but using configured cookie domain of %q", host, domain)
-		}
-	}
-
-	return &http.Cookie{
-		Name:     name,
-		Value:    value,
-		Path:     path,
-		Domain:   domain,
-		HttpOnly: httpOnly,
-		Secure:   secure,
-		Expires:  now.Add(expiration),
-		SameSite: sameSite,
-	}
-}
-
 // MakeCookieFromOptions constructs a cookie based on the given *options.CookieOptions,
 // value and creation time
-func MakeCookieFromOptions(req *http.Request, name string, value string, cookieOpts *options.Cookie, expiration time.Duration, now time.Time) *http.Cookie {
-	domain := GetCookieDomain(req, cookieOpts.Domains)
-
-	if domain != "" {
-		return MakeCookie(req, name, value, cookieOpts.Path, domain, cookieOpts.HTTPOnly, cookieOpts.Secure, expiration, now, ParseSameSite(cookieOpts.SameSite))
-	}
+func MakeCookieFromOptions(req *http.Request, name string, value string, opts *options.Cookie, expiration time.Duration, now time.Time) *http.Cookie {
+	domain := GetCookieDomain(req, opts.Domains)
 	// If nothing matches, create the cookie with the shortest domain
-	defaultDomain := ""
-	if len(cookieOpts.Domains) > 0 {
-		logger.Errorf("Warning: request host %q did not match any of the specific cookie domains of %q", requestutil.GetRequestHost(req), strings.Join(cookieOpts.Domains, ","))
-		defaultDomain = cookieOpts.Domains[len(cookieOpts.Domains)-1]
+	if domain == "" && len(opts.Domains) > 0 {
+		logger.Errorf("Warning: request host %q did not match any of the specific cookie domains of %q",
+			requestutil.GetRequestHost(req),
+			strings.Join(opts.Domains, ","),
+		)
+		domain = opts.Domains[len(opts.Domains)-1]
 	}
-	return MakeCookie(req, name, value, cookieOpts.Path, defaultDomain, cookieOpts.HTTPOnly, cookieOpts.Secure, expiration, now, ParseSameSite(cookieOpts.SameSite))
+
+	c := &http.Cookie{
+		Name:     name,
+		Value:    value,
+		Path:     opts.Path,
+		Domain:   domain,
+		Expires:  now.Add(expiration),
+		HttpOnly: opts.HTTPOnly,
+		Secure:   opts.Secure,
+		SameSite: ParseSameSite(opts.SameSite),
+	}
+
+	WarnInvalidDomain(c, req)
+
+	return c
 }
 
 // GetCookieDomain returns the correct cookie domain given a list of domains
@@ -79,5 +66,21 @@ func ParseSameSite(v string) http.SameSite {
 		return 0
 	default:
 		panic(fmt.Sprintf("Invalid value for SameSite: %s", v))
+	}
+}
+
+// WarnInvalidDomain logs a warning if the request host and cookie domain are
+// mismatched.
+func WarnInvalidDomain(c *http.Cookie, req *http.Request) {
+	if c.Domain == "" {
+		return
+	}
+
+	host := requestutil.GetRequestHost(req)
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	if !strings.HasSuffix(host, c.Domain) {
+		logger.Errorf("Warning: request host is %q but using configured cookie domain of %q", host, c.Domain)
 	}
 }

--- a/pkg/cookies/cookies_suite_test.go
+++ b/pkg/cookies/cookies_suite_test.go
@@ -1,0 +1,35 @@
+package cookies
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/logger"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	csrfState = "1234asdf1234asdf1234asdf"
+	csrfNonce = "0987lkjh0987lkjh0987lkjh"
+
+	cookieName   = "cookie_test_12345"
+	cookieSecret = "3q48hmFH30FJ2HfJF0239UFJCVcl3kj3"
+	cookieDomain = "o2p.cookies.test"
+	cookiePath   = "/cookie-tests"
+
+	nowEpoch = 1609366421
+)
+
+func TestProviderSuite(t *testing.T) {
+	logger.SetOutput(GinkgoWriter)
+
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Cookies")
+}
+
+func testCookieExpires(exp time.Time) string {
+	var buf [len(http.TimeFormat)]byte
+	return string(exp.UTC().AppendFormat(buf[:0], http.TimeFormat))
+}

--- a/pkg/cookies/cookies_test.go
+++ b/pkg/cookies/cookies_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
+	middlewareapi "github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/middleware"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -29,6 +30,9 @@ var _ = Describe("Cookie Tests", func() {
 
 				if in.xForwardedHost != "" {
 					req.Header.Add("X-Forwarded-Host", in.xForwardedHost)
+					req = middlewareapi.AddRequestScope(req, &middlewareapi.RequestScope{
+						ReverseProxy: true,
+					})
 				}
 
 				Expect(GetCookieDomain(req, in.cookieDomains)).To(Equal(in.expectedOutput))

--- a/pkg/cookies/cookies_test.go
+++ b/pkg/cookies/cookies_test.go
@@ -1,0 +1,75 @@
+package cookies
+
+import (
+	"fmt"
+	"net/http"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Cookie Tests", func() {
+	Context("GetCookieDomain", func() {
+		type getCookieDomainTableInput struct {
+			host           string
+			xForwardedHost string
+			cookieDomains  []string
+			expectedOutput string
+		}
+
+		DescribeTable("should return expected results",
+			func(in getCookieDomainTableInput) {
+				req, err := http.NewRequest(
+					http.MethodGet,
+					fmt.Sprintf("https://%s/%s", in.host, cookiePath),
+					nil,
+				)
+				Expect(err).ToNot(HaveOccurred())
+
+				if in.xForwardedHost != "" {
+					req.Header.Add("X-Forwarded-Host", in.xForwardedHost)
+				}
+
+				Expect(GetCookieDomain(req, in.cookieDomains)).To(Equal(in.expectedOutput))
+			},
+			Entry("a single exact match for the Host header", getCookieDomainTableInput{
+				host:           "www.cookies.test",
+				cookieDomains:  []string{"www.cookies.test"},
+				expectedOutput: "www.cookies.test",
+			}),
+			Entry("a single exact match for the X-Forwarded-Host header", getCookieDomainTableInput{
+				host:           "backend.cookies.internal",
+				xForwardedHost: "www.cookies.test",
+				cookieDomains:  []string{"www.cookies.test"},
+				expectedOutput: "www.cookies.test",
+			}),
+			Entry("a single suffix match for the Host header", getCookieDomainTableInput{
+				host:           "www.cookies.test",
+				cookieDomains:  []string{".cookies.test"},
+				expectedOutput: ".cookies.test",
+			}),
+			Entry("a single suffix match for the X-Forwarded-Host header", getCookieDomainTableInput{
+				host:           "backend.cookies.internal",
+				xForwardedHost: "www.cookies.test",
+				cookieDomains:  []string{".cookies.test"},
+				expectedOutput: ".cookies.test",
+			}),
+			Entry("the first match is used", getCookieDomainTableInput{
+				host:           "www.cookies.test",
+				cookieDomains:  []string{"www.cookies.test", ".cookies.test"},
+				expectedOutput: "www.cookies.test",
+			}),
+			Entry("the only match is used", getCookieDomainTableInput{
+				host:           "www.cookies.test",
+				cookieDomains:  []string{".cookies.wrong", ".cookies.test"},
+				expectedOutput: ".cookies.test",
+			}),
+			Entry("blank is returned for no matches", getCookieDomainTableInput{
+				host:           "www.cookies.test",
+				cookieDomains:  []string{".cookies.wrong", ".cookies.false"},
+				expectedOutput: "",
+			}),
+		)
+	})
+})

--- a/pkg/cookies/csrf.go
+++ b/pkg/cookies/csrf.go
@@ -1,0 +1,142 @@
+package cookies
+
+import (
+	"crypto/hmac"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/encryption"
+	"github.com/vmihailenco/msgpack/v4"
+)
+
+var now = time.Now
+
+// CSRF manages various nonces stored in the CSRF cookie during the initial
+// authentication flows.
+type CSRF struct {
+	// State holds the OAuth2 csrfState parameter's csrfNonce component set in the
+	// initial authentication request and mirrored back in the callback
+	// redirect from the IdP for CSRF protection.
+	State string `msgpack:"s,omitempty"`
+
+	// Nonce holds the OIDC csrfNonce parameter used in the initial authentication
+	// and then set in all subsequent OIDC ID Tokens as the csrfNonce claim. This is
+	// used to mitigate reply attacks.
+	Nonce string `msgpack:"n,omitempty"`
+
+	cookieOpts *options.Cookie
+}
+
+// NewCSRF creates a CSRF with random nonces
+func NewCSRF(opts *options.Cookie) (*CSRF, error) {
+	state, err := encryption.Nonce()
+	if err != nil {
+		return nil, err
+	}
+	nonce, err := encryption.Nonce()
+	if err != nil {
+		return nil, err
+	}
+
+	return &CSRF{
+		State:      state,
+		Nonce:      nonce,
+		cookieOpts: opts,
+	}, nil
+}
+
+// CheckState compares OAuth2 csrfState nonces in a constant time manner to protect
+// against timing attacks
+func (c CSRF) CheckState(other string) bool {
+	return hmac.Equal([]byte(c.State), []byte(other))
+}
+
+// CheckNonce compares OIDC nonces in a constant time manner to protect
+// against timing attacks
+func (c CSRF) CheckNonce(other string) bool {
+	return hmac.Equal([]byte(c.Nonce), []byte(other))
+}
+
+// SetCookie encodes the CSRF to a signed cookie and sets it on the ResponseWriter
+func (c CSRF) SetCookie(rw http.ResponseWriter, req *http.Request) error {
+	encoded, err := c.EncodeCookie()
+	if err != nil {
+		return err
+	}
+
+	http.SetCookie(rw, MakeCookieFromOptions(
+		req,
+		c.CookieName(),
+		encoded,
+		c.cookieOpts,
+		c.cookieOpts.Expire,
+		now(),
+	))
+
+	return nil
+}
+
+// LoadCSRFCookie loads a CSRF object from a request's CSRF cookie
+func LoadCSRFCookie(req *http.Request, opts *options.Cookie) (*CSRF, error) {
+	cookie, err := req.Cookie(csrfCookieName(opts))
+	if err != nil {
+		// Don't wrap this error to allow `err == http.ErrNoCookie` checks
+		return nil, err
+	}
+
+	return DecodeCSRFCookie(cookie, opts)
+}
+
+// ClearCookie removes the CSRF cookie
+func (c CSRF) ClearCookie(rw http.ResponseWriter, req *http.Request) {
+	http.SetCookie(rw, MakeCookieFromOptions(
+		req,
+		c.CookieName(),
+		"",
+		c.cookieOpts,
+		time.Hour*-1,
+		now(),
+	))
+}
+
+// EncodeCookie MessagePack encodes the CSRF and then creates a signed
+// cookie value
+func (c CSRF) EncodeCookie() (string, error) {
+	packed, err := msgpack.Marshal(c)
+	if err != nil {
+		return "", fmt.Errorf("error marshalling CSRF to msgpack: %v", err)
+	}
+
+	return encryption.SignedValue(c.cookieOpts.Secret, c.CookieName(), packed, now())
+}
+
+// DecodeCSRFCookie validates the signature and decodes a CSRF cookie into
+// a CSRF struct
+func DecodeCSRFCookie(cookie *http.Cookie, opts *options.Cookie) (*CSRF, error) {
+	val, _, ok := encryption.Validate(cookie, opts.Secret, opts.Expire)
+	if !ok {
+		return nil, errors.New("CSRF cookie failed validation")
+	}
+
+	// Valid cookie, Unmarshal the CSRF
+	csrf := &CSRF{cookieOpts: opts}
+	err := msgpack.Unmarshal(val, csrf)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshalling data to CSRF: %v", err)
+	}
+
+	return csrf, nil
+}
+
+// CookieName returns the CSRF cookie's name derived from the base
+// session cookie name
+func (c CSRF) CookieName() string {
+	return csrfCookieName(c.cookieOpts)
+}
+
+func csrfCookieName(opts *options.Cookie) string {
+	return fmt.Sprintf("%v_csrf", opts.Name)
+}

--- a/pkg/cookies/csrf.go
+++ b/pkg/cookies/csrf.go
@@ -16,15 +16,15 @@ var now = time.Now
 // CSRF manages various nonces stored in the CSRF cookie during the initial
 // authentication flows.
 type CSRF struct {
-	// State holds the OAuth2 state parameter's nonce component set in the
+	// OAuthState holds the OAuth2 state parameter's nonce component set in the
 	// initial authentication request and mirrored back in the callback
 	// redirect from the IdP for CSRF protection.
-	State []byte `msgpack:"s,omitempty"`
+	OAuthState []byte `msgpack:"s,omitempty"`
 
-	// Nonce holds the OIDC nonce parameter used in the initial authentication
+	// OIDCNonce holds the OIDC nonce parameter used in the initial authentication
 	// and then set in all subsequent OIDC ID Tokens as the nonce claim. This
-	// is used to mitigate reply attacks.
-	Nonce []byte `msgpack:"n,omitempty"`
+	// is used to mitigate replay attacks.
+	OIDCNonce []byte `msgpack:"n,omitempty"`
 
 	cookieOpts *options.Cookie
 }
@@ -41,31 +41,32 @@ func NewCSRF(opts *options.Cookie) (*CSRF, error) {
 	}
 
 	return &CSRF{
-		State: state,
-		Nonce: nonce,
+		OAuthState: state,
+		OIDCNonce:  nonce,
 
 		cookieOpts: opts,
 	}, nil
 }
 
-// HashState returns the hash of the OAuth state nonce
-func (c CSRF) HashState() string {
-	return encryption.HashNonce(c.State)
+// HashOAuthState returns the hash of the OAuth state nonce
+func (c CSRF) HashOAuthState() string {
+	return encryption.HashNonce(c.OAuthState)
 }
 
-// HashNonce returns the hash of the OIDC nonce
-func (c CSRF) HashNonce() string {
-	return encryption.HashNonce(c.Nonce)
+// HashOIDCNonce returns the hash of the OIDC nonce
+func (c CSRF) HashOIDCNonce() string {
+	return encryption.HashNonce(c.OIDCNonce)
 }
 
-// CheckNonce compares the OAuth state nonce against a potential hash of it
-func (c CSRF) CheckState(hashed string) bool {
-	return encryption.CheckNonce(c.State, hashed)
+// CheckOAuthState compares the OAuth state nonce against a potential
+// hash of it
+func (c CSRF) CheckOAuthState(hashed string) bool {
+	return encryption.CheckNonce(c.OAuthState, hashed)
 }
 
-// CheckNonce compares the OIDC nonce against a potential hash of it
-func (c CSRF) CheckNonce(hashed string) bool {
-	return encryption.CheckNonce(c.Nonce, hashed)
+// CheckOIDCNonce compares the OIDC nonce against a potential hash of it
+func (c CSRF) CheckOIDCNonce(hashed string) bool {
+	return encryption.CheckNonce(c.OIDCNonce, hashed)
 }
 
 // SetCookie encodes the CSRF to a signed cookie and sets it on the ResponseWriter

--- a/pkg/cookies/csrf.go
+++ b/pkg/cookies/csrf.go
@@ -195,5 +195,5 @@ func decrypt(data []byte, opts *options.Cookie) ([]byte, error) {
 }
 
 func makeCipher(opts *options.Cookie) (encryption.Cipher, error) {
-	return encryption.NewCFBCipher([]byte(opts.Secret))
+	return encryption.NewCFBCipher(encryption.SecretBytes(opts.Secret))
 }

--- a/pkg/cookies/csrf.go
+++ b/pkg/cookies/csrf.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/sessions"
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/encryption"
 	"github.com/vmihailenco/msgpack/v4"
 )
@@ -15,7 +16,19 @@ var now = time.Now
 
 // CSRF manages various nonces stored in the CSRF cookie during the initial
 // authentication flows.
-type CSRF struct {
+type CSRF interface {
+	HashOAuthState() string
+	HashOIDCNonce() string
+	CheckOAuthState(string) bool
+	CheckOIDCNonce(string) bool
+
+	SetSessionNonce(s *sessions.SessionState)
+
+	SetCookie(http.ResponseWriter, *http.Request) (*http.Cookie, error)
+	ClearCookie(http.ResponseWriter, *http.Request)
+}
+
+type csrf struct {
 	// OAuthState holds the OAuth2 state parameter's nonce component set in the
 	// initial authentication request and mirrored back in the callback
 	// redirect from the IdP for CSRF protection.
@@ -30,7 +43,7 @@ type CSRF struct {
 }
 
 // NewCSRF creates a CSRF with random nonces
-func NewCSRF(opts *options.Cookie) (*CSRF, error) {
+func NewCSRF(opts *options.Cookie) (CSRF, error) {
 	state, err := encryption.Nonce()
 	if err != nil {
 		return nil, err
@@ -40,7 +53,7 @@ func NewCSRF(opts *options.Cookie) (*CSRF, error) {
 		return nil, err
 	}
 
-	return &CSRF{
+	return &csrf{
 		OAuthState: state,
 		OIDCNonce:  nonce,
 
@@ -48,62 +61,67 @@ func NewCSRF(opts *options.Cookie) (*CSRF, error) {
 	}, nil
 }
 
+// LoadCSRFCookie loads a CSRF object from a request's CSRF cookie
+func LoadCSRFCookie(req *http.Request, opts *options.Cookie) (CSRF, error) {
+	cookie, err := req.Cookie(csrfCookieName(opts))
+	if err != nil {
+		return nil, err
+	}
+
+	return decodeCSRFCookie(cookie, opts)
+}
+
 // HashOAuthState returns the hash of the OAuth state nonce
-func (c CSRF) HashOAuthState() string {
+func (c csrf) HashOAuthState() string {
 	return encryption.HashNonce(c.OAuthState)
 }
 
 // HashOIDCNonce returns the hash of the OIDC nonce
-func (c CSRF) HashOIDCNonce() string {
+func (c csrf) HashOIDCNonce() string {
 	return encryption.HashNonce(c.OIDCNonce)
 }
 
 // CheckOAuthState compares the OAuth state nonce against a potential
 // hash of it
-func (c CSRF) CheckOAuthState(hashed string) bool {
+func (c csrf) CheckOAuthState(hashed string) bool {
 	return encryption.CheckNonce(c.OAuthState, hashed)
 }
 
 // CheckOIDCNonce compares the OIDC nonce against a potential hash of it
-func (c CSRF) CheckOIDCNonce(hashed string) bool {
+func (c csrf) CheckOIDCNonce(hashed string) bool {
 	return encryption.CheckNonce(c.OIDCNonce, hashed)
 }
 
+// SetSessionNonce sets the OIDCNonce on a SessionState
+func (c csrf) SetSessionNonce(s *sessions.SessionState) {
+	s.Nonce = c.OIDCNonce
+}
+
 // SetCookie encodes the CSRF to a signed cookie and sets it on the ResponseWriter
-func (c CSRF) SetCookie(rw http.ResponseWriter, req *http.Request) error {
-	encoded, err := c.EncodeCookie()
+func (c csrf) SetCookie(rw http.ResponseWriter, req *http.Request) (*http.Cookie, error) {
+	encoded, err := c.encodeCookie()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	http.SetCookie(rw, MakeCookieFromOptions(
+	cookie := MakeCookieFromOptions(
 		req,
-		c.CookieName(),
+		c.cookieName(),
 		encoded,
 		c.cookieOpts,
 		c.cookieOpts.Expire,
 		now(),
-	))
+	)
+	http.SetCookie(rw, cookie)
 
-	return nil
-}
-
-// LoadCSRFCookie loads a CSRF object from a request's CSRF cookie
-func LoadCSRFCookie(req *http.Request, opts *options.Cookie) (*CSRF, error) {
-	cookie, err := req.Cookie(csrfCookieName(opts))
-	if err != nil {
-		// Don't wrap this error to allow `err == http.ErrNoCookie` checks
-		return nil, err
-	}
-
-	return DecodeCSRFCookie(cookie, opts)
+	return cookie, nil
 }
 
 // ClearCookie removes the CSRF cookie
-func (c CSRF) ClearCookie(rw http.ResponseWriter, req *http.Request) {
+func (c csrf) ClearCookie(rw http.ResponseWriter, req *http.Request) {
 	http.SetCookie(rw, MakeCookieFromOptions(
 		req,
-		c.CookieName(),
+		c.cookieName(),
 		"",
 		c.cookieOpts,
 		time.Hour*-1,
@@ -111,9 +129,9 @@ func (c CSRF) ClearCookie(rw http.ResponseWriter, req *http.Request) {
 	))
 }
 
-// EncodeCookie MessagePack encodes and encrypts the CSRF and then creates a
+// encodeCookie MessagePack encodes and encrypts the CSRF and then creates a
 // signed cookie value
-func (c CSRF) EncodeCookie() (string, error) {
+func (c csrf) encodeCookie() (string, error) {
 	packed, err := msgpack.Marshal(c)
 	if err != nil {
 		return "", fmt.Errorf("error marshalling CSRF to msgpack: %v", err)
@@ -124,12 +142,12 @@ func (c CSRF) EncodeCookie() (string, error) {
 		return "", err
 	}
 
-	return encryption.SignedValue(c.cookieOpts.Secret, c.CookieName(), encrypted, now())
+	return encryption.SignedValue(c.cookieOpts.Secret, c.cookieName(), encrypted, now())
 }
 
-// DecodeCSRFCookie validates the signature then decrypts and decodes a CSRF
+// decodeCSRFCookie validates the signature then decrypts and decodes a CSRF
 // cookie into a CSRF struct
-func DecodeCSRFCookie(cookie *http.Cookie, opts *options.Cookie) (*CSRF, error) {
+func decodeCSRFCookie(cookie *http.Cookie, opts *options.Cookie) (*csrf, error) {
 	val, _, ok := encryption.Validate(cookie, opts.Secret, opts.Expire)
 	if !ok {
 		return nil, errors.New("CSRF cookie failed validation")
@@ -141,7 +159,7 @@ func DecodeCSRFCookie(cookie *http.Cookie, opts *options.Cookie) (*CSRF, error) 
 	}
 
 	// Valid cookie, Unmarshal the CSRF
-	csrf := &CSRF{cookieOpts: opts}
+	csrf := &csrf{cookieOpts: opts}
 	err = msgpack.Unmarshal(decrypted, csrf)
 	if err != nil {
 		return nil, fmt.Errorf("error unmarshalling data to CSRF: %v", err)
@@ -150,9 +168,9 @@ func DecodeCSRFCookie(cookie *http.Cookie, opts *options.Cookie) (*CSRF, error) 
 	return csrf, nil
 }
 
-// CookieName returns the CSRF cookie's name derived from the base
+// cookieName returns the CSRF cookie's name derived from the base
 // session cookie name
-func (c CSRF) CookieName() string {
+func (c csrf) cookieName() string {
 	return csrfCookieName(c.cookieOpts)
 }
 

--- a/pkg/cookies/csrf.go
+++ b/pkg/cookies/csrf.go
@@ -8,11 +8,10 @@ import (
 
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/sessions"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/clock"
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/encryption"
 	"github.com/vmihailenco/msgpack/v4"
 )
-
-var now = time.Now
 
 // CSRF manages various nonces stored in the CSRF cookie during the initial
 // authentication flows.
@@ -40,6 +39,7 @@ type csrf struct {
 	OIDCNonce []byte `msgpack:"n,omitempty"`
 
 	cookieOpts *options.Cookie
+	time       clock.Clock
 }
 
 // NewCSRF creates a CSRF with random nonces
@@ -72,33 +72,33 @@ func LoadCSRFCookie(req *http.Request, opts *options.Cookie) (CSRF, error) {
 }
 
 // HashOAuthState returns the hash of the OAuth state nonce
-func (c csrf) HashOAuthState() string {
+func (c *csrf) HashOAuthState() string {
 	return encryption.HashNonce(c.OAuthState)
 }
 
 // HashOIDCNonce returns the hash of the OIDC nonce
-func (c csrf) HashOIDCNonce() string {
+func (c *csrf) HashOIDCNonce() string {
 	return encryption.HashNonce(c.OIDCNonce)
 }
 
 // CheckOAuthState compares the OAuth state nonce against a potential
 // hash of it
-func (c csrf) CheckOAuthState(hashed string) bool {
+func (c *csrf) CheckOAuthState(hashed string) bool {
 	return encryption.CheckNonce(c.OAuthState, hashed)
 }
 
 // CheckOIDCNonce compares the OIDC nonce against a potential hash of it
-func (c csrf) CheckOIDCNonce(hashed string) bool {
+func (c *csrf) CheckOIDCNonce(hashed string) bool {
 	return encryption.CheckNonce(c.OIDCNonce, hashed)
 }
 
 // SetSessionNonce sets the OIDCNonce on a SessionState
-func (c csrf) SetSessionNonce(s *sessions.SessionState) {
+func (c *csrf) SetSessionNonce(s *sessions.SessionState) {
 	s.Nonce = c.OIDCNonce
 }
 
 // SetCookie encodes the CSRF to a signed cookie and sets it on the ResponseWriter
-func (c csrf) SetCookie(rw http.ResponseWriter, req *http.Request) (*http.Cookie, error) {
+func (c *csrf) SetCookie(rw http.ResponseWriter, req *http.Request) (*http.Cookie, error) {
 	encoded, err := c.encodeCookie()
 	if err != nil {
 		return nil, err
@@ -110,7 +110,7 @@ func (c csrf) SetCookie(rw http.ResponseWriter, req *http.Request) (*http.Cookie
 		encoded,
 		c.cookieOpts,
 		c.cookieOpts.Expire,
-		now(),
+		c.time.Now(),
 	)
 	http.SetCookie(rw, cookie)
 
@@ -118,20 +118,20 @@ func (c csrf) SetCookie(rw http.ResponseWriter, req *http.Request) (*http.Cookie
 }
 
 // ClearCookie removes the CSRF cookie
-func (c csrf) ClearCookie(rw http.ResponseWriter, req *http.Request) {
+func (c *csrf) ClearCookie(rw http.ResponseWriter, req *http.Request) {
 	http.SetCookie(rw, MakeCookieFromOptions(
 		req,
 		c.cookieName(),
 		"",
 		c.cookieOpts,
 		time.Hour*-1,
-		now(),
+		c.time.Now(),
 	))
 }
 
 // encodeCookie MessagePack encodes and encrypts the CSRF and then creates a
 // signed cookie value
-func (c csrf) encodeCookie() (string, error) {
+func (c *csrf) encodeCookie() (string, error) {
 	packed, err := msgpack.Marshal(c)
 	if err != nil {
 		return "", fmt.Errorf("error marshalling CSRF to msgpack: %v", err)
@@ -142,7 +142,7 @@ func (c csrf) encodeCookie() (string, error) {
 		return "", err
 	}
 
-	return encryption.SignedValue(c.cookieOpts.Secret, c.cookieName(), encrypted, now())
+	return encryption.SignedValue(c.cookieOpts.Secret, c.cookieName(), encrypted, c.time.Now())
 }
 
 // decodeCSRFCookie validates the signature then decrypts and decodes a CSRF
@@ -170,7 +170,7 @@ func decodeCSRFCookie(cookie *http.Cookie, opts *options.Cookie) (*csrf, error) 
 
 // cookieName returns the CSRF cookie's name derived from the base
 // session cookie name
-func (c csrf) cookieName() string {
+func (c *csrf) cookieName() string {
 	return csrfCookieName(c.cookieOpts)
 }
 

--- a/pkg/cookies/csrf_test.go
+++ b/pkg/cookies/csrf_test.go
@@ -128,17 +128,15 @@ var _ = Describe("CSRF Cookie Tests", func() {
 			It("adds the encoded CSRF cookie to a ResponseWriter", func() {
 				rw := httptest.NewRecorder()
 
-				expectedValue, err := csrf.EncodeCookie()
+				err := csrf.SetCookie(rw, req)
 				Expect(err).ToNot(HaveOccurred())
 
-				err = csrf.SetCookie(rw, req)
-				Expect(err).ToNot(HaveOccurred())
-
-				Expect(rw.Header().Get("Set-Cookie")).To(Equal(
+				Expect(rw.Header().Get("Set-Cookie")).To(ContainSubstring(
+					fmt.Sprintf("%s=", csrf.CookieName()),
+				))
+				Expect(rw.Header().Get("Set-Cookie")).To(ContainSubstring(
 					fmt.Sprintf(
-						"%s=%s; Path=%s; Domain=%s; Expires=%s; HttpOnly; Secure; SameSite",
-						csrf.CookieName(),
-						expectedValue,
+						"; Path=%s; Domain=%s; Expires=%s; HttpOnly; Secure; SameSite",
 						cookiePath,
 						cookieDomain,
 						testCookieExpires(now().Add(cookieOpts.Expire)),

--- a/pkg/cookies/csrf_test.go
+++ b/pkg/cookies/csrf_test.go
@@ -1,0 +1,168 @@
+package cookies
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"time"
+
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/encryption"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("CSRF Cookie Tests", func() {
+	var (
+		csrf       *CSRF
+		cookieOpts *options.Cookie
+		err        error
+	)
+
+	BeforeEach(func() {
+		cookieOpts = &options.Cookie{
+			Name:     cookieName,
+			Secret:   cookieSecret,
+			Domains:  []string{cookieDomain},
+			Path:     cookiePath,
+			Expire:   time.Hour,
+			Secure:   true,
+			HTTPOnly: true,
+		}
+
+		csrf, err = NewCSRF(cookieOpts)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	Context("NewCSRF", func() {
+		It("makes unique nonces", func() {
+			Expect(csrf.State).ToNot(BeEmpty())
+			Expect(csrf.Nonce).ToNot(BeEmpty())
+			Expect(csrf.State).ToNot(Equal(csrf.Nonce))
+		})
+	})
+
+	Context("CheckState and CheckNonce", func() {
+		It("checks equality", func() {
+			csrf.State = csrfState
+			csrf.Nonce = csrfNonce
+
+			Expect(csrf.CheckState(csrfState)).To(BeTrue())
+			Expect(csrf.CheckNonce(csrfNonce)).To(BeTrue())
+
+			Expect(csrf.CheckState(csrfNonce)).To(BeFalse())
+			Expect(csrf.CheckNonce(csrfState)).To(BeFalse())
+			Expect(csrf.CheckState(csrfState + csrfNonce)).To(BeFalse())
+			Expect(csrf.CheckNonce(csrfNonce + csrfState)).To(BeFalse())
+			Expect(csrf.CheckState("")).To(BeFalse())
+			Expect(csrf.CheckNonce("")).To(BeFalse())
+		})
+	})
+
+	Context("CookieName", func() {
+		It("has the cookie options name as a base", func() {
+			Expect(csrf.CookieName()).To(ContainSubstring(cookieName))
+		})
+	})
+
+	Context("EncodeCookie and DecodeCSRFCookie", func() {
+		It("encodes and decodes to the same nonces", func() {
+			csrf.State = csrfState
+			csrf.Nonce = csrfNonce
+
+			encoded, err := csrf.EncodeCookie()
+			Expect(err).ToNot(HaveOccurred())
+
+			cookie := &http.Cookie{
+				Name:  csrf.CookieName(),
+				Value: encoded,
+			}
+			decoded, err := DecodeCSRFCookie(cookie, cookieOpts)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(decoded).ToNot(BeNil())
+			Expect(decoded.State).To(Equal(csrfState))
+			Expect(decoded.Nonce).To(Equal(csrfNonce))
+		})
+
+		It("signs the encoded cookie value", func() {
+			encoded, err := csrf.EncodeCookie()
+			Expect(err).ToNot(HaveOccurred())
+
+			cookie := &http.Cookie{
+				Name:  csrf.CookieName(),
+				Value: encoded,
+			}
+
+			_, _, valid := encryption.Validate(cookie, cookieOpts.Secret, cookieOpts.Expire)
+			Expect(valid).To(BeTrue())
+		})
+	})
+
+	Context("Cookie Management", func() {
+		var req *http.Request
+
+		BeforeEach(func() {
+			now = func() time.Time {
+				return time.Unix(nowEpoch, 0)
+			}
+
+			req = &http.Request{
+				Method: http.MethodGet,
+				Proto:  "HTTP/1.1",
+				Host:   cookieDomain,
+
+				URL: &url.URL{
+					Scheme: "https",
+					Host:   cookieDomain,
+					Path:   cookiePath,
+				},
+			}
+		})
+
+		Context("SetCookie", func() {
+			It("adds the encoded CSRF cookie to a ResponseWriter", func() {
+				csrf.State = csrfState
+				csrf.Nonce = csrfNonce
+
+				rw := httptest.NewRecorder()
+
+				expectedValue, err := csrf.EncodeCookie()
+				Expect(err).ToNot(HaveOccurred())
+
+				err = csrf.SetCookie(rw, req)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(rw.Header().Get("Set-Cookie")).To(Equal(
+					fmt.Sprintf(
+						"%s=%s; Path=%s; Domain=%s; Expires=%s; HttpOnly; Secure; SameSite",
+						csrf.CookieName(),
+						expectedValue,
+						cookiePath,
+						cookieDomain,
+						testCookieExpires(now().Add(cookieOpts.Expire)),
+					),
+				))
+			})
+		})
+
+		Context("ClearCookie", func() {
+			It("sets a cookie with an empty value in the past", func() {
+				rw := httptest.NewRecorder()
+
+				csrf.ClearCookie(rw, req)
+
+				Expect(rw.Header().Get("Set-Cookie")).To(Equal(
+					fmt.Sprintf(
+						"%s=; Path=%s; Domain=%s; Expires=%s; HttpOnly; Secure; SameSite",
+						csrf.CookieName(),
+						cookiePath,
+						cookieDomain,
+						testCookieExpires(now().Add(time.Hour*-1)),
+					),
+				))
+			})
+		})
+	})
+})

--- a/pkg/cookies/csrf_test.go
+++ b/pkg/cookies/csrf_test.go
@@ -150,7 +150,7 @@ var _ = Describe("CSRF Cookie Tests", func() {
 				))
 				Expect(rw.Header().Get("Set-Cookie")).To(ContainSubstring(
 					fmt.Sprintf(
-						"; Path=%s; Domain=%s; Expires=%s; HttpOnly; Secure; SameSite",
+						"; Path=%s; Domain=%s; Expires=%s; HttpOnly; Secure",
 						cookiePath,
 						cookieDomain,
 						testCookieExpires(now().Add(cookieOpts.Expire)),
@@ -167,7 +167,7 @@ var _ = Describe("CSRF Cookie Tests", func() {
 
 				Expect(rw.Header().Get("Set-Cookie")).To(Equal(
 					fmt.Sprintf(
-						"%s=; Path=%s; Domain=%s; Expires=%s; HttpOnly; Secure; SameSite",
+						"%s=; Path=%s; Domain=%s; Expires=%s; HttpOnly; Secure",
 						privateCSRF.cookieName(),
 						cookiePath,
 						cookieDomain,

--- a/pkg/cookies/csrf_test.go
+++ b/pkg/cookies/csrf_test.go
@@ -120,10 +120,10 @@ var _ = Describe("CSRF Cookie Tests", func() {
 	Context("Cookie Management", func() {
 		var req *http.Request
 
+		testNow := time.Unix(nowEpoch, 0)
+
 		BeforeEach(func() {
-			now = func() time.Time {
-				return time.Unix(nowEpoch, 0)
-			}
+			privateCSRF.time.Set(testNow)
 
 			req = &http.Request{
 				Method: http.MethodGet,
@@ -136,6 +136,10 @@ var _ = Describe("CSRF Cookie Tests", func() {
 					Path:   cookiePath,
 				},
 			}
+		})
+
+		AfterEach(func() {
+			privateCSRF.time.Reset()
 		})
 
 		Context("SetCookie", func() {
@@ -153,7 +157,7 @@ var _ = Describe("CSRF Cookie Tests", func() {
 						"; Path=%s; Domain=%s; Expires=%s; HttpOnly; Secure",
 						cookiePath,
 						cookieDomain,
-						testCookieExpires(now().Add(cookieOpts.Expire)),
+						testCookieExpires(testNow.Add(cookieOpts.Expire)),
 					),
 				))
 			})
@@ -171,7 +175,7 @@ var _ = Describe("CSRF Cookie Tests", func() {
 						privateCSRF.cookieName(),
 						cookiePath,
 						cookieDomain,
-						testCookieExpires(now().Add(time.Hour*-1)),
+						testCookieExpires(testNow.Add(time.Hour*-1)),
 					),
 				))
 			})

--- a/pkg/encryption/nonce.go
+++ b/pkg/encryption/nonce.go
@@ -19,6 +19,10 @@ func Nonce() ([]byte, error) {
 }
 
 // HashNonce returns the BLAKE2b 256-bit hash of a nonce
+// NOTE: Error checking (G104) is purposefully skipped:
+// - `blake2b.New256` has no error path with a nil signing key
+// - `hash.Hash` interface's `Write` has an error signature, but
+//   `blake2b.digest.Write` does not use it.
 /* #nosec G104 */
 func HashNonce(nonce []byte) string {
 	hasher, _ := blake2b.New256(nil)

--- a/pkg/encryption/nonce.go
+++ b/pkg/encryption/nonce.go
@@ -1,17 +1,33 @@
 package encryption
 
 import (
+	"crypto/hmac"
 	"crypto/rand"
-	"fmt"
+	"encoding/base64"
+
+	"golang.org/x/crypto/blake2b"
 )
 
-// Nonce generates a random 16 byte string to be used as a nonce
-func Nonce() (nonce string, err error) {
-	b := make([]byte, 16)
-	_, err = rand.Read(b)
+// Nonce generates a random 32-byte slice to be used as a nonce
+func Nonce() ([]byte, error) {
+	b := make([]byte, 32)
+	_, err := rand.Read(b)
 	if err != nil {
-		return
+		return nil, err
 	}
-	nonce = fmt.Sprintf("%x", b)
-	return
+	return b, nil
+}
+
+// HashNonce returns the BLAKE2b 256-bit hash of a nonce
+/* #nosec G104 */
+func HashNonce(nonce []byte) string {
+	hasher, _ := blake2b.New256(nil)
+	hasher.Write(nonce)
+	sum := hasher.Sum(nil)
+	return base64.RawURLEncoding.EncodeToString(sum)
+}
+
+// CheckNonce tests if a nonce matches the hashed version of it
+func CheckNonce(nonce []byte, hashed string) bool {
+	return hmac.Equal([]byte(HashNonce(nonce)), []byte(hashed))
 }

--- a/pkg/validation/options.go
+++ b/pkg/validation/options.go
@@ -264,6 +264,7 @@ func parseProviderInfo(o *options.Options, msgs []string) []string {
 		p.SetTeam(o.Providers[0].BitbucketConfig.Team)
 		p.SetRepository(o.Providers[0].BitbucketConfig.Repository)
 	case *providers.OIDCProvider:
+		p.SkipNonce = o.Providers[0].OIDCConfig.InsecureSkipNonce
 		if p.Verifier == nil {
 			msgs = append(msgs, "oidc provider requires an oidc issuer URL")
 		}

--- a/pkg/validation/sessions.go
+++ b/pkg/validation/sessions.go
@@ -2,6 +2,7 @@ package validation
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"time"
 
@@ -50,10 +51,11 @@ func validateRedisSessionStore(o *options.Options) []string {
 		return []string{fmt.Sprintf("unable to initialize a redis client: %v", err)}
 	}
 
-	nonce, err := encryption.Nonce()
+	n, err := encryption.Nonce()
 	if err != nil {
 		return []string{fmt.Sprintf("unable to generate a redis initialization test key: %v", err)}
 	}
+	nonce := base64.RawURLEncoding.EncodeToString(n)
 
 	key := fmt.Sprintf("%s-healthcheck-%s", o.Cookie.Name, nonce)
 	return sendRedisConnectionTest(client, key, nonce)

--- a/providers/azure.go
+++ b/providers/azure.go
@@ -107,7 +107,7 @@ func overrideTenantURL(current, defaultURL *url.URL, tenant, path string) {
 	}
 }
 
-func (p *AzureProvider) GetLoginURL(redirectURI, state string) string {
+func (p *AzureProvider) GetLoginURL(redirectURI, state, _ string) string {
 	extraParams := url.Values{}
 	if p.ProtectedResource != nil && p.ProtectedResource.String() != "" {
 		extraParams.Add("resource", p.ProtectedResource.String())

--- a/providers/azure_test.go
+++ b/providers/azure_test.go
@@ -336,7 +336,7 @@ func TestAzureProviderRedeem(t *testing.T) {
 func TestAzureProviderProtectedResourceConfigured(t *testing.T) {
 	p := testAzureProvider("")
 	p.ProtectedResource, _ = url.Parse("http://my.resource.test")
-	result := p.GetLoginURL("https://my.test.app/oauth", "")
+	result := p.GetLoginURL("https://my.test.app/oauth", "", "")
 	assert.Contains(t, result, "resource="+url.QueryEscape("http://my.resource.test"))
 }
 

--- a/providers/logingov.go
+++ b/providers/logingov.go
@@ -228,7 +228,7 @@ func (p *LoginGovProvider) Redeem(ctx context.Context, redirectURL, code string)
 }
 
 // GetLoginURL overrides GetLoginURL to add login.gov parameters
-func (p *LoginGovProvider) GetLoginURL(redirectURI, state string) string {
+func (p *LoginGovProvider) GetLoginURL(redirectURI, state, _ string) string {
 	extraParams := url.Values{}
 	if p.AcrValues == "" {
 		acr := "http://idmanagement.gov/ns/assurance/loa/1"

--- a/providers/logingov_test.go
+++ b/providers/logingov_test.go
@@ -292,7 +292,7 @@ func TestLoginGovProviderBadNonce(t *testing.T) {
 
 func TestLoginGovProviderGetLoginURL(t *testing.T) {
 	p, _, _ := newLoginGovProvider()
-	result := p.GetLoginURL("http://redirect/", "")
+	result := p.GetLoginURL("http://redirect/", "", "")
 	assert.Contains(t, result, "acr_values="+url.QueryEscape("http://idmanagement.gov/ns/assurance/loa/1"))
 	assert.Contains(t, result, "nonce=fakenonce")
 }

--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"reflect"
 	"time"
 
@@ -16,15 +17,30 @@ import (
 // OIDCProvider represents an OIDC based Identity Provider
 type OIDCProvider struct {
 	*ProviderData
+
+	SkipNonce bool
 }
 
 // NewOIDCProvider initiates a new OIDCProvider
 func NewOIDCProvider(p *ProviderData) *OIDCProvider {
 	p.ProviderName = "OpenID Connect"
-	return &OIDCProvider{ProviderData: p}
+	return &OIDCProvider{
+		ProviderData: p,
+		SkipNonce:    true,
+	}
 }
 
 var _ Provider = (*OIDCProvider)(nil)
+
+// GetLoginURL makes the LoginURL with optional nonce support
+func (p *OIDCProvider) GetLoginURL(redirectURI, state, nonce string) string {
+	extraParams := url.Values{}
+	if !p.SkipNonce {
+		extraParams.Add("nonce", nonce)
+	}
+	loginURL := makeLoginURL(p.Data(), redirectURI, state, extraParams)
+	return loginURL.String()
+}
 
 // Redeem exchanges the OAuth2 authentication token for an ID token
 func (p *OIDCProvider) Redeem(ctx context.Context, redirectURL, code string) (*sessions.SessionState, error) {
@@ -109,8 +125,22 @@ func (p *OIDCProvider) enrichFromProfileURL(ctx context.Context, s *sessions.Ses
 
 // ValidateSession checks that the session's IDToken is still valid
 func (p *OIDCProvider) ValidateSession(ctx context.Context, s *sessions.SessionState) bool {
-	_, err := p.Verifier.Verify(ctx, s.IDToken)
-	return err == nil
+	idToken, err := p.Verifier.Verify(ctx, s.IDToken)
+	if err != nil {
+		logger.Errorf("id_token verification failed: %v", err)
+		return false
+	}
+
+	if p.SkipNonce {
+		return true
+	}
+	err = p.checkNonce(s, idToken)
+	if err != nil {
+		logger.Errorf("nonce verification failed: %v", err)
+		return false
+	}
+
+	return true
 }
 
 // RefreshSessionIfNeeded checks if the session has expired and uses the

--- a/providers/oidc_test.go
+++ b/providers/oidc_test.go
@@ -2,6 +2,7 @@ package providers
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -82,8 +83,9 @@ func TestOIDCProviderGetLoginURL(t *testing.T) {
 	}
 	provider := newOIDCProvider(serverURL)
 
-	nonce, err := encryption.Nonce()
+	n, err := encryption.Nonce()
 	assert.NoError(t, err)
+	nonce := base64.RawURLEncoding.EncodeToString(n)
 
 	// SkipNonce defaults to true
 	skipNonce := provider.GetLoginURL("http://redirect/", "", nonce)

--- a/providers/provider_data.go
+++ b/providers/provider_data.go
@@ -2,7 +2,6 @@ package providers
 
 import (
 	"context"
-	"crypto/hmac"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -200,7 +199,7 @@ func (p *ProviderData) checkNonce(s *sessions.SessionState, idToken *oidc.IDToke
 	if err != nil {
 		return fmt.Errorf("id_token claims extraction failed: %v", err)
 	}
-	if !hmac.Equal([]byte(s.Nonce), []byte(claims.Nonce)) {
+	if !s.CheckNonce(claims.Nonce) {
 		return errors.New("id_token nonce claim does not match the session nonce")
 	}
 	return nil

--- a/providers/provider_data.go
+++ b/providers/provider_data.go
@@ -2,6 +2,7 @@ package providers
 
 import (
 	"context"
+	"crypto/hmac"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -122,6 +123,7 @@ type OIDCClaims struct {
 	Email    string   `json:"-"`
 	Groups   []string `json:"-"`
 	Verified *bool    `json:"email_verified"`
+	Nonce    string   `json:"nonce"`
 
 	raw map[string]interface{}
 }
@@ -190,6 +192,18 @@ func (p *ProviderData) getClaims(idToken *oidc.IDToken) (*OIDCClaims, error) {
 	claims.Groups = p.extractGroups(claims.raw)
 
 	return claims, nil
+}
+
+// checkNonce compares the session's nonce with the IDToken's nonce claim
+func (p *ProviderData) checkNonce(s *sessions.SessionState, idToken *oidc.IDToken) error {
+	claims, err := p.getClaims(idToken)
+	if err != nil {
+		return fmt.Errorf("id_token claims extraction failed: %v", err)
+	}
+	if !hmac.Equal([]byte(s.Nonce), []byte(claims.Nonce)) {
+		return errors.New("id_token nonce claim does not match the session nonce")
+	}
+	return nil
 }
 
 // extractGroups extracts groups from a claim to a list in a type safe manner.

--- a/providers/provider_data_test.go
+++ b/providers/provider_data_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/encryption"
 	"strings"
 	"testing"
 	"time"
@@ -16,6 +15,7 @@ import (
 	"github.com/coreos/go-oidc"
 	"github.com/dgrijalva/jwt-go"
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/sessions"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/encryption"
 	. "github.com/onsi/gomega"
 	"golang.org/x/oauth2"
 )

--- a/providers/provider_data_test.go
+++ b/providers/provider_data_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/encryption"
 	"strings"
 	"testing"
 	"time"
@@ -54,7 +55,7 @@ var (
 		Groups:         []string{"test:a", "test:b"},
 		Roles:          []string{"test:c", "test:d"},
 		Verified:       &verified,
-		Nonce:          oidcNonce,
+		Nonce:          encryption.HashNonce([]byte(oidcNonce)),
 		StandardClaims: standardClaims,
 	}
 
@@ -359,14 +360,14 @@ func TestProviderData_checkNonce(t *testing.T) {
 	}{
 		"Nonces match": {
 			Session: &sessions.SessionState{
-				Nonce: oidcNonce,
+				Nonce: []byte(oidcNonce),
 			},
 			IDToken:       defaultIDToken,
 			ExpectedError: nil,
 		},
 		"Nonces do not match": {
 			Session: &sessions.SessionState{
-				Nonce: "WrongWrongWrong",
+				Nonce: []byte("WrongWrongWrong"),
 			},
 			IDToken:       defaultIDToken,
 			ExpectedError: errors.New("id_token nonce claim does not match the session nonce"),
@@ -374,7 +375,7 @@ func TestProviderData_checkNonce(t *testing.T) {
 
 		"Missing nonce claim": {
 			Session: &sessions.SessionState{
-				Nonce: oidcNonce,
+				Nonce: []byte(oidcNonce),
 			},
 			IDToken:       minimalIDToken,
 			ExpectedError: errors.New("id_token nonce claim does not match the session nonce"),

--- a/providers/provider_data_test.go
+++ b/providers/provider_data_test.go
@@ -27,6 +27,7 @@ const (
 	oidcIssuer   = "https://issuer.example.com"
 	oidcClientID = "https://test.myapp.com"
 	oidcSecret   = "SuperSecret123456789"
+	oidcNonce    = "abcde12345edcba09876abcde12345ff"
 
 	failureTokenID = "this-id-fails-verification"
 )
@@ -53,6 +54,7 @@ var (
 		Groups:         []string{"test:a", "test:b"},
 		Roles:          []string{"test:c", "test:d"},
 		Verified:       &verified,
+		Nonce:          oidcNonce,
 		StandardClaims: standardClaims,
 	}
 
@@ -96,6 +98,7 @@ type idTokenClaims struct {
 	Groups   interface{} `json:"groups,omitempty"`
 	Roles    interface{} `json:"roles,omitempty"`
 	Verified *bool       `json:"email_verified,omitempty"`
+	Nonce    string      `json:"nonce,omitempty"`
 	jwt.StandardClaims
 }
 
@@ -343,6 +346,63 @@ func TestProviderData_buildSessionFromClaims(t *testing.T) {
 			}
 			if ss != nil {
 				g.Expect(ss).To(Equal(tc.ExpectedSession))
+			}
+		})
+	}
+}
+
+func TestProviderData_checkNonce(t *testing.T) {
+	testCases := map[string]struct {
+		Session       *sessions.SessionState
+		IDToken       idTokenClaims
+		ExpectedError error
+	}{
+		"Nonces match": {
+			Session: &sessions.SessionState{
+				Nonce: oidcNonce,
+			},
+			IDToken:       defaultIDToken,
+			ExpectedError: nil,
+		},
+		"Nonces do not match": {
+			Session: &sessions.SessionState{
+				Nonce: "WrongWrongWrong",
+			},
+			IDToken:       defaultIDToken,
+			ExpectedError: errors.New("id_token nonce claim does not match the session nonce"),
+		},
+
+		"Missing nonce claim": {
+			Session: &sessions.SessionState{
+				Nonce: oidcNonce,
+			},
+			IDToken:       minimalIDToken,
+			ExpectedError: errors.New("id_token nonce claim does not match the session nonce"),
+		},
+	}
+	for testName, tc := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			g := NewWithT(t)
+
+			provider := &ProviderData{
+				Verifier: oidc.NewVerifier(
+					oidcIssuer,
+					mockJWKS{},
+					&oidc.Config{ClientID: oidcClientID},
+				),
+			}
+
+			rawIDToken, err := newSignedTestIDToken(tc.IDToken)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			idToken, err := provider.Verifier.Verify(context.Background(), rawIDToken)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			err = provider.checkNonce(tc.Session, idToken)
+			if err != nil {
+				g.Expect(err).To(Equal(tc.ExpectedError))
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
 			}
 		})
 	}

--- a/providers/provider_default.go
+++ b/providers/provider_default.go
@@ -33,6 +33,13 @@ var (
 	_ Provider = (*ProviderData)(nil)
 )
 
+// GetLoginURL with typical oauth parameters
+func (p *ProviderData) GetLoginURL(redirectURI, state, _ string) string {
+	extraParams := url.Values{}
+	loginURL := makeLoginURL(p, redirectURI, state, extraParams)
+	return loginURL.String()
+}
+
 // Redeem provides a default implementation of the OAuth2 token redemption process
 func (p *ProviderData) Redeem(ctx context.Context, redirectURL, code string) (*sessions.SessionState, error) {
 	if code == "" {
@@ -84,13 +91,6 @@ func (p *ProviderData) Redeem(ctx context.Context, redirectURL, code string) (*s
 	}
 
 	return nil, fmt.Errorf("no access token found %s", result.Body())
-}
-
-// GetLoginURL with typical oauth parameters
-func (p *ProviderData) GetLoginURL(redirectURI, state string) string {
-	extraParams := url.Values{}
-	a := makeLoginURL(p, redirectURI, state, extraParams)
-	return a.String()
 }
 
 // GetEmailAddress returns the Account email address

--- a/providers/provider_default_test.go
+++ b/providers/provider_default_test.go
@@ -31,7 +31,7 @@ func TestAcrValuesNotConfigured(t *testing.T) {
 		},
 	}
 
-	result := p.GetLoginURL("https://my.test.app/oauth", "")
+	result := p.GetLoginURL("https://my.test.app/oauth", "", "")
 	assert.NotContains(t, result, "acr_values")
 }
 
@@ -45,7 +45,7 @@ func TestAcrValuesConfigured(t *testing.T) {
 		AcrValues: "testValue",
 	}
 
-	result := p.GetLoginURL("https://my.test.app/oauth", "")
+	result := p.GetLoginURL("https://my.test.app/oauth", "", "")
 	assert.Contains(t, result, "acr_values=testValue")
 }
 

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -11,11 +11,11 @@ type Provider interface {
 	Data() *ProviderData
 	// Deprecated: Migrate to EnrichSession
 	GetEmailAddress(ctx context.Context, s *sessions.SessionState) (string, error)
+	GetLoginURL(redirectURI, state, nonce string) string
 	Redeem(ctx context.Context, redirectURI, code string) (*sessions.SessionState, error)
 	EnrichSession(ctx context.Context, s *sessions.SessionState) error
 	Authorize(ctx context.Context, s *sessions.SessionState) (bool, error)
 	ValidateSession(ctx context.Context, s *sessions.SessionState) bool
-	GetLoginURL(redirectURI, finalRedirect string) string
 	RefreshSessionIfNeeded(ctx context.Context, s *sessions.SessionState) (bool, error)
 	CreateSessionFromToken(ctx context.Context, token string) (*sessions.SessionState, error)
 }


### PR DESCRIPTION
https://github.com/oauth2-proxy/oauth2-proxy/issues/966

Implements OIDC Nonce setting:
- A nonce is always created and sent as a parameter to all provider's `GetLoginURL` (even if they don't use it).
- Once a session is created, the nonce is added to `session.Nonce` for any providers to use during the lifespan of the session to validate the nonce.

In the initial OAuth flow, after LoginURL, Redeem, EnrichSession - ValidateSession is now called as well (for all providers). For OIDC, this allows a final check on the ID Token `nonce` claim before minting the session as valid.

The `--insecure-oidc-skip-nonce` flag is `true` by default for now in case any existing OIDC IdPs don't support it properly.

CSRF management is refactored to its own struct in `cookies` package. It handles both the OAuth2 state nonce & the OIDC nonce. The cookie value is now additionally signed and verified before any CSRF checks with the OAuth2 callback or OIDC ID Token nonce claim.

Any nonce checks use `hmac.Equal` for constant time comparisons to not leak time details.

(Slight Scope Creep) Unit tests added to the `cookies` package for existing code in addition to new CSRF code.

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
