### PR TITLE
Update release process to use makefile go version check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ test: lint
 	GO111MODULE=on $(GO) test $(TESTCOVER) -v -race ./...
 
 .PHONY: release
-release: lint test
+release: validate-go-version lint test
 	BINARY=${BINARY} VERSION=${VERSION} ./dist.sh
 
 .PHONY: validate-go-version

--- a/dist.sh
+++ b/dist.sh
@@ -7,13 +7,6 @@ if [[ -z ${BINARY} ]] || [[ -z ${VERSION} ]]; then
 	exit 1
 fi
 
-# Check for Go version 1.14.*
-GO_VERSION=$(go version | awk '{print $3}')
-if [[ ! "${GO_VERSION}" =~ ^go1.14.* ]]; then
-	echo "Go version must be >= go1.14"
-	exit 1
-fi
-
 ARCHS=(darwin-amd64 linux-amd64 linux-arm64 linux-armv6 freebsd-amd64 windows-amd64)
 
 mkdir -p release
@@ -28,10 +21,10 @@ for ARCH in "${ARCHS[@]}"; do
 	# Create architecture specific binaries
 	if [[ ${GO_ARCH} == "armv6" ]]; then
 		GO111MODULE=on GOOS=${GO_OS} GOARCH=arm GOARM=6 CGO_ENABLED=0 go build -ldflags="-X main.VERSION=${VERSION}" \
-			-o release/${BINARY}-${VERSION}.${ARCH}/${BINARY} github.com/oauth2-proxy/oauth2-proxy
+			-o release/${BINARY}-${VERSION}.${ARCH}/${BINARY} .
 	else
 		GO111MODULE=on GOOS=${GO_OS} GOARCH=${GO_ARCH} CGO_ENABLED=0 go build -ldflags="-X main.VERSION=${VERSION}" \
-			-o release/${BINARY}-${VERSION}.${ARCH}/${BINARY} github.com/oauth2-proxy/oauth2-proxy
+			-o release/${BINARY}-${VERSION}.${ARCH}/${BINARY} .
 	fi
 
 	cd release


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Remove the go version check in the release script and instead use the makefile version check on release instead.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Even though I have go1.15, I couldn't make a release with the script as it was.
Since we already have a go version check in the makefile it makes sense to just use the one check.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually testing during release process.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
