### PR TITLE
implement upstream proxy feature to remove mapped path from upstream requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Changes since v7.0.1
 
+- [#1058](https://github.com/oauth2-proxy/oauth2-proxy/pull/1058) Add support for removal of mapped path from upstream requests
 - [#1054](https://github.com/oauth2-proxy/oauth2-proxy/pull/1054) Update to Go 1.16 (@JoelSpeed)
 - [#1052](https://github.com/oauth2-proxy/oauth2-proxy/pull/1052) Update golangci-lint to latest version (v1.36.0) (@JoelSpeed)
 - [#1043](https://github.com/oauth2-proxy/oauth2-proxy/pull/1043) Refactor Sign In Page rendering and capture all page rendering code in pagewriter package (@JoelSpeed)

--- a/docs/docs/configuration/alpha_config.md
+++ b/docs/docs/configuration/alpha_config.md
@@ -201,6 +201,7 @@ Requests will be proxied to this upstream if the path matches the request path.
 | `flushInterval` | _[Duration](#duration)_ | FlushInterval is the period between flushing the response buffer when<br/>streaming response from the upstream.<br/>Defaults to 1 second. |
 | `passHostHeader` | _bool_ | PassHostHeader determines whether the request host header should be proxied<br/>to the upstream server.<br/>Defaults to true. |
 | `proxyWebSockets` | _bool_ | ProxyWebSockets enables proxying of websockets to upstream servers<br/>Defaults to true. |
+| `trimPath` | _bool_ | TrimPath will remove the path mapping from the path<br/>in the request send to the upstream.<br/>Defaults to false. |
 
 ### Upstreams
 

--- a/pkg/apis/options/upstreams.go
+++ b/pkg/apis/options/upstreams.go
@@ -62,4 +62,9 @@ type Upstream struct {
 	// ProxyWebSockets enables proxying of websockets to upstream servers
 	// Defaults to true.
 	ProxyWebSockets *bool `json:"proxyWebSockets,omitempty"`
+
+	// TrimPath will remove the path mapping from the path
+	// in the request send to the upstream.
+	// Defaults to false.
+	TrimPath bool `json:"trimPath,omitempty"`
 }

--- a/pkg/upstream/request_factory_test.go
+++ b/pkg/upstream/request_factory_test.go
@@ -1,0 +1,14 @@
+package upstream
+
+import (
+	"net/http"
+	"net/http/httptest"
+)
+
+type requestFactory func() *http.Request
+
+func requestFactoryGet(target string) requestFactory {
+	return func() *http.Request {
+		return httptest.NewRequest("", target, nil)
+	}
+}

--- a/pkg/upstream/sign_request.go
+++ b/pkg/upstream/sign_request.go
@@ -1,0 +1,24 @@
+package upstream
+
+import (
+	"net/http"
+
+	"github.com/mbland/hmacauth"
+)
+
+// StripPrefix returns a handler that serves HTTP requests by adding
+// a signature to the request header set and invoking the handler h.
+func SignRequest(signer hmacauth.HmacAuth, h http.Handler) http.Handler {
+	if signer == nil {
+		return h
+	}
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		r.Header.Set("GAP-Auth", w.Header().Get("GAP-Auth"))
+		signer.SignRequest(r)
+
+		h.ServeHTTP(w, r)
+	}
+
+	return http.HandlerFunc(handler)
+}

--- a/pkg/upstream/trim_path.go
+++ b/pkg/upstream/trim_path.go
@@ -1,0 +1,61 @@
+package upstream
+
+import (
+	"net/http"
+)
+
+// TrimRequestURIPath returns a handler that serves HTTP requests by removing
+// the given prefix from the request URL's Path, RawPath (if set), and RequestURI
+// before passing the request object on to the handler h. Apart from the change
+// to the RequestURI, TrimRequestURIPath is also different from http.StripPath
+// in that it does not reply with HTTP 404 if the request path does not start
+// with the specified prefix.
+func TrimRequestURIPath(prefix string, h http.Handler) http.Handler {
+	if prefix == "" {
+		return h
+	}
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		req := trimRequestURIPath(r, prefix)
+
+		h.ServeHTTP(w, req)
+	}
+
+	return http.HandlerFunc(handler)
+}
+
+// trimRequestURIPath remove the given prefix from the request RequestURI,
+// URL Path and URL RawPath. prefix is expected to have no trailing slash
+// in order for it to be able to trim the prefix from request paths which
+// do not have one either.
+func trimRequestURIPath(req *http.Request, prefix string) (res *http.Request) {
+	var path, rawPath string
+
+	sub := prefix + "/"
+	cut := len(prefix)
+	res = req
+
+	if req.URL.Path == prefix { // http://host/prefix
+		path = "/"
+	} else if len(req.URL.Path) >= cut && req.URL.Path[0:cut+1] == sub { // http://host/prefix/
+		path = req.URL.Path[cut:]
+	}
+
+	if req.URL.RawPath == prefix {
+		rawPath = "/"
+	} else if len(req.URL.RawPath) >= cut && req.URL.RawPath[0:cut+1] == sub {
+		rawPath = req.URL.RawPath[cut:]
+		// this block is strings.HasPrefix and strings.TrimPrefix
+		// combined, with the difference, that it does not return
+		// the input if it does not start with the given prefix
+	}
+
+	if path != "" || rawPath != "" {
+		res = req.Clone(req.Context())
+		res.URL.Path = path
+		res.URL.RawPath = rawPath
+		res.RequestURI = res.URL.String()
+	}
+
+	return
+}

--- a/pkg/upstream/trim_path_test.go
+++ b/pkg/upstream/trim_path_test.go
@@ -1,0 +1,69 @@
+package upstream
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("TrimRequestURIPath", func() {
+	type trimPathTableInput struct {
+		input, output requestFactory
+		prefix        string
+	}
+
+	DescribeTable("ServeHTTP",
+		func(in *trimPathTableInput) {
+			rw := httptest.NewRecorder()
+			input := in.input()
+			verify := func(w http.ResponseWriter, r *http.Request) {
+				output := in.output()
+
+				Expect(r.URL.Path).To(Equal(output.URL.Path))
+				Expect(r.URL.RawPath).To(Equal(output.URL.RawPath))
+				Expect(r.RequestURI).To(Equal(output.RequestURI))
+			}
+			subject := TrimRequestURIPath(in.prefix, http.HandlerFunc(verify))
+
+			subject.ServeHTTP(rw, input)
+		},
+		Entry("with / prefix against a root request", &trimPathTableInput{
+			input:  requestFactoryGet("http://trim-path.test/"),
+			output: requestFactoryGet("http://trim-path.test/"),
+			prefix: "/",
+		}),
+		Entry("with / prefix against a subdir request", &trimPathTableInput{
+			input:  requestFactoryGet("http://trim-path.test/path"),
+			output: requestFactoryGet("http://trim-path.test/path"),
+			prefix: "/",
+		}),
+		Entry("with /path prefix against a root request", &trimPathTableInput{
+			input:  requestFactoryGet("http://trim-path.test/"),
+			output: requestFactoryGet("http://trim-path.test/"),
+			prefix: "/path",
+		}),
+		Entry("with /path prefix against a subdir request", &trimPathTableInput{
+			input:  requestFactoryGet("http://trim-path.test/path"),
+			output: requestFactoryGet("http://trim-path.test/"),
+			prefix: "/path",
+		}),
+		Entry("with /path prefix against a sub-subdir request", &trimPathTableInput{
+			input:  requestFactoryGet("http://trim-path.test/path/else"),
+			output: requestFactoryGet("http://trim-path.test/else"),
+			prefix: "/path",
+		}),
+		Entry("with /path prefix against a sub-subdir request (repetition)", &trimPathTableInput{
+			input:  requestFactoryGet("http://trim-path.test/path/path"),
+			output: requestFactoryGet("http://trim-path.test/path"),
+			prefix: "/path",
+		}),
+		Entry("with /path prefix against a sub-subdir request (suffix match)", &trimPathTableInput{
+			input:  requestFactoryGet("http://trim-path.test/else/path"),
+			output: requestFactoryGet("http://trim-path.test/else/path"),
+			prefix: "/path",
+		}),
+	)
+})


### PR DESCRIPTION
oauth2-proxy does routing based on the request path. with multiple
upstream locations, only a single root mapping can exist. since
oauth2-proxy retains the request path for request to its upstream
targets, information leaks to the upstream servers.
this change adds the ability to remove the mapped path and allows
to operate oauth2-proxy with multiple upstreams, all receiving
requests at the root path.

<!--- Provide a general summary of your changes in the Title above -->

## Description

the code simply chains http.Handlers to perform preprocessing steps prior
to dispatching the request to the upstream server.

<!--- Describe your changes in detail -->

## Motivation and Context

i operate oauth2-proxy with multiple upstreams, each of which expects request
to query the root path

```yaml
upstreams:
-
  id: a
  path: /a
  uri: http://svc-a/
-
  id: b
  path: /b
  uri: http://svc-b/
```

i do not want the mapped path to end up in the requests to the upstream servers, e.g.:

`http://oauth2-proxy/a/health` -> `http://svc-a/health`


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

i have updated the test suite to cover possible use case scenarios

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
