### PR TITLE
fix: OIDC provider's refresh method ignores the actual refresh period

### DIFF
--- a/pkg/middleware/stored_session.go
+++ b/pkg/middleware/stored_session.go
@@ -132,7 +132,7 @@ func (s *storedSessionLoader) refreshSessionIfNeeded(rw http.ResponseWriter, req
 	return nil
 }
 
-// refreshSessionWithProvider attempts to refresh the sessinon with the provider
+// refreshSessionWithProvider attempts to refresh the session with the provider
 // and will save the session if it was updated.
 func (s *storedSessionLoader) refreshSessionWithProvider(rw http.ResponseWriter, req *http.Request, session *sessionsapi.SessionState) (bool, error) {
 	refreshed, err := s.refreshSessionWithProviderIfNeeded(req.Context(), session)

--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -113,10 +113,10 @@ func (p *OIDCProvider) ValidateSession(ctx context.Context, s *sessions.SessionS
 	return err == nil
 }
 
-// RefreshSessionIfNeeded checks if the session has expired and uses the
+// RefreshSessionIfNeeded uses the
 // RefreshToken to fetch a new Access Token (and optional ID token) if required
 func (p *OIDCProvider) RefreshSessionIfNeeded(ctx context.Context, s *sessions.SessionState) (bool, error) {
-	if s == nil || (s.ExpiresOn != nil && s.ExpiresOn.After(time.Now())) || s.RefreshToken == "" {
+	if s == nil || s.RefreshToken == "" {
 		return false, nil
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

As mentioned in #793, especially in comment [739 - comment from @peppered](https://github.com/oauth2-proxy/oauth2-proxy/issues/793#issuecomment-748952258), the oidc provider ignores the actual refresh period set by `cookie_refresh`.

## Motivation and Context

When e.g. using the access token as a bearer token for upstream authentication / authorization the cookie used will not be refreshed due to the different ways refreshing cookies are handled. 

I'll quote from @peppered here (issue and comment referenced above), which explains the issue in detail:

> Another problem — tokens are not refreshed actually despite the log messages (@JoelSpeed is it a bug?). There is the following flow in stored_session.go : loadSession() —> getValidatedSession() —> refreshSessionIfNeeded(). The latter function checks if the session has to be refreshed based on the session age and the refresh period (--cookie-refresh argument). And if it's time to refresh then it calls refreshSessionWithProvider() —> refreshSessionWithProviderIfNeeded(). The latter function is implemented by providers. In case of oidc.go provider there is a method RefreshSessionIfNeeded() which again checks if the session has to be refreshed, but it does it in different way — by testing the session/token expiration time. So OIDC provider's refresh method ignores the actual refresh period. And if you try to refresh token that is not expired, then nothing will happen — OIDC provider's refresh method return false and you just get a log message Refreshing <AGE> old session cookie... mentioned in the issue description. 

In my opinion it does not make sense to be able to set `cookie_refresh` to refresh the cookie after a specified duration and then having the provider block the refresh due to a still valid session. Therefore the check in the oidc provider if the session is still valid was removed.

## How Has This Been Tested?

Removed the logic from `providers/oidc.go`, built a new container image and tested this image using a Kubernetes Dashboard upstream and Keycloak as OIDC provider. 

go tests were successful as well.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
