### PR TITLE
Ensure errors in tests are logged to the GinkgoWriter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Changes since v7.0.1
 
+- [#1039](https://github.com/oauth2-proxy/oauth2-proxy/pull/1039) Ensure errors in tests are logged to the GinkgoWriter (@JoelSpeed)
+
 # V7.0.1
 
 ## Release Highlights

--- a/main_suite_test.go
+++ b/main_suite_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestMainSuite(t *testing.T) {
 	logger.SetOutput(GinkgoWriter)
+	logger.SetErrOutput(GinkgoWriter)
 
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Main Suite")

--- a/pkg/apis/middleware/middleware_suite_test.go
+++ b/pkg/apis/middleware/middleware_suite_test.go
@@ -13,6 +13,7 @@ import (
 // this functionality
 func TestMiddlewareSuite(t *testing.T) {
 	logger.SetOutput(GinkgoWriter)
+	logger.SetErrOutput(GinkgoWriter)
 
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Middleware API")

--- a/pkg/apis/options/options_suite_test.go
+++ b/pkg/apis/options/options_suite_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestOptionsSuite(t *testing.T) {
 	logger.SetOutput(GinkgoWriter)
+	logger.SetErrOutput(GinkgoWriter)
 
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Options Suite")

--- a/pkg/apis/options/util/util_suite_test.go
+++ b/pkg/apis/options/util/util_suite_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestUtilSuite(t *testing.T) {
 	logger.SetOutput(GinkgoWriter)
+	logger.SetErrOutput(GinkgoWriter)
 
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Options Util Suite")

--- a/pkg/authentication/basic/basic_suite_test.go
+++ b/pkg/authentication/basic/basic_suite_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestBasicSuite(t *testing.T) {
 	logger.SetOutput(GinkgoWriter)
+	logger.SetErrOutput(GinkgoWriter)
 
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Basic")

--- a/pkg/header/header_suite_test.go
+++ b/pkg/header/header_suite_test.go
@@ -17,6 +17,7 @@ var (
 
 func TestHeaderSuite(t *testing.T) {
 	logger.SetOutput(GinkgoWriter)
+	logger.SetErrOutput(GinkgoWriter)
 
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Header")

--- a/pkg/middleware/middleware_suite_test.go
+++ b/pkg/middleware/middleware_suite_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestMiddlewareSuite(t *testing.T) {
 	logger.SetOutput(GinkgoWriter)
+	logger.SetErrOutput(GinkgoWriter)
 
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Middleware")

--- a/pkg/requests/requests_suite_test.go
+++ b/pkg/requests/requests_suite_test.go
@@ -21,6 +21,7 @@ var (
 
 func TestRequetsSuite(t *testing.T) {
 	logger.SetOutput(GinkgoWriter)
+	logger.SetErrOutput(GinkgoWriter)
 	log.SetOutput(GinkgoWriter)
 
 	RegisterFailHandler(Fail)

--- a/pkg/requests/util/util_suite_test.go
+++ b/pkg/requests/util/util_suite_test.go
@@ -13,6 +13,7 @@ import (
 // this functionality
 func TestRequestUtilSuite(t *testing.T) {
 	logger.SetOutput(GinkgoWriter)
+	logger.SetErrOutput(GinkgoWriter)
 
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Request Utils")

--- a/pkg/sessions/cookie/session_store_test.go
+++ b/pkg/sessions/cookie/session_store_test.go
@@ -19,6 +19,8 @@ import (
 
 func TestSessionStore(t *testing.T) {
 	logger.SetOutput(GinkgoWriter)
+	logger.SetErrOutput(GinkgoWriter)
+
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Cookie SessionStore")
 }

--- a/pkg/sessions/persistence/persistence_suite_test.go
+++ b/pkg/sessions/persistence/persistence_suite_test.go
@@ -10,6 +10,8 @@ import (
 
 func TestPersistenceSuite(t *testing.T) {
 	logger.SetOutput(GinkgoWriter)
+	logger.SetErrOutput(GinkgoWriter)
+
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Persistence")
 }

--- a/pkg/sessions/redis/redis_store_test.go
+++ b/pkg/sessions/redis/redis_store_test.go
@@ -33,6 +33,7 @@ func (l *wrappedRedisLogger) Printf(_ context.Context, format string, v ...inter
 
 func TestSessionStore(t *testing.T) {
 	logger.SetOutput(GinkgoWriter)
+	logger.SetErrOutput(GinkgoWriter)
 
 	redisLogger := &wrappedRedisLogger{Logger: log.New(os.Stderr, "redis: ", log.LstdFlags|log.Lshortfile)}
 	redisLogger.SetOutput(GinkgoWriter)

--- a/pkg/sessions/session_store_test.go
+++ b/pkg/sessions/session_store_test.go
@@ -18,6 +18,7 @@ import (
 
 func TestSessionStore(t *testing.T) {
 	logger.SetOutput(GinkgoWriter)
+	logger.SetErrOutput(GinkgoWriter)
 
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "SessionStore")

--- a/pkg/upstream/upstream_suite_test.go
+++ b/pkg/upstream/upstream_suite_test.go
@@ -26,6 +26,7 @@ var (
 
 func TestUpstreamSuite(t *testing.T) {
 	logger.SetOutput(GinkgoWriter)
+	logger.SetErrOutput(GinkgoWriter)
 	log.SetOutput(GinkgoWriter)
 
 	RegisterFailHandler(Fail)

--- a/pkg/validation/validation_suite_test.go
+++ b/pkg/validation/validation_suite_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestValidationSuite(t *testing.T) {
 	logger.SetOutput(GinkgoWriter)
+	logger.SetErrOutput(GinkgoWriter)
 
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Validation Suite")

--- a/providers/providers_suite_test.go
+++ b/providers/providers_suite_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestProviderSuite(t *testing.T) {
 	logger.SetOutput(GinkgoWriter)
+	logger.SetErrOutput(GinkgoWriter)
 
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Providers")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Ensure that all logger output is captured by the `GinkgoWriter`

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When writing tests in Ginkgo, we can set the log output to be captured by the `GinkgoWriter`.
By doing so, it captures the logs and collates those logs for specific tests cases.
If a test case fails, it can show exactly the logs for that test case.

We used to have this working everywhere but then we added a separate error log output which broke this.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests are passing, and the error logs are no longer polluting the test log.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
