### PR TITLE
Add Gitlab version warning/constaint in documentation

### DIFF
--- a/docs/docs/configuration/auth.md
+++ b/docs/docs/configuration/auth.md
@@ -157,6 +157,8 @@ you should define the 'keycloak-group' value to /admin.
 
 ### GitLab Auth Provider
 
+This auth provider has been tested against Gitlab version 12.X. Due to Gitlab API changes, it may not work for version prior to 12.X (see [994](https://github.com/oauth2-proxy/oauth2-proxy/issues/994)).
+
 Whether you are using GitLab.com or self-hosting GitLab, follow [these steps to add an application](https://docs.gitlab.com/ce/integration/oauth_provider.html). Make sure to enable at least the `openid`, `profile` and `email` scopes, and set the redirect url to your application url e.g. https://myapp.com/oauth2/callback.
 
 If you need projects filtering, add the extra `read_api` scope to your application.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Doc update to warn users about minimal Gitlab version requirements for the Gitlab OAuth provider.

<!--- Describe your changes in detail -->

## Motivation and Context

This is caused by issue #994. The added note will be useful to prevent more issue like the one mentioned.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [X] I have created a feature (non-master) branch for my PR.

@NickMeves 