### PR TITLE
Update Overview.md / Auth.md : Add missing option "keycloak-group", update Keycloak Auth Provider configuration

### DIFF
--- a/docs/versioned_docs/version-6.1.x/configuration/overview.md
+++ b/docs/versioned_docs/version-6.1.x/configuration/overview.md
@@ -60,6 +60,7 @@ An example [oauth2-proxy.cfg](https://github.com/oauth2-proxy/oauth2-proxy/blob/
 | `--htpasswd-file` | string | additionally authenticate against a htpasswd file. Entries must be created with `htpasswd -s` for SHA encryption | |
 | `--http-address` | string | `[http://]<addr>:<port>` or `unix://<path>` to listen on for HTTP clients | `"127.0.0.1:4180"` |
 | `--https-address` | string | `<addr>:<port>` to listen on for HTTPS clients | `":443"` |
+| `--keycloak-group` | string | restrict logins to members of this keycloak group. | |
 | `--logging-compress` | bool | Should rotated log files be compressed using gzip | false |
 | `--logging-filename` | string | File to log requests to, empty for `stdout` | `""` (stdout) |
 | `--logging-local-time` | bool | Use local time in log files and backup filenames instead of UTC | true (local time) |
@@ -82,7 +83,7 @@ An example [oauth2-proxy.cfg](https://github.com/oauth2-proxy/oauth2-proxy/blob/
 | `--profile-url` | string | Profile access endpoint | |
 | `--prompt` | string | [OIDC prompt](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest); if present, `approval-prompt` is ignored | `""` |
 | `--provider` | string | OAuth provider | google |
-| `--provider-ca-file` |  string \| list |  Paths to CA certificates that should be used when connecting to the provider.  If not specified, the default Go trust sources are used instead. |
+| `--provider-ca-files` |  string \| list |  Paths to CA certificates that should be used when connecting to the provider.  If not specified, the default Go trust sources are used instead. |
 | `--provider-display-name` | string | Override the provider's name with the given string; used for the sign-in page | (depends on provider) |
 | `--ping-path` | string | the ping endpoint that can be used for basic health checks | `"/ping"` |
 | `--ping-user-agent` | string | a User-Agent that can be used for basic health checks | `""` (don't check user agent) |
@@ -124,7 +125,7 @@ An example [oauth2-proxy.cfg](https://github.com/oauth2-proxy/oauth2-proxy/blob/
 | `--standard-logging-format` | string | Template for standard log lines | see [Logging Configuration](#logging-configuration) |
 | `--tls-cert-file` | string | path to certificate file | |
 | `--tls-key-file` | string | path to private key file | |
-| `--upstream` | string \| list | the http url(s) of the upstream endpoint, file:// paths for static files or `static://<status_code>` for static response. Routing is based on the path | |
+| `--upstreams` | string \| list | the http url(s) of the upstream endpoint, file:// paths for static files or `static://<status_code>` for static response. Routing is based on the path | |
 | `--user-id-claim` | string | which claim contains the user ID | \["email"\] |
 | `--validate-url` | string | Access token validation endpoint | |
 | `--version` | n/a | print version string | |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Update Overview.md page so that the options / flags correctly reflect in [Configuration - Overview](https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/overview) page.
- Update Auth.md page concerning Keycloak Auth Provider configuration : Provide additional details in oauth2 proxy options and Keycloak configuration steps required for successful containers start up and user login via proxy.

## Motivation and Context

While working on [Securing Kibana using OAuth2 Proxy](https://github.com/dcm4che/dcm4chee-arc-light/issues/2820) docker container [wiki](https://github.com/dcm4che/dcm4chee-arc-light/wiki/Secure-Kibana-using-OAuth2-Proxy), I found that following flags were missing or incorrectly documented. After going through some code of OAuth2 Proxy, I figured out the right configuration option / flag names.
- `--keycloak-group` options is specified in [Keycloak Auth Provider configuration](https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/oauth_provider#keycloak-auth-provider) but is missing in [Overview - Command Line options](https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/overview#command-line-options)
- [Keycloak Auth Provider](https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/oauth_provider#keycloak-auth-provider) configuration is very limited / incomplete for oauth2 proxy docker container to successfully startup. Also 2 additional points in Keycloak configuration settings were missing for an authorized user to successfully login and get redirected to Upstream endpoint.

## How Has This Been Tested?

Using the specified [OAuth2 Proxy docker configuration](https://github.com/dcm4che/dcm4chee-arc-light/wiki/Secure-Kibana-using-OAuth2-Proxy#oauth2-proxy) which contains the above flags correctly specified, I'm able to successfully secure Kibana and post login access Kibana's Dashboard. i.e. using : 
- `OAUTH2_PROXY_KEYCLOAK_GROUP` : `Token Claim Name` value in the created Mapper
- `OAUTH2_PROXY_REDIRECT_URL` : Value same as `Valid Redirect URI` configured in Keycloak Client
- `OAUTH2_PROXY_SCOPE: openid`
- `OAUTH2_PROXY_EMAIL_DOMAINS: "*"`
- `OAUTH2_PROXY_COOKIE_SECRET: <some-(base64 encoded)-value>` : Ensure the cookie secret is 16, 24, or 32 bytes long.
- `OAUTH2_PROXY_UPSTREAMS: "http(s)://<upstream-endpoint>"`

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
