### PR TITLE
Grafana Provider

### DIFF
--- a/docs/docs/configuration/auth.md
+++ b/docs/docs/configuration/auth.md
@@ -10,6 +10,7 @@ Valid providers are :
 - [Google](#google-auth-provider) _default_
 - [Azure](#azure-auth-provider)
 - [Facebook](#facebook-auth-provider)
+- [Grafana](#grafana-auth-provider)
 - [GitHub](#github-auth-provider)
 - [Keycloak](#keycloak-auth-provider)
 - [GitLab](#gitlab-auth-provider)
@@ -91,6 +92,15 @@ Note: When using the Azure Auth provider with nginx and the cookie session store
 
 1.  Create a new FB App from <https://developers.facebook.com/>
 2.  Under FB Login, set your Valid OAuth redirect URIs to `https://internal.yourcompany.com/oauth2/callback`
+
+### Grafana Auth Provider
+1. Create an OAuth Client for your Grafana organisation
+    - Under _"Security"_ > _"OAuth Clients"_ on your organisation dashboard, click **"+ Add OAuth Client Application"**
+    - Enter your name and description. For the URL, enter your configured return URL to `https://internal.yourcompany.com/oauth2/callback`
+    
+The Grafana auth provider supports email domain authentication through the `--email-domain` flag.
+
+Support for authorizing a user by their Grafana Cloud Organization membership is currently not supported.
 
 ### GitHub Auth Provider
 

--- a/providers/grafana.go
+++ b/providers/grafana.go
@@ -1,0 +1,73 @@
+package providers
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/sessions"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/requests"
+)
+
+// GrafanaProvider represents an Grafana based Identity Provider
+type GrafanaProvider struct {
+	*ProviderData
+}
+
+var _ Provider = (*GrafanaProvider)(nil)
+
+// https://?access_type=online&client_id=a339e72afa3a51a5be00&redirect_uri=https://labbbles.grafana.net/login/grafana_com&response_type=code&scope=user:email&state=xjV-CQTPhUZsfWjYKUzhiGC-4xOWPfG_FV6QxC7ZNRo=
+const (
+	GrafanaProviderName = "Grafana"
+	grafanaDefaultScope = "user:email"
+)
+
+var (
+	grafanaDefaultLoginURL = &url.URL{
+		Scheme: "https",
+		Host:   "grafana.com",
+		Path:   "/oauth2/authorize",
+	}
+
+	grafanaDefaultRedeemURL = &url.URL{
+		Scheme: "https",
+		Host:   "grafana.com",
+		Path:   "/api/oauth2/token",
+	}
+
+	grafanaDefaultProfileURL = &url.URL{
+		Scheme: "https",
+		Host:   "grafana.com",
+		Path:   "/api/profile",
+	}
+)
+
+// NewGrafanaProvider initiates a new GrafanaProvider
+func NewGrafanaProvider(p *ProviderData) *GrafanaProvider {
+	p.setProviderDefaults(providerDefaults{
+		name:        GrafanaProviderName,
+		loginURL:    grafanaDefaultLoginURL,
+		redeemURL:   grafanaDefaultRedeemURL,
+		profileURL:  grafanaDefaultProfileURL,
+		validateURL: grafanaDefaultProfileURL,
+		scope:       grafanaDefaultScope,
+	})
+	return &GrafanaProvider{ProviderData: p}
+}
+
+
+// GetEmailAddress returns the Account email address
+func (p *GrafanaProvider) GetEmailAddress(ctx context.Context, s *sessions.SessionState) (string, error) {
+	json, err := requests.New(p.ProfileURL.String()).
+		WithContext(ctx).
+		WithHeaders(makeOIDCHeader(s.AccessToken)).
+		Do().
+		UnmarshalJSON()
+
+	if err != nil {
+		return "", fmt.Errorf("error making request: %v", err)
+	}
+
+	email, err := json.Get("email").String()
+	return email, err
+}

--- a/providers/grafana.go
+++ b/providers/grafana.go
@@ -82,7 +82,12 @@ func (p *GrafanaProvider) EnrichSession(ctx context.Context, s *sessions.Session
 }
 
 func (p *GrafanaProvider) getUser(json *simplejson.Json) (string, error) {
-	return json.Get("username").String()
+	u, found := json.CheckGet("username")
+	if !found {
+		return "", nil
+	}
+
+	return u.String()
 }
 
 func (p *GrafanaProvider) getEmail(json *simplejson.Json) (string, error) {

--- a/providers/grafana_test.go
+++ b/providers/grafana_test.go
@@ -1,0 +1,140 @@
+package providers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/sessions"
+)
+
+const grafanaUserPath = "/api/profile"
+
+func testGrafanaProvider(hostname string) *GrafanaProvider {
+	p := NewGrafanaProvider(&ProviderData{
+		ProviderName: "",
+		LoginURL:     &url.URL{},
+		RedeemURL:    &url.URL{},
+		ProfileURL:   &url.URL{},
+		ValidateURL:  &url.URL{},
+		Scope:        "",
+	})
+	if hostname != "" {
+		updateURL(p.Data().LoginURL, hostname)
+		updateURL(p.Data().RedeemURL, hostname)
+		updateURL(p.Data().ProfileURL, hostname)
+		updateURL(p.Data().ValidateURL, hostname)
+	}
+	return p
+}
+
+func TestGrafanaProviderDefaults(t *testing.T) {
+	p := testGrafanaProvider("")
+	assert.NotEqual(t, nil, p)
+	assert.Equal(t, "Grafana", p.Data().ProviderName)
+	assert.Equal(t, "https://grafana.com/oauth2/authorize", p.Data().LoginURL.String())
+	assert.Equal(t, "https://grafana.com/api/oauth2/token", p.Data().RedeemURL.String())
+	assert.Equal(t, "https://grafana.com/api/profile", p.Data().ValidateURL.String())
+}
+
+func testGrafanaBackend(payload, path, query string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != path || r.URL.RawQuery != query {
+				w.WriteHeader(404)
+			} else if !IsAuthorizedInHeader(r.Header) {
+				w.WriteHeader(403)
+			} else {
+				w.WriteHeader(200)
+				w.Write([]byte(payload))
+			}
+		},
+	))
+}
+
+func TestGrafanaProviderOverrides(t *testing.T) {
+	p := NewGrafanaProvider(
+		&ProviderData{
+			LoginURL: &url.URL{
+				Scheme: "https",
+				Host:   "example.com",
+				Path:   "/index.php/apps/oauth2/authorize"},
+			RedeemURL: &url.URL{
+				Scheme: "https",
+				Host:   "example.com",
+				Path:   "/index.php/apps/oauth2/api/v1/token"},
+			ValidateURL: &url.URL{
+				Scheme: "https",
+				Host:   "example.com",
+				Path:   "/test/ocs/v2.php/cloud/user",
+			},
+			Scope: "profile"})
+	assert.NotEqual(t, nil, p)
+	assert.Equal(t, "Grafana", p.Data().ProviderName)
+	assert.Equal(t, "https://example.com/index.php/apps/oauth2/authorize",
+		p.Data().LoginURL.String())
+	assert.Equal(t, "https://example.com/index.php/apps/oauth2/api/v1/token",
+		p.Data().RedeemURL.String())
+	assert.Equal(t, "https://example.com/test/ocs/v2.php/cloud/user",
+		p.Data().ValidateURL.String())
+}
+
+func TestGrafanaProviderGetEmailAddress(t *testing.T) {
+	b := testGrafanaBackend(
+		`{"id": "1245", "email": "foo@bar.com", "emailConfirmed": 1}`,
+		grafanaUserPath,
+		"")
+	defer b.Close()
+
+	bURL, _ := url.Parse(b.URL)
+	p := testGrafanaProvider(bURL.Host)
+	p.ValidateURL.Path = grafanaUserPath
+
+	session := CreateAuthorizedSession()
+	email, err := p.GetEmailAddress(context.Background(), session)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "foo@bar.com", email)
+}
+
+// Note that trying to trigger the "failed building request" case is not
+// practical, since the only way it can fail is if the URL fails to parse.
+func TestGrafanaProviderGetEmailAddressFailedRequest(t *testing.T) {
+	b := testGrafanaBackend(
+		"unused payload",
+		grafanaUserPath,
+		"")
+	defer b.Close()
+
+	bURL, _ := url.Parse(b.URL)
+	p := testGrafanaProvider(bURL.Host)
+	p.ValidateURL.Path = grafanaUserPath
+
+	// We'll trigger a request failure by using an unexpected access
+	// token. Alternatively, we could allow the parsing of the payload as
+	// JSON to fail.
+	session := &sessions.SessionState{AccessToken: "unexpected_access_token"}
+	email, err := p.GetEmailAddress(context.Background(), session)
+	assert.NotEqual(t, nil, err)
+	assert.Equal(t, "", email)
+}
+
+func TestGrafanaProviderGetEmailAddressEmailNotPresentInPayload(t *testing.T) {
+	b := testGrafanaBackend(
+		`{"id": "1234", "emailConfirmed": 0}`,
+		grafanaUserPath,
+		"")
+	defer b.Close()
+
+	bURL, _ := url.Parse(b.URL)
+	p := testGrafanaProvider(bURL.Host)
+	p.ValidateURL.Path = grafanaUserPath
+
+	session := CreateAuthorizedSession()
+	email, err := p.GetEmailAddress(context.Background(), session)
+	assert.NotEqual(t, nil, err)
+	assert.Equal(t, "", email)
+}

--- a/providers/grafana_test.go
+++ b/providers/grafana_test.go
@@ -95,9 +95,9 @@ func TestGrafanaProviderGetEmailAddress(t *testing.T) {
 	p.ValidateURL.Path = grafanaUserPath
 
 	session := CreateAuthorizedSession()
-	email, err := p.GetEmailAddress(context.Background(), session)
+	err := p.EnrichSession(context.Background(), session)
 	assert.Equal(t, nil, err)
-	assert.Equal(t, "foo@bar.com", email)
+	assert.Equal(t, "foo@bar.com", session.Email)
 }
 
 // Note that trying to trigger the "failed building request" case is not
@@ -117,9 +117,9 @@ func TestGrafanaProviderGetEmailAddressFailedRequest(t *testing.T) {
 	// token. Alternatively, we could allow the parsing of the payload as
 	// JSON to fail.
 	session := &sessions.SessionState{AccessToken: "unexpected_access_token"}
-	email, err := p.GetEmailAddress(context.Background(), session)
+	err := p.EnrichSession(context.Background(), session)
 	assert.NotEqual(t, nil, err)
-	assert.Equal(t, "", email)
+	assert.Equal(t, "", session.Email)
 }
 
 func TestGrafanaProviderGetEmailAddressEmailNotPresentInPayload(t *testing.T) {
@@ -134,7 +134,7 @@ func TestGrafanaProviderGetEmailAddressEmailNotPresentInPayload(t *testing.T) {
 	p.ValidateURL.Path = grafanaUserPath
 
 	session := CreateAuthorizedSession()
-	email, err := p.GetEmailAddress(context.Background(), session)
+	err := p.EnrichSession(context.Background(), session)
 	assert.NotEqual(t, nil, err)
-	assert.Equal(t, "", email)
+	assert.Equal(t, "", session.Email)
 }

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -47,6 +47,8 @@ func New(provider string, p *ProviderData) Provider {
 		return NewDigitalOceanProvider(p)
 	case "google":
 		return NewGoogleProvider(p)
+	case "grafana":
+		return NewGrafanaProvider(p)
 	default:
 		return nil
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds [Grafana](https://grafana.com) as an OAuth provider to allow users to authenticate with.

_Note: I believe this provider is exclusively useful for grafana.com and not self-hosted Grafana instances. Therefore I'm not 100% sure on the provider name `grafana`, perhaps `grafana_cloud` is more apt._

## Motivation and Context
The main motivation for this is to protect Grafana datasources behind oauth2-proxy when exposed to Grafana Cloud. This is done by enabling `Forward OAuth Identity` in Grafana.
<img width="283" alt="image" src="https://user-images.githubusercontent.com/10098811/103482784-234b8980-4de3-11eb-945c-998ce7af19e3.png">

If set up correctly, the user's Grafana credentials will transiently be passed along from the Grafana instance to the data sources, flowing through the proxy.

Currently, this PR only supports authorizing `email_domains` for the account. I plan to extend this (either in this PR or preferably a subsequent PR) with ability to authorize on users memberships to Grafana organizations (similar to GitHub/GitLab)


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
I created a Grafana cloud org and registered an OAuth2 client for the organization.
I populated the oauth id/secret into oauth2 proxy and started the proxy.

I tested two things:

1. Login via Grafana through oauth2-proxy on web
Navigated to oauth2-proxy and sign-in, grant my registered application access to my Grafana account, and be proxied through to the upstreams.

2. In a Grafana Cloud instance
I set up an oauth2-proxy configured with my Grafana oauth credentials in front of a prometheus server. I added the url as a Prometheus datasource and check `Forward OAuth Identity`.
I clicked `Save & Test` and Grafana was able to reach my prometheus instance by passing through my OAuth identity to the proxy

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
