### PR TITLE
Update to Go 1.16

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,10 +20,10 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v2
 
-    - name: Set up Go 1.15
+    - name: Set up Go 1.16
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15.x
+        go-version: 1.16.x
       id: go
 
     - name: Get dependencies

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,6 @@ jobs:
     - name: Get dependencies
       run: |
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.36.0
-        go mod download
         curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
         chmod +x ./cc-test-reporter
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Changes since v7.0.1
 
+- [#1054](https://github.com/oauth2-proxy/oauth2-proxy/pull/1054) Update to Go 1.16 (@JoelSpeed)
 - [#1052](https://github.com/oauth2-proxy/oauth2-proxy/pull/1052) Update golangci-lint to latest version (v1.36.0) (@JoelSpeed)
 - [#1043](https://github.com/oauth2-proxy/oauth2-proxy/pull/1043) Refactor Sign In Page rendering and capture all page rendering code in pagewriter package (@JoelSpeed)
 - [#1029](https://github.com/oauth2-proxy/oauth2-proxy/pull/1029) Refactor error page rendering and allow debug messages on error (@JoelSpeed)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15-buster AS builder
+FROM golang:1.16-buster AS builder
 ARG VERSION
 
 # Copy sources

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,4 +1,4 @@
-FROM golang:1.15-buster AS builder
+FROM golang:1.16-buster AS builder
 ARG VERSION
 
 # Copy sources

--- a/Dockerfile.armv6
+++ b/Dockerfile.armv6
@@ -1,4 +1,4 @@
-FROM golang:1.15-buster AS builder
+FROM golang:1.16-buster AS builder
 ARG VERSION
 
 # Copy sources

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/oauth2-proxy/oauth2-proxy/v7
 
-go 1.15
+go 1.16
 
 require (
 	github.com/Bose/minisentinel v0.0.0-20200130220412-917c5a9223bb

--- a/pkg/app/pagewriter/error.html
+++ b/pkg/app/pagewriter/error.html
@@ -1,0 +1,100 @@
+{{define "error.html"}}
+<!DOCTYPE html>
+<html lang="en" charset="utf-8">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+  <title>{{.StatusCode}} {{.Title}}</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.1/css/bulma.min.css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.2/css/all.min.css">
+
+<script type="text/javascript">
+  document.addEventListener('DOMContentLoaded', function() {
+    let cardToggles = document.getElementsByClassName('card-toggle');
+    for (let i = 0; i < cardToggles.length; i++) {
+      cardToggles[i].addEventListener('click', e => {
+        e.currentTarget.parentElement.parentElement.childNodes[3].classList.toggle('is-hidden');
+      });
+    }
+  });
+</script>
+
+<style>
+  body {
+    height: 100vh;
+  }
+  .error-box {
+    margin: 1.25rem auto;
+    max-width: 600px;
+  }
+  .status-code {
+    font-size: 12rem;
+    font-weight: 600;
+  }
+  #more-info.card {
+    border: 1px solid #f0f0f0;
+  }
+  footer a {
+    text-decoration: underline;
+  }
+</style>
+</head>
+<body class="has-background-light">
+<section class="section">
+  <div class="box block error-box has-text-centered">
+    <div class="status-code">{{.StatusCode}}</div>
+    <div class="block">
+      <h1 class="subtitle is-1">{{.Title}}</h1>
+    </div>
+
+    {{ if .Message }}
+    <div id="more-info" class="block card is-fullwidth is-shadowless">
+      <header class="card-header is-shadowless">
+        <p class="card-header-title">More Info</p>
+        <a class="card-header-icon card-toggle">
+          <i class="fa fa-angle-down"></i>
+        </a>
+      </header>
+      <div class="card-content has-text-left is-hidden">
+        <div class="content">
+          {{.Message}}
+        </div>
+      </div>
+    </div>
+    {{ end }}
+
+    {{ if .Redirect }}
+    <hr>
+
+    <div class="columns">
+      <div class="column">
+        <form method="GET" action="{{.Redirect}}">
+          <button type="submit" class="button is-danger is-fullwidth">Go back</button>
+        </form>
+      </div>
+      <div class="column">
+        <form method="GET" action="{{.ProxyPrefix}}/sign_in">
+          <input type="hidden" name="rd" value="{{.Redirect}}">
+          <button type="submit" class="button is-primary is-fullwidth">Sign in</button>
+        </form>
+      </div>
+    </div>
+    {{ end }}
+
+  </div>
+</section>
+
+<footer class="footer has-text-grey has-background-light is-size-7">
+  <div class="content has-text-centered">
+    {{ if eq .Footer "-" }}
+    {{ else if eq .Footer ""}}
+    <p>Secured with <a href="https://github.com/oauth2-proxy/oauth2-proxy#oauth2_proxy" class="has-text-grey">OAuth2 Proxy</a> version {{.Version}}</p>
+    {{ else }}
+    <p>{{.Footer}}</p>
+    {{ end }}
+  </div>
+</footer>
+
+</body>
+</html>
+{{end}}

--- a/pkg/app/pagewriter/sign_in.html
+++ b/pkg/app/pagewriter/sign_in.html
@@ -1,0 +1,89 @@
+{{define "sign_in.html"}}
+<!DOCTYPE html>
+<html lang="en" charset="utf-8">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+    <title>Sign In</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.1/css/bulma.min.css">
+
+    <style>
+      body {
+        height: 100vh;
+      }
+      .sign-in-box {
+        max-width: 400px;
+        margin: 1.25rem auto;
+      }
+      footer a {
+        text-decoration: underline;
+      }
+    </style>
+
+    <script>
+      if (window.location.hash) {
+        (function() {
+          var inputs = document.getElementsByName('rd');
+          for (var i = 0; i < inputs.length; i++) {
+            // Add hash, but make sure it is only added once
+            var idx = inputs[i].value.indexOf('#');
+            if (idx >= 0) {
+              // Remove existing hash from URL
+              inputs[i].value = inputs[i].value.substr(0, idx);
+            }
+            inputs[i].value += window.location.hash;
+          }
+        })();
+      }
+    </script>
+  </head>
+  <body class="has-background-light">
+  <section class="section">
+    <div class="box block sign-in-box has-text-centered">
+      <form method="GET" action="{{.ProxyPrefix}}/start">
+        <input type="hidden" name="rd" value="{{.Redirect}}">
+          {{ if .SignInMessage }}
+          <p class="block">{{.SignInMessage}}</p>
+          {{ end}}
+          <button type="submit" class="button block is-primary">Sign in with {{.ProviderName}}</button>
+      </form>
+
+      {{ if .CustomLogin }}
+      <hr>
+
+      <form method="POST" action="{{.ProxyPrefix}}/sign_in" class="block">
+        <input type="hidden" name="rd" value="{{.Redirect}}">
+
+        <div class="field">
+          <label class="label" for="username">Username</label>
+          <div class="control">
+            <input class="input" type="email" placeholder="e.g. userx@example.com"  name="username" id="username">
+          </div>
+        </div>
+
+        <div class="field">
+          <label class="label" for="password">Password</label>
+          <div class="control">
+            <input class="input" type="password" placeholder="********" name="password" id="password">
+          </div>
+        </div>
+        <button class="button is-primary">Sign in</button>
+        {{ end }}
+    </form>
+    </div>
+  </section>
+
+  <footer class="footer has-text-grey has-background-light is-size-7">
+    <div class="content has-text-centered">
+    	{{ if eq .Footer "-" }}
+    	{{ else if eq .Footer ""}}
+    	<p>Secured with <a href="https://github.com/oauth2-proxy/oauth2-proxy#oauth2_proxy" class="has-text-grey">OAuth2 Proxy</a> version {{.Version}}</p>
+    	{{ else }}
+    	<p>{{.Footer}}</p>
+    	{{ end }}
+    </div>
+	</footer>
+
+  </body>
+</html>
+{{end}}

--- a/pkg/app/pagewriter/templates.go
+++ b/pkg/app/pagewriter/templates.go
@@ -1,6 +1,9 @@
 package pagewriter
 
 import (
+	// Import embed to allow importing default page templates
+	_ "embed"
+
 	"fmt"
 	"html/template"
 	"os"
@@ -13,198 +16,13 @@ import (
 const (
 	errorTemplateName  = "error.html"
 	signInTemplateName = "sign_in.html"
-
-	defaultErrorTemplate = `{{define "error.html"}}
-<!DOCTYPE html>
-<html lang="en" charset="utf-8">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
-  	<title>{{.StatusCode}} {{.Title}}</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.1/css/bulma.min.css">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.2/css/all.min.css">
-
-  <script type="text/javascript">
-    document.addEventListener('DOMContentLoaded', function() {
-    	let cardToggles = document.getElementsByClassName('card-toggle');
-    	for (let i = 0; i < cardToggles.length; i++) {
-    		cardToggles[i].addEventListener('click', e => {
-    			e.currentTarget.parentElement.parentElement.childNodes[3].classList.toggle('is-hidden');
-    		});
-    	}
-    });
-  </script>
-
-  <style>
-    body {
-      height: 100vh;
-    }
-    .error-box {
-      margin: 1.25rem auto;
-      max-width: 600px;
-    }
-    .status-code {
-      font-size: 12rem;
-      font-weight: 600;
-    }
-    #more-info.card {
-      border: 1px solid #f0f0f0;
-    }
-    footer a {
-      text-decoration: underline;
-    }
-  </style>
-</head>
-<body class="has-background-light">
-  <section class="section">
-    <div class="box block error-box has-text-centered">
-      <div class="status-code">{{.StatusCode}}</div>
-      <div class="block">
-        <h1 class="subtitle is-1">{{.Title}}</h1>
-      </div>
-
-      {{ if .Message }}
-      <div id="more-info" class="block card is-fullwidth is-shadowless">
-  			<header class="card-header is-shadowless">
-  				<p class="card-header-title">More Info</p>
-  				<a class="card-header-icon card-toggle">
-  					<i class="fa fa-angle-down"></i>
-  				</a>
-  			</header>
-  			<div class="card-content has-text-left is-hidden">
-  				<div class="content">
-  					{{.Message}}
-  				</div>
-  			</div>
-  		</div>
-      {{ end }}
-
-      {{ if .Redirect }}
-      <hr>
-
-      <div class="columns">
-        <div class="column">
-          <form method="GET" action="{{.Redirect}}">
-            <button type="submit" class="button is-danger is-fullwidth">Go back</button>
-          </form>
-        </div>
-        <div class="column">
-          <form method="GET" action="{{.ProxyPrefix}}/sign_in">
-            <input type="hidden" name="rd" value="{{.Redirect}}">
-            <button type="submit" class="button is-primary is-fullwidth">Sign in</button>
-          </form>
-        </div>
-      </div>
-      {{ end }}
-
-    </div>
-  </section>
-
-  <footer class="footer has-text-grey has-background-light is-size-7">
-    <div class="content has-text-centered">
-    	{{ if eq .Footer "-" }}
-    	{{ else if eq .Footer ""}}
-    	<p>Secured with <a href="https://github.com/oauth2-proxy/oauth2-proxy#oauth2_proxy" class="has-text-grey">OAuth2 Proxy</a> version {{.Version}}</p>
-    	{{ else }}
-    	<p>{{.Footer}}</p>
-    	{{ end }}
-    </div>
-	</footer>
-
-  </body>
-</html>
-{{end}}`
-
-	defaultSignInTemplate = `{{define "sign_in.html"}}
-<!DOCTYPE html>
-<html lang="en" charset="utf-8">
-  <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
-    <title>Sign In</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.1/css/bulma.min.css">
-
-    <style>
-      body {
-        height: 100vh;
-      }
-      .sign-in-box {
-        max-width: 400px;
-        margin: 1.25rem auto;
-      }
-      footer a {
-        text-decoration: underline;
-      }
-    </style>
-
-    <script>
-      if (window.location.hash) {
-        (function() {
-          var inputs = document.getElementsByName('rd');
-          for (var i = 0; i < inputs.length; i++) {
-            // Add hash, but make sure it is only added once
-            var idx = inputs[i].value.indexOf('#');
-            if (idx >= 0) {
-              // Remove existing hash from URL
-              inputs[i].value = inputs[i].value.substr(0, idx);
-            }
-            inputs[i].value += window.location.hash;
-          }
-        })();
-      }
-    </script>
-  </head>
-  <body class="has-background-light">
-  <section class="section">
-    <div class="box block sign-in-box has-text-centered">
-      <form method="GET" action="{{.ProxyPrefix}}/start">
-        <input type="hidden" name="rd" value="{{.Redirect}}">
-          {{ if .SignInMessage }}
-          <p class="block">{{.SignInMessage}}</p>
-          {{ end}}
-          <button type="submit" class="button block is-primary">Sign in with {{.ProviderName}}</button>
-      </form>
-
-      {{ if .CustomLogin }}
-      <hr>
-
-      <form method="POST" action="{{.ProxyPrefix}}/sign_in" class="block">
-        <input type="hidden" name="rd" value="{{.Redirect}}">
-
-        <div class="field">
-          <label class="label" for="username">Username</label>
-          <div class="control">
-            <input class="input" type="email" placeholder="e.g. userx@example.com"  name="username" id="username">
-          </div>
-        </div>
-
-        <div class="field">
-          <label class="label" for="password">Password</label>
-          <div class="control">
-            <input class="input" type="password" placeholder="********" name="password" id="password">
-          </div>
-        </div>
-        <button class="button is-primary">Sign in</button>
-        {{ end }}
-    </form>
-    </div>
-  </section>
-
-  <footer class="footer has-text-grey has-background-light is-size-7">
-    <div class="content has-text-centered">
-    	{{ if eq .Footer "-" }}
-    	{{ else if eq .Footer ""}}
-    	<p>Secured with <a href="https://github.com/oauth2-proxy/oauth2-proxy#oauth2_proxy" class="has-text-grey">OAuth2 Proxy</a> version {{.Version}}</p>
-    	{{ else }}
-    	<p>{{.Footer}}</p>
-    	{{ end }}
-    </div>
-	</footer>
-
-  </body>
-</html>
-{{end}}`
 )
+
+//go:embed error.html
+var defaultErrorTemplate string
+
+//go:embed sign_in.html
+var defaultSignInTemplate string
 
 // loadTemplates adds the Sign In and Error templates from the custom template
 // directory, or uses the defaults if they do not exist or the custom directory

--- a/pkg/cookies/cookies.go
+++ b/pkg/cookies/cookies.go
@@ -76,7 +76,7 @@ func ParseSameSite(v string) http.SameSite {
 	case "none":
 		return http.SameSiteNoneMode
 	case "":
-		return http.SameSiteDefaultMode
+		return 0
 	default:
 		panic(fmt.Sprintf("Invalid value for SameSite: %s", v))
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Update Go to 1.16.
Use the embed package to extract default page templates into html files.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This will make it easier for people to use our existing templates as bases for their own templates if they decide to customise the look of OAuth2 Proxy.

Since Go 1.16 has literally only just been release, this may be a bit premature? Not sure

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually using the local testing environment + unit tests cover this.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
