### PR TITLE
Update the redeem URL for the google provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [#1039](https://github.com/oauth2-proxy/oauth2-proxy/pull/1039) Ensure errors in tests are logged to the GinkgoWriter (@JoelSpeed)
 - [#980](https://github.com/oauth2-proxy/oauth2-proxy/pull/980) Add Prometheus metrics endpoint
 - [#1023](https://github.com/oauth2-proxy/oauth2-proxy/pull/1023) Update docs on Traefik ForwardAuth support without the use of Traefik 'errors' middleware
+- [#1059](https://github.com/oauth2-proxy/oauth2-proxy/pull/1059) Update the Google provider token endpoint
 
 # V7.0.1
 

--- a/providers/google.go
+++ b/providers/google.go
@@ -62,11 +62,11 @@ var (
 	}
 
 	// Default Redeem URL for Google.
-	// Pre-parsed URL of https://www.googleapis.com/oauth2/v3/token.
+	// Pre-parsed URL of https://oauth2.googleapis.com/token.
 	googleDefaultRedeemURL = &url.URL{
 		Scheme: "https",
-		Host:   "www.googleapis.com",
-		Path:   "/oauth2/v3/token",
+		Host:   "oauth2.googleapis.com",
+		Path:   "/token",
 	}
 
 	// Default Validation URL for Google.

--- a/providers/google_test.go
+++ b/providers/google_test.go
@@ -43,7 +43,7 @@ func TestNewGoogleProvider(t *testing.T) {
 	providerData := NewGoogleProvider(&ProviderData{}).Data()
 	g.Expect(providerData.ProviderName).To(Equal("Google"))
 	g.Expect(providerData.LoginURL.String()).To(Equal("https://accounts.google.com/o/oauth2/auth?access_type=offline"))
-	g.Expect(providerData.RedeemURL.String()).To(Equal("https://www.googleapis.com/oauth2/v3/token"))
+	g.Expect(providerData.RedeemURL.String()).To(Equal("https://oauth2.googleapis.com/token"))
 	g.Expect(providerData.ProfileURL.String()).To(Equal(""))
 	g.Expect(providerData.ValidateURL.String()).To(Equal("https://www.googleapis.com/oauth2/v1/tokeninfo"))
 	g.Expect(providerData.Scope).To(Equal("profile email"))


### PR DESCRIPTION
## Description

This follows the current doc at https://developers.google.com/identity/protocols/oauth2/web-server#exchange-authorization-code. The major difference is that the old reedeem url returns JWTs with the iss set to `accounts.google.com`, while the new one uses `https://accounts.google.com`. 

## Motivation and Context

While both iss are valid (https://developers.google.com/identity/protocols/oauth2/openid-connect#an-id-tokens-payload), the latter is the same one as the tokens you'd get via the OIDC flow, so this unifies and future-proofs the setup.

## How Has This Been Tested?

Verified that the new path is functional manually.

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
