### PR TITLE
Use JWTBearerVerifiers to validate OIDC token.

### DIFF
--- a/pkg/validation/options.go
+++ b/pkg/validation/options.go
@@ -238,6 +238,7 @@ func parseProviderInfo(o *options.Options, msgs []string) []string {
 	p.EmailClaim = o.OIDCEmailClaim
 	p.GroupsClaim = o.OIDCGroupsClaim
 	p.Verifier = o.GetOIDCVerifier()
+	p.JWTBearerVerifiers = o.GetJWTBearerVerifiers()
 
 	// TODO (@NickMeves) - Remove This
 	// Backwards Compatibility for Deprecated UserIDClaim option

--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -181,9 +181,18 @@ func (p *OIDCProvider) redeemRefreshToken(ctx context.Context, s *sessions.Sessi
 func (p *OIDCProvider) CreateSessionFromToken(ctx context.Context, token string) (*sessions.SessionState, error) {
 	idToken, err := p.Verifier.Verify(ctx, token)
 	if err != nil {
-		return nil, err
+		for _, jwtBearerVerifier := range p.JWTBearerVerifiers {
+			if idToken2, err2 := jwtBearerVerifier.Verify(ctx, token); err2 == nil {
+				idToken = idToken2
+				err = nil
+				break
+			}
+		}
 	}
 
+	if err != nil {
+		return nil, err
+	}
 	ss, err := p.buildSessionFromClaims(idToken)
 	if err != nil {
 		return nil, err

--- a/providers/provider_data.go
+++ b/providers/provider_data.go
@@ -44,6 +44,7 @@ type ProviderData struct {
 	EmailClaim           string
 	GroupsClaim          string
 	Verifier             *oidc.IDTokenVerifier
+	JWTBearerVerifiers   []*oidc.IDTokenVerifier
 
 	// Universal Group authorization data structure
 	// any provider can set to consume


### PR DESCRIPTION
## Description

If the OIDC validation fails, use JWT Bearer validation (if configured)

## Motivation and Context

It implements the feature #993 

## How Has This Been Tested?

Manual tests have been performed, using --extra-jwt-issuer

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
