### PR TITLE
Flatten array-based response headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Changes since v7.0.0
 
+- [#1020](https://github.com/oauth2-proxy/oauth2-proxy/pull/1020) Flatten array-based response headers (@NickMeves)
+
 # V7.0.0
 
 ## Release Highlights

--- a/pkg/middleware/headers.go
+++ b/pkg/middleware/headers.go
@@ -108,7 +108,7 @@ func injectResponseHeaders(injector header.Injector, next http.Handler) http.Han
 		// If scope is nil, this will panic.
 		// A scope should always be injected before this handler is called.
 		injector.Inject(rw.Header(), scope.Session)
-		flattenHeaders(req.Header)
+		flattenHeaders(rw.Header())
 		next.ServeHTTP(rw, req)
 	})
 }

--- a/pkg/middleware/headers_test.go
+++ b/pkg/middleware/headers_test.go
@@ -249,7 +249,7 @@ var _ = Describe("Headers Suite", func() {
 			},
 			session: &sessionsapi.SessionState{},
 			expectedHeaders: http.Header{
-				"Foo": []string{"bar", "baz"},
+				"Foo": []string{"bar,baz"},
 			},
 			expectedErr: "",
 		}),
@@ -273,7 +273,7 @@ var _ = Describe("Headers Suite", func() {
 				IDToken: "IDToken-1234",
 			},
 			expectedHeaders: http.Header{
-				"Foo":   []string{"bar", "baz"},
+				"Foo":   []string{"bar,baz"},
 				"Claim": []string{"IDToken-1234"},
 			},
 			expectedErr: "",
@@ -298,7 +298,7 @@ var _ = Describe("Headers Suite", func() {
 				IDToken: "IDToken-1234",
 			},
 			expectedHeaders: http.Header{
-				"Claim": []string{"bar", "baz", "IDToken-1234"},
+				"Claim": []string{"bar,baz,IDToken-1234"},
 			},
 			expectedErr: "",
 		}),
@@ -323,7 +323,7 @@ var _ = Describe("Headers Suite", func() {
 				IDToken: "IDToken-1234",
 			},
 			expectedHeaders: http.Header{
-				"Claim": []string{"bar", "baz", "IDToken-1234"},
+				"Claim": []string{"bar,baz,IDToken-1234"},
 			},
 			expectedErr: "",
 		}),
@@ -345,7 +345,7 @@ var _ = Describe("Headers Suite", func() {
 			},
 			session: nil,
 			expectedHeaders: http.Header{
-				"Claim": []string{"bar", "baz"},
+				"Claim": []string{"bar,baz"},
 			},
 			expectedErr: "",
 		}),
@@ -368,7 +368,7 @@ var _ = Describe("Headers Suite", func() {
 			},
 			session: nil,
 			expectedHeaders: http.Header{
-				"Claim": []string{"bar", "baz"},
+				"Claim": []string{"bar,baz"},
 			},
 			expectedErr: "",
 		}),


### PR DESCRIPTION
https://github.com/oauth2-proxy/oauth2-proxy/issues/1017

## Description

Array response headers weren't flattened, the `flattenHeaders` help was called on `req.Header`

## How Has This Been Tested?

Unit Tests

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
