### PR TITLE
Refactor error page rendering and allow debug messages on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Changes since v7.0.1
 
+- [#1029](https://github.com/oauth2-proxy/oauth2-proxy/pull/1029) Refactor error page rendering and allow debug messages on error (@JoelSpeed)
 - [#1028](https://github.com/oauth2-proxy/oauth2-proxy/pull/1028) Refactor templates, update theme and provide styled error pages (@JoelSpeed)
 - [#1039](https://github.com/oauth2-proxy/oauth2-proxy/pull/1039) Ensure errors in tests are logged to the GinkgoWriter (@JoelSpeed)
 

--- a/docs/docs/configuration/overview.md
+++ b/docs/docs/configuration/overview.md
@@ -115,6 +115,7 @@ An example [oauth2-proxy.cfg](https://github.com/oauth2-proxy/oauth2-proxy/blob/
 | `--set-xauthrequest` | bool | set X-Auth-Request-User, X-Auth-Request-Groups, X-Auth-Request-Email and X-Auth-Request-Preferred-Username response headers (useful in Nginx auth_request mode). When used with `--pass-access-token`, X-Auth-Request-Access-Token is added to response headers.  | false |
 | `--set-authorization-header` | bool | set Authorization Bearer response header (useful in Nginx auth_request mode) | false |
 | `--set-basic-auth` | bool | set HTTP Basic Auth information in response (useful in Nginx auth_request mode) | false |
+| `--show-debug-on-error` | bool | show detailed error information on error pages (WARNING: this may contain sensitive information - do not use in production) | false |
 | `--signature-key` | string | GAP-Signature request signature key (algorithm:secretkey) | |
 | `--silence-ping-logging` | bool | disable logging of requests to ping endpoint | false |
 | `--skip-auth-preflight` | bool | will skip authentication for OPTIONS requests | false |

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -122,8 +122,15 @@ func NewOAuthProxy(opts *options.Options, validator func(string) bool) (*OAuthPr
 	if err != nil {
 		return nil, fmt.Errorf("error loading templates: %v", err)
 	}
-	proxyErrorHandler := upstream.NewProxyErrorHandler(templates.Lookup("error.html"), opts.ProxyPrefix)
-	upstreamProxy, err := upstream.NewProxy(opts.UpstreamServers, opts.GetSignatureData(), proxyErrorHandler)
+
+	errorPage := &app.ErrorPage{
+		Template:    templates.Lookup("error.html"),
+		ProxyPrefix: opts.ProxyPrefix,
+		Footer:      opts.Templates.Footer,
+		Version:     VERSION,
+	}
+
+	upstreamProxy, err := upstream.NewProxy(opts.UpstreamServers, opts.GetSignatureData(), errorPage.ProxyErrorHandler)
 	if err != nil {
 		return nil, fmt.Errorf("error initialising upstream proxy: %v", err)
 	}
@@ -225,12 +232,7 @@ func NewOAuthProxy(opts *options.Options, validator func(string) bool) (*OAuthPr
 		sessionChain:        sessionChain,
 		headersChain:        headersChain,
 		preAuthChain:        preAuthChain,
-		errorPage: &app.ErrorPage{
-			Template:    templates.Lookup("error.html"),
-			ProxyPrefix: opts.ProxyPrefix,
-			Footer:      opts.Templates.Footer,
-			Version:     VERSION,
-		},
+		errorPage:           errorPage,
 	}, nil
 }
 

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -2815,7 +2815,7 @@ func TestProxyAllowedGroups(t *testing.T) {
 			test.proxy.ServeHTTP(test.rw, test.req)
 
 			if tt.expectUnauthorized {
-				assert.Equal(t, http.StatusUnauthorized, test.rw.Code)
+				assert.Equal(t, http.StatusForbidden, test.rw.Code)
 			} else {
 				assert.Equal(t, http.StatusOK, test.rw.Code)
 			}

--- a/pkg/apis/options/app.go
+++ b/pkg/apis/options/app.go
@@ -22,6 +22,12 @@ type Templates struct {
 	// password form if a static passwords file (htpasswd file) has been
 	// configured.
 	DisplayLoginForm bool `flag:"display-htpasswd-form" cfg:"display_htpasswd_form"`
+
+	// Debug renders detailed errors when an error page is shown.
+	// It is not advised to use this in production as errors may contain sensitive
+	// information.
+	// Use only for diagnosing backend errors.
+	Debug bool `flag:"show-debug-on-error" cfg:"show-debug-on-error"`
 }
 
 func templatesFlagSet() *pflag.FlagSet {
@@ -31,6 +37,7 @@ func templatesFlagSet() *pflag.FlagSet {
 	flagSet.String("banner", "", "custom banner string. Use \"-\" to disable default banner.")
 	flagSet.String("footer", "", "custom footer string. Use \"-\" to disable default footer.")
 	flagSet.Bool("display-htpasswd-form", true, "display username / password login form if an htpasswd file is provided")
+	flagSet.Bool("show-debug-on-error", false, "show detailed error information on error pages (WARNING: this may contain sensitive information - do not use in production)")
 
 	return flagSet
 }

--- a/pkg/app/error_page.go
+++ b/pkg/app/error_page.go
@@ -54,3 +54,11 @@ func (e *ErrorPage) Render(rw http.ResponseWriter, status int, redirectURL strin
 		http.Error(rw, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 	}
 }
+
+// ProxyErrorHandler is used by the upstream ReverseProxy to render error pages
+// when there are issues with upstream servers.
+// It is expected to always render a bad gateway error.
+func (e *ErrorPage) ProxyErrorHandler(rw http.ResponseWriter, req *http.Request, proxyErr error) {
+	logger.Errorf("Error proxying to upstream server: %v", proxyErr)
+	e.Render(rw, http.StatusBadGateway, "", "Error proxying to upstream server")
+}

--- a/pkg/app/error_page.go
+++ b/pkg/app/error_page.go
@@ -1,0 +1,56 @@
+package app
+
+import (
+	"html/template"
+	"net/http"
+
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/logger"
+)
+
+// ErrorPage is used to render error pages.
+type ErrorPage struct {
+	// Template is the error page HTML template.
+	Template *template.Template
+
+	// ProxyPrefix is the prefix under which OAuth2 Proxy pages are served.
+	ProxyPrefix string
+
+	// Footer is the footer to be displayed at the bottom of the page.
+	// If not set, a default footer will be used.
+	Footer string
+
+	// Version is the OAuth2 Proxy version to be used in the default footer.
+	Version string
+}
+
+// Render writes an error page to the given response writer.
+// It uses the passed redirectURL to give users the option to go back to where
+// they originally came from or try signing in again.
+func (e *ErrorPage) Render(rw http.ResponseWriter, status int, redirectURL string, appError string) {
+	rw.WriteHeader(status)
+
+	// We allow unescaped template.HTML since it is user configured options
+	/* #nosec G203 */
+	data := struct {
+		Title       string
+		Message     string
+		ProxyPrefix string
+		StatusCode  int
+		Redirect    string
+		Footer      template.HTML
+		Version     string
+	}{
+		Title:       http.StatusText(status),
+		Message:     appError,
+		ProxyPrefix: e.ProxyPrefix,
+		StatusCode:  status,
+		Redirect:    redirectURL,
+		Footer:      template.HTML(e.Footer),
+		Version:     e.Version,
+	}
+
+	if err := e.Template.Execute(rw, data); err != nil {
+		logger.Printf("Error rendering error template: %v", err)
+		http.Error(rw, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+	}
+}

--- a/pkg/app/error_page.go
+++ b/pkg/app/error_page.go
@@ -1,11 +1,21 @@
 package app
 
 import (
+	"fmt"
 	"html/template"
 	"net/http"
 
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/logger"
 )
+
+// errorMessages are default error messages for each of the the different
+// http status codes expected to be rendered in the error page.
+var errorMessages = map[int]string{
+	http.StatusInternalServerError: "Oops! Something went wrong. For more information contact your server administrator.",
+	http.StatusNotFound:            "We could not find the resource you were looking for.",
+	http.StatusForbidden:           "You do not have permission to access this resource.",
+	http.StatusUnauthorized:        "You need to be logged in to access this resource.",
+}
 
 // ErrorPage is used to render error pages.
 type ErrorPage struct {
@@ -21,12 +31,16 @@ type ErrorPage struct {
 
 	// Version is the OAuth2 Proxy version to be used in the default footer.
 	Version string
+
+	// Debug determines whether errors pages should be rendered with detailed
+	// errors.
+	Debug bool
 }
 
 // Render writes an error page to the given response writer.
 // It uses the passed redirectURL to give users the option to go back to where
 // they originally came from or try signing in again.
-func (e *ErrorPage) Render(rw http.ResponseWriter, status int, redirectURL string, appError string) {
+func (e *ErrorPage) Render(rw http.ResponseWriter, status int, redirectURL string, appError string, messages ...interface{}) {
 	rw.WriteHeader(status)
 
 	// We allow unescaped template.HTML since it is user configured options
@@ -41,7 +55,7 @@ func (e *ErrorPage) Render(rw http.ResponseWriter, status int, redirectURL strin
 		Version     string
 	}{
 		Title:       http.StatusText(status),
-		Message:     appError,
+		Message:     e.getMessage(status, appError, messages...),
 		ProxyPrefix: e.ProxyPrefix,
 		StatusCode:  status,
 		Redirect:    redirectURL,
@@ -60,5 +74,24 @@ func (e *ErrorPage) Render(rw http.ResponseWriter, status int, redirectURL strin
 // It is expected to always render a bad gateway error.
 func (e *ErrorPage) ProxyErrorHandler(rw http.ResponseWriter, req *http.Request, proxyErr error) {
 	logger.Errorf("Error proxying to upstream server: %v", proxyErr)
-	e.Render(rw, http.StatusBadGateway, "", "Error proxying to upstream server")
+	e.Render(rw, http.StatusBadGateway, "", proxyErr.Error(), "There was a problem connecting to the upstream server.")
+}
+
+// getMessage creates the message for the template parameters.
+// If the ErrorPage.Debug is enabled, the application error takes precedence.
+// Otherwise, any messages will be used.
+// The first message is expected to be a format string.
+// If no messages are supplied, a default error message will be used.
+func (e *ErrorPage) getMessage(status int, appError string, messages ...interface{}) string {
+	if e.Debug {
+		return appError
+	}
+	if len(messages) > 0 {
+		format := fmt.Sprintf("%v", messages[0])
+		return fmt.Sprintf(format, messages[1:]...)
+	}
+	if msg, ok := errorMessages[status]; ok {
+		return msg
+	}
+	return "Unknown error"
 }

--- a/pkg/app/error_page_test.go
+++ b/pkg/app/error_page_test.go
@@ -32,7 +32,25 @@ var _ = Describe("Error Page", func() {
 
 			body, err := ioutil.ReadAll(recorder.Result().Body)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(string(body)).To(Equal("Forbidden Access Denied /prefix/ 403 /redirect Custom Footer Text v0.0.0-test"))
+			Expect(string(body)).To(Equal("Forbidden You do not have permission to access this resource. /prefix/ 403 /redirect Custom Footer Text v0.0.0-test"))
+		})
+
+		It("With a different code, uses the stock message for the correct code", func() {
+			recorder := httptest.NewRecorder()
+			errorPage.Render(recorder, 500, "/redirect", "Access Denied")
+
+			body, err := ioutil.ReadAll(recorder.Result().Body)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(body)).To(Equal("Internal Server Error Oops! Something went wrong. For more information contact your server administrator. /prefix/ 500 /redirect Custom Footer Text v0.0.0-test"))
+		})
+
+		It("With a message override, uses the message", func() {
+			recorder := httptest.NewRecorder()
+			errorPage.Render(recorder, 403, "/redirect", "Access Denied", "An extra message: %s", "with more context.")
+
+			body, err := ioutil.ReadAll(recorder.Result().Body)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(body)).To(Equal("Forbidden An extra message: with more context. /prefix/ 403 /redirect Custom Footer Text v0.0.0-test"))
 		})
 	})
 
@@ -44,7 +62,40 @@ var _ = Describe("Error Page", func() {
 
 			body, err := ioutil.ReadAll(recorder.Result().Body)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(string(body)).To(Equal("Bad Gateway Error proxying to upstream server /prefix/ 502  Custom Footer Text v0.0.0-test"))
+			Expect(string(body)).To(Equal("Bad Gateway There was a problem connecting to the upstream server. /prefix/ 502  Custom Footer Text v0.0.0-test"))
+		})
+	})
+
+	Context("With Debug enabled", func() {
+		BeforeEach(func() {
+			tmpl, err := template.New("").Parse("{{.Message}}")
+			Expect(err).ToNot(HaveOccurred())
+
+			errorPage.Template = tmpl
+			errorPage.Debug = true
+		})
+
+		Context("Render", func() {
+			It("Writes the detailed error in place of the message", func() {
+				recorder := httptest.NewRecorder()
+				errorPage.Render(recorder, 403, "/redirect", "Debug error")
+
+				body, err := ioutil.ReadAll(recorder.Result().Body)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(string(body)).To(Equal("Debug error"))
+			})
+		})
+
+		Context("ProxyErrorHandler", func() {
+			It("Writes a bad gateway error the response writer", func() {
+				req := httptest.NewRequest("", "/bad-gateway", nil)
+				recorder := httptest.NewRecorder()
+				errorPage.ProxyErrorHandler(recorder, req, errors.New("some upstream error"))
+
+				body, err := ioutil.ReadAll(recorder.Result().Body)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(string(body)).To(Equal("some upstream error"))
+			})
 		})
 	})
 })

--- a/pkg/app/error_page_test.go
+++ b/pkg/app/error_page_test.go
@@ -1,0 +1,35 @@
+package app
+
+import (
+	"html/template"
+	"io/ioutil"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Error Page", func() {
+
+	Context("Render", func() {
+		It("Writes the template to the response writer", func() {
+			tmpl, err := template.New("").Parse("{{.Title}} {{.Message}} {{.ProxyPrefix}} {{.StatusCode}} {{.Redirect}} {{.Footer}} {{.Version}}")
+			Expect(err).ToNot(HaveOccurred())
+
+			errorPage := &ErrorPage{
+				Template:    tmpl,
+				ProxyPrefix: "/prefix/",
+				Footer:      "Custom Footer Text",
+				Version:     "v0.0.0-test",
+			}
+
+			recorder := httptest.NewRecorder()
+			errorPage.Render(recorder, 403, "/redirect", "Access Denied")
+
+			body, err := ioutil.ReadAll(recorder.Result().Body)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(body)).To(Equal("Forbidden Access Denied /prefix/ 403 /redirect Custom Footer Text v0.0.0-test"))
+		})
+	})
+
+})

--- a/pkg/app/templates.go
+++ b/pkg/app/templates.go
@@ -79,6 +79,7 @@ const (
   		</div>
       {{ end }}
 
+      {{ if .Redirect }}
       <hr>
 
       <div class="columns">
@@ -94,6 +95,7 @@ const (
           </form>
         </div>
       </div>
+      {{ end }}
 
     </div>
   </section>

--- a/pkg/upstream/proxy.go
+++ b/pkg/upstream/proxy.go
@@ -2,7 +2,6 @@ package upstream
 
 import (
 	"fmt"
-	"html/template"
 	"net/http"
 	"net/url"
 
@@ -70,25 +69,4 @@ func (m *multiUpstreamProxy) registerFileServer(upstream options.Upstream, u *ur
 func (m *multiUpstreamProxy) registerHTTPUpstreamProxy(upstream options.Upstream, u *url.URL, sigData *options.SignatureData, errorHandler ProxyErrorHandler) {
 	logger.Printf("mapping path %q => upstream %q", upstream.Path, upstream.URI)
 	m.serveMux.Handle(upstream.Path, newHTTPUpstreamProxy(upstream, u, sigData, errorHandler))
-}
-
-// NewProxyErrorHandler creates a ProxyErrorHandler using the template given.
-func NewProxyErrorHandler(errorTemplate *template.Template, proxyPrefix string) ProxyErrorHandler {
-	return func(rw http.ResponseWriter, req *http.Request, proxyErr error) {
-		logger.Errorf("Error proxying to upstream server: %v", proxyErr)
-		rw.WriteHeader(http.StatusBadGateway)
-		data := struct {
-			Title       string
-			Message     string
-			ProxyPrefix string
-		}{
-			Title:       "Bad Gateway",
-			Message:     "Error proxying to upstream server",
-			ProxyPrefix: proxyPrefix,
-		}
-		err := errorTemplate.Execute(rw, data)
-		if err != nil {
-			http.Error(rw, "Internal Server Error", http.StatusInternalServerError)
-		}
-	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
This moves the error page rendering to its own struct (with the required information captured) to break it apart from the main OAuth2 Proxy app.

This also adds a debug option so that detailed errors can be shown for users who choose this, on the error page.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Improve the debug experience by rendering detailed errors in the web page when an authentication flow fails.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually with the local testing environment.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
- [x] I have added appropriate comments throughout
- [x] I have added appropriate tests throughout
