### PR TITLE
Fix joined cookie name for those containing underline in the suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@
 
 ## Changes since v6.1.1
 
-- [#630](https://github.com/oauth2-proxy/oauth2-proxy/pull/970) Fix joined cookie name for those containing underline in the suffix (@peppered)
+- [#970](https://github.com/oauth2-proxy/oauth2-proxy/pull/970) Fix joined cookie name for those containing underline in the suffix (@peppered)
 - [#953](https://github.com/oauth2-proxy/oauth2-proxy/pull/953) Migrate Keycloak to EnrichSession & support multiple groups for authorization (@NickMeves)
 - [#957](https://github.com/oauth2-proxy/oauth2-proxy/pull/957) Use X-Forwarded-{Proto,Host,Uri} on redirect as last resort (@linuxgemini)
 - [#630](https://github.com/oauth2-proxy/oauth2-proxy/pull/630) Add support for Gitlab project based authentication (@factorysh)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 
 ## Changes since v6.1.1
 
+- [#630](https://github.com/oauth2-proxy/oauth2-proxy/pull/970) Fix joined cookie name for those containing underline in the suffix (@peppered)
 - [#953](https://github.com/oauth2-proxy/oauth2-proxy/pull/953) Migrate Keycloak to EnrichSession & support multiple groups for authorization (@NickMeves)
 - [#957](https://github.com/oauth2-proxy/oauth2-proxy/pull/957) Use X-Forwarded-{Proto,Host,Uri} on redirect as last resort (@linuxgemini)
 - [#630](https://github.com/oauth2-proxy/oauth2-proxy/pull/630) Add support for Gitlab project based authentication (@factorysh)

--- a/pkg/sessions/cookie/session_store.go
+++ b/pkg/sessions/cookie/session_store.go
@@ -236,7 +236,7 @@ func joinCookies(cookies []*http.Cookie) (*http.Cookie, error) {
 	for i := 1; i < len(cookies); i++ {
 		c.Value += cookies[i].Value
 	}
-	c.Name = strings.TrimRight(c.Name, "_0")
+	c.Name = strings.TrimSuffix(c.Name, "_0")
 	return c, nil
 }
 

--- a/pkg/sessions/cookie/session_store.go
+++ b/pkg/sessions/cookie/session_store.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
-	"strings"
 	"time"
 
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
@@ -220,12 +219,12 @@ func loadCookie(req *http.Request, cookieName string) (*http.Cookie, error) {
 	if len(cookies) == 0 {
 		return nil, fmt.Errorf("could not find cookie %s", cookieName)
 	}
-	return joinCookies(cookies)
+	return joinCookies(cookies, cookieName)
 }
 
 // joinCookies takes a slice of cookies from the request and reconstructs the
 // full session cookie
-func joinCookies(cookies []*http.Cookie) (*http.Cookie, error) {
+func joinCookies(cookies []*http.Cookie, cookieName string) (*http.Cookie, error) {
 	if len(cookies) == 0 {
 		return nil, fmt.Errorf("list of cookies must be > 0")
 	}
@@ -236,7 +235,7 @@ func joinCookies(cookies []*http.Cookie) (*http.Cookie, error) {
 	for i := 1; i < len(cookies); i++ {
 		c.Value += cookies[i].Value
 	}
-	c.Name = strings.TrimSuffix(c.Name, "_0")
+	c.Name = cookieName
 	return c, nil
 }
 

--- a/pkg/sessions/cookie/session_store_test.go
+++ b/pkg/sessions/cookie/session_store_test.go
@@ -183,7 +183,7 @@ func Test_joinCookies_withUnderlineSuffix(t *testing.T) {
 			SplitOrder: []int{1, 3, 0, 2, 4},
 		},
 		"Arbitrary order split with \"_1\" suffix": {
-			CookieName: "_cookie_name_0",
+			CookieName: "_cookie_name_1",
 			SplitOrder: []int{4, 1, 3, 0, 2},
 		},
 		"Arbitrary order split with \"__\" suffix": {

--- a/pkg/sessions/cookie/session_store_test.go
+++ b/pkg/sessions/cookie/session_store_test.go
@@ -148,10 +148,10 @@ func Test_splitCookie_joinCookies(t *testing.T) {
 	value := strings.Repeat(string(v), 1000)
 
 	nameSizes := []int{1, 10, 50, 100, 200, 254}
-	nameSuffixes := []string{"", "_", "__", "__0"}
+	nameSuffixes := []string{"", "_", "_0", "__", "__0"}
 	for _, nameSize := range nameSizes {
 		for _, nameSuffix := range nameSuffixes {
-			testName := fmt.Sprintf("%d length cookie name with \"%s\" suffix ", nameSize, nameSuffix)
+			testName := fmt.Sprintf("%d length cookie name with \"%s\" suffix", nameSize, nameSuffix)
 			t.Run(testName, func(t *testing.T) {
 				adjustedNameSize := nameSize
 				if adjustedNameSize+len(nameSuffix) > 254 {

--- a/pkg/sessions/cookie/session_store_test.go
+++ b/pkg/sessions/cookie/session_store_test.go
@@ -147,16 +147,25 @@ func Test_splitCookie_joinCookies(t *testing.T) {
 	}
 	value := strings.Repeat(string(v), 1000)
 
-	for _, nameSize := range []int{1, 10, 50, 100, 200, 254} {
-		t.Run(fmt.Sprintf("%d length cookie name", nameSize), func(t *testing.T) {
-			cookie := &http.Cookie{
-				Name:  strings.Repeat("n", nameSize),
-				Value: value,
-			}
-			splitCookies := splitCookie(cookie)
-			joinedCookie, err := joinCookies(splitCookies)
-			assert.NoError(t, err)
-			assert.Equal(t, *cookie, *joinedCookie)
-		})
+	nameSizes := []int{1, 10, 50, 100, 200, 254}
+	nameSuffixes := []string{"", "_", "__", "__0"}
+	for _, nameSize := range nameSizes {
+		for _, nameSuffix := range nameSuffixes {
+			testName := fmt.Sprintf("%d length cookie name with \"%s\" suffix ", nameSize, nameSuffix)
+			t.Run(testName, func(t *testing.T) {
+				adjustedNameSize := nameSize
+				if adjustedNameSize+len(nameSuffix) > 254 {
+					adjustedNameSize -= len(nameSuffix)
+				}
+				cookie := &http.Cookie{
+					Name:  strings.Repeat("n", adjustedNameSize) + nameSuffix,
+					Value: value,
+				}
+				splitCookies := splitCookie(cookie)
+				joinedCookie, err := joinCookies(splitCookies)
+				assert.NoError(t, err)
+				assert.Equal(t, *cookie, *joinedCookie)
+			})
+		}
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove fixed `_0` instead of removing all `_` and `0` chars in the cookie name suffix while joining splitted cookie.

## Motivation and Context
Fixes the https://github.com/oauth2-proxy/oauth2-proxy/issues/960.

## How Has This Been Tested?
The existing tests have been updated to reflect the changes.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
