### PR TITLE
[provider_azure] Extract "groups" claim from jwt and add it to Session

### DIFF
--- a/docs/docs/configuration/group.md
+++ b/docs/docs/configuration/group.md
@@ -71,13 +71,13 @@ presented to the oauth2-proxy
 ## Configuring this for new Provider
 
 Check the existing implementation in 
-* [`azure.go`](../providers/azure.go)
+* [`azure.go`](/providers/azure.go)
   Using the
   ```go
   EnrichSession(ctx context.Context, s *sessions.SessionState) error;
   ```
   method to extract the `groups` claim from the `id_token` returned by azure
-* [`oidc.go`](../providers/oidc.go)
+* [`oidc.go`](/providers/oidc.go)
   Using a separate implementation
   ```go
   createSessionState(ctx context.Context, token *oauth2.Token, idToken *oidc.IDToken) (*sessions.SessionState, error);

--- a/docs/docs/configuration/group.md
+++ b/docs/docs/configuration/group.md
@@ -1,0 +1,85 @@
+---
+id: allowed_groups
+title: Allowing group based access
+---
+
+Limiting access to a resource based on the users group membership gives you a finer level of access control.  
+You will need an oauth provider that supports adding the `group` claim in the `id_token`.
+
+Configured providers are :
+
+- [Azure](#azure-auth-provider)
+
+### Azure Auth Provider
+
+In azure, you can configure additional claims for a service principal in general as described here
+[https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-optional-claims](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-optional-claims).
+
+The `groups` claim is a bit special, as its value comes from an existing value for the user and not a single static value 
+[https://docs.microsoft.com/en-us/azure/active-directory/hybrid/how-to-connect-fed-group-claims](https://docs.microsoft.com/en-us/azure/active-directory/hybrid/how-to-connect-fed-group-claims)  
+
+1. Configure the service principal to get the groups from the logged in user   
+   ```bash
+   az ad app update --id <sp_object_id> --set groupMembershipClaims=ApplicationGroup
+   ```
+   The option here are `All` where every group the user is assigned to is sent to the oauth2-proxy. 
+   And then `ApplicationGroup` where only the group that is configured for the service principal and the user belongs to
+   is sent.
+2. Configure the service principal to send the groups from above for the logged in user in the `idToken`
+   ```bash
+   az ad app update --id <sp_object_id> --optional-claims @claims.json
+   # claims.json context
+   {
+     "accessToken": [],
+     "idToken": [
+       {
+         "name": "groups",
+         "source": null,
+         "essential": false,
+         "additionalProperties": ["group_id"]
+       }
+     ],
+     "saml2Token": [],
+     "samlToken": null
+   }
+   ```
+
+An azure example: [github azure-samples](https://github.com/Azure-Samples/active-directory-aspnetcore-webapp-openidconnect-v2/blob/master/5-WebApp-AuthZ/5-2-Groups/README.md#configure-your-application-to-receive-the-groups-claim-values-from-a-filtered-set-of-groups-a-user-may-be-assigned-to)
+
+## Usage
+Use the
+ 
+`--allowed-group` | string \| list | restrict logins to members of this group (may be given multiple times) | |
+
+parameter to configure the ids of the groups that should have access to this resource.
+
+Example:  
+```bash
+oauth2-proxy \
+--http-address=0.0.0.0:4180 \
+... \
+--allowed-group=<object-id-of-group-1> \
+--allowed-group=<object-id-of-group-2> \
+--allowed-group=<object-id-of-group-x>
+```
+
+Notes for azure:  
+* You need to configure the `object_id`s.
+* Depending on the value of `groupMembershipClaims` configured in your service principal, not all user groups might be
+presented to the oauth2-proxy
+
+## Configuring this for new Provider
+
+Check the existing implementation in 
+* [`azure.go`](../providers/azure.go)
+  Using the
+  ```go
+  EnrichSession(ctx context.Context, s *sessions.SessionState) error;
+  ```
+  method to extract the `groups` claim from the `id_token` returned by azure
+* [`oidc.go`](../providers/oidc.go)
+  Using a separate implementation
+  ```go
+  createSessionState(ctx context.Context, token *oauth2.Token, idToken *oidc.IDToken) (*sessions.SessionState, error);
+  ```
+  called from the `Redeem` and `redeemRefreshToken` methods

--- a/docs/docs/configuration/group.md
+++ b/docs/docs/configuration/group.md
@@ -71,13 +71,13 @@ presented to the oauth2-proxy
 ## Configuring this for new Provider
 
 Check the existing implementation in 
-* [`azure.go`](/providers/azure.go)
+* [`azure.go`](https://github.com/oauth2-proxy/oauth2-proxy/blob/master/providers/azure.go)
   Using the
   ```go
   EnrichSession(ctx context.Context, s *sessions.SessionState) error;
   ```
   method to extract the `groups` claim from the `id_token` returned by azure
-* [`oidc.go`](/providers/oidc.go)
+* [`oidc.go`](https://github.com/oauth2-proxy/oauth2-proxy/blob/master/providers/oidc.go)
   Using a separate implementation
   ```go
   createSessionState(ctx context.Context, token *oauth2.Token, idToken *oidc.IDToken) (*sessions.SessionState, error);

--- a/providers/azure.go
+++ b/providers/azure.go
@@ -177,21 +177,27 @@ func (p *AzureProvider) Redeem(ctx context.Context, redirectURL, code string) (*
 	return session, nil
 }
 
-// EnrichSession finds the email to enrich the session state
+// EnrichSession finds the email and groups claim to enrich the session state
 func (p *AzureProvider) EnrichSession(ctx context.Context, s *sessions.SessionState) error {
-	if s.Email != "" {
-		return nil
+	if s.Email == "" {
+		// add email
+		email, err := p.getEmailFromProfileAPI(ctx, s.AccessToken)
+		if err != nil {
+			return fmt.Errorf("unable to get email address: %v", err)
+		}
+		if email == "" {
+			return errors.New("unable to get email address")
+		}
+		s.Email = email
 	}
 
-	email, err := p.getEmailFromProfileAPI(ctx, s.AccessToken)
-	if err != nil {
-		return fmt.Errorf("unable to get email address: %v", err)
+	if s.Groups == nil {
+		// add groups claim
+		oidcClaims, err := p.verifyTokenAndExtractClaims(ctx, s.IDToken)
+		if err == nil && oidcClaims != nil {
+			s.Groups = oidcClaims.Groups
+		}
 	}
-	if email == "" {
-		return errors.New("unable to get email address")
-	}
-	s.Email = email
-
 	return nil
 }
 
@@ -216,10 +222,24 @@ func (p *AzureProvider) prepareRedeem(redirectURL, code string) (url.Values, err
 	return params, nil
 }
 
-// verifyTokenAndExtractEmail tries to extract email claim from either id_token or access token
+// verifyTokenAndExtractEmail tries to extract email from either id_token or access token
 // when oidc verifier is configured
 func (p *AzureProvider) verifyTokenAndExtractEmail(ctx context.Context, token string) (string, error) {
 	email := ""
+
+	oidcClaims, err := p.verifyTokenAndExtractClaims(ctx, token)
+	if err == nil && oidcClaims != nil {
+		email = oidcClaims.Email
+	}
+
+	return email, nil
+}
+
+// verifyTokenAndExtractClaims tries to extract oauth claims from either id_token or access token
+// when oidc verifier is configured
+func (p *AzureProvider) verifyTokenAndExtractClaims(ctx context.Context, token string) (*OIDCClaims, error) {
+	var oidcClaims *OIDCClaims
+	oidcClaims = nil
 
 	if token != "" && p.Verifier != nil {
 		token, err := p.Verifier.Verify(ctx, token)
@@ -227,7 +247,7 @@ func (p *AzureProvider) verifyTokenAndExtractEmail(ctx context.Context, token st
 		if err == nil {
 			claims, err := p.getClaims(token)
 			if err == nil {
-				email = claims.Email
+				oidcClaims = claims
 			} else {
 				logger.Printf("unable to get claims from token: %v", err)
 			}
@@ -236,7 +256,7 @@ func (p *AzureProvider) verifyTokenAndExtractEmail(ctx context.Context, token st
 		}
 	}
 
-	return email, nil
+	return oidcClaims, nil
 }
 
 // RefreshSessionIfNeeded checks if the session has expired and uses the
@@ -364,26 +384,4 @@ func (p *AzureProvider) getEmailFromProfileAPI(ctx context.Context, accessToken 
 // ValidateSession validates the AccessToken
 func (p *AzureProvider) ValidateSession(ctx context.Context, s *sessions.SessionState) bool {
 	return validateToken(ctx, p, s.AccessToken, makeAzureHeader(s.AccessToken))
-}
-
-func (p *AzureProvider) EnrichSession(ctx context.Context, s *sessions.SessionState) error {
-	if p.Verifier == nil {
-		logger.Errorf("Verifier is empty can not verify id token and extract claims")
-		return nil
-	}
-	// verify jwt
-	idToken, err := p.Verifier.Verify(ctx, s.IDToken)
-	if err != nil {
-		logger.Errorf("id_token is not valid (failed to verify)")
-		return nil
-	}
-	// extract claims
-	claims, err := p.getClaims(idToken)
-	if err != nil {
-		logger.Errorf("Failed to decode claims of id_token")
-		return nil
-	}
-	// set claims for session
-	s.Groups = claims.Groups
-	return nil
 }

--- a/providers/azure.go
+++ b/providers/azure.go
@@ -375,13 +375,13 @@ func (p *AzureProvider) EnrichSession(ctx context.Context, s *sessions.SessionSt
 		logger.Errorf("IDToken is not a valid jwd")
 		return nil
 	}
-	claimsJson, err := base64.RawStdEncoding.DecodeString(jwtParts[1])
+	claimsJSON, err := base64.RawStdEncoding.DecodeString(jwtParts[1])
 	if err != nil {
 		logger.Errorf("Failed to decode jwt %v", err)
 		return nil
 	}
 	claims := AzureClaims{}
-	err = json.Unmarshal(claimsJson, &claims)
+	err = json.Unmarshal(claimsJSON, &claims)
 	if err != nil {
 		logger.Errorf("Failed to decode jwt into json %v", err)
 		return nil

--- a/providers/azure.go
+++ b/providers/azure.go
@@ -370,16 +370,11 @@ func (p *AzureProvider) ValidateSession(ctx context.Context, s *sessions.Session
 }
 
 func (p *AzureProvider) EnrichSession(ctx context.Context, s *sessions.SessionState) error {
-	if s.IDToken == "" {
-		logger.Errorf("IDToken is empty")
-		return nil
-	}
 	jwtParts := strings.Split(s.IDToken, ".")
 	if len(jwtParts) != 3 {
 		logger.Errorf("IDToken is not a valid jwd")
 		return nil
 	}
-	logger.Errorf("Decoding token %v", jwtParts[1])
 	claimsJson, err := base64.RawStdEncoding.DecodeString(jwtParts[1])
 	if err != nil {
 		logger.Errorf("Failed to decode jwt %v", err)

--- a/providers/azure_test.go
+++ b/providers/azure_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/coreos/go-oidc"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -14,7 +13,8 @@ import (
 	"testing"
 	"time"
 
-	oidc "github.com/coreos/go-oidc"
+	"github.com/coreos/go-oidc"
+
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/sessions"
 
 	. "github.com/onsi/gomega"

--- a/providers/azure_test.go
+++ b/providers/azure_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/coreos/go-oidc"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -48,6 +49,7 @@ func testAzureProvider(hostname string) *AzureProvider {
 			ProtectedResource: &url.URL{},
 			Scope:             "",
 			EmailClaim:        "email",
+			GroupsClaim:       "groups",
 			Verifier: oidc.NewVerifier(
 				"https://issuer.example.com",
 				fakeAzureKeySetStub{},
@@ -59,7 +61,6 @@ func testAzureProvider(hostname string) *AzureProvider {
 				},
 			),
 		})
-
 	if hostname != "" {
 		updateURL(p.Data().LoginURL, hostname)
 		updateURL(p.Data().RedeemURL, hostname)
@@ -68,6 +69,16 @@ func testAzureProvider(hostname string) *AzureProvider {
 		updateURL(p.Data().ProtectedResource, hostname)
 	}
 	return p
+}
+
+type fakeAzureKeySetStub struct{}
+
+func (fakeAzureKeySetStub) VerifySignature(_ context.Context, jwt string) (payload []byte, err error) {
+	decodeString, err := base64.RawURLEncoding.DecodeString(strings.Split(jwt, ".")[1])
+	if err != nil {
+		return nil, err
+	}
+	return decodeString, nil
 }
 
 func TestNewAzureProvider(t *testing.T) {
@@ -409,7 +420,7 @@ func TestAzureProviderGetGroupsEmpty(t *testing.T) {
 func TestAzureProviderGetGroupsFromJWT(t *testing.T) {
 	/**
 	This jwt id_token
-	'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdWQiOiJhdWQiLCJpc3MiOiJpc3MiLCJpYXQiOjE2MDczMzI1MzksIm5iZiI6MTYwNzMzMjUzOSwiZXhwIjoxNjA3MzM2Mjg1LCJhbXIiOlsibWZhIl0sImZhbWlseV9uYW1lIjoiVXNlciIsImdpdmVuX25hbWUiOiJUZXN0IiwiZ3JvdXBzIjpbInVzZXJfZ3JvdXAiXSwiaXBhZGRyIjoiMTkyLjE2OC4xNy41IiwibmFtZSI6IlRlc3QgVXNlciAoQUQpIiwib2lkIjoib2JqZWN0X2lkIiwicmgiOiJyaCIsInN1YiI6InN1YnNjcmlwdGlvbiIsInRpZCI6InRlbmFudF9pZCIsInVuaXF1ZV9uYW1lIjoidGVzdHVzZXJAb2F1dGgyLmNvbSIsInVwbiI6InRlc3R1c2VyQG9hdXRoMi5jb20iLCJ1dGkiOiJ1dGkiLCJ2ZXIiOiIxLjAiLCJqdGkiOiI4ZTA3MDhlNS1jODg3LTRhZWUtYjdjMS04YjAzOThhODUxMWIifQ.aReJV2o8ukOCC_ddQDj3e0olZ9fGyT5aTNKPLAb8rGw'
+	'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJhdWQiLCJpc3MiOiJpc3MiLCJpYXQiOjE2MDczMzI1MzksIm5iZiI6MTYwNzMzMjUzOSwiZXhwIjoxNjA3MzMyNTY1LCJhbXIiOlsibWZhIl0sImZhbWlseV9uYW1lIjoiVXNlciIsImdpdmVuX25hbWUiOiJUZXN0IiwiZ3JvdXBzIjpbInVzZXJfZ3JvdXAiXSwiaXBhZGRyIjoiMTkyLjE2OC4xNy41IiwibmFtZSI6IlRlc3QgVXNlciAoQUQpIiwib2lkIjoib2JqZWN0X2lkIiwicmgiOiJyaCIsInN1YiI6InN1YnNjcmlwdGlvbiIsInRpZCI6InRlbmFudF9pZCIsInVuaXF1ZV9uYW1lIjoidGVzdHVzZXJAb2F1dGgyLmNvbSIsInVwbiI6InRlc3R1c2VyQG9hdXRoMi5jb20iLCJ1dGkiOiJ1dGkiLCJ2ZXIiOiIxLjAifQ.XnF9lMHViBK4wyfE6_X2c2iFlZD62WLUHJFQ7iPuvMkFb0XNBS3nVuWONkqCdQ4IFyYvzJHUQ0YH_hN5Zs8ho4fuzLcfcjjqhrLKvdY5UEAWwqeYQAWnGFc1cAwyEECwf2EcjU7ZBPVKardGTOUYyENUH_-Bdd29l_RlRyUtvnGc8WVmLaqS2EKij2oC7RbanlBUHbpLoINCpgVJrrwr87XpA8OPKqzG384AgYCvPwjCoofeXBOpz0EZw49mFQ4qdWaIjoG0wDcoZq-wKmnzly0L-sTdcYJchoXvP1ha3UXg092HK9mLuGo76DlZK6SE5FkHp2X-mP6dGWQWPo65eg'
 
 	contains
 	'''
@@ -440,9 +451,47 @@ func TestAzureProviderGetGroupsFromJWT(t *testing.T) {
 	}
 	'''
 
-	using the secret 'secret'
+	using the public key
+	-----BEGIN PUBLIC KEY-----
+	MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnzyis1ZjfNB0bBgKFMSv
+	vkTtwlvBsaJq7S5wA+kzeVOVpVWwkWdVha4s38XM/pa/yr47av7+z3VTmvDRyAHc
+	aT92whREFpLv9cj5lTeJSibyr/Mrm/YtjCZVWgaOYIhwrXwKLqPr/11inWsAkfIy
+	tvHWTxZYEcXLgAXFuUuaS3uF9gEiNQwzGTU1v0FqkqTBr4B8nW3HCN47XUu0t8Y0
+	e+lf4s4OxQawWD79J9/5d3Ry0vbV3Am1FtGJiJvOwRsIfVChDpYStTcHTCMqtvWb
+	V6L11BWkpzGXSW4Hv43qa+GSYOD2QU68Mb59oSk2OB+BtOLpJofmbGEGgvmwyCI9
+	MwIDAQAB
+	-----END PUBLIC KEY-----
+
+	and private key
+	-----BEGIN RSA PRIVATE KEY-----
+	MIIEogIBAAKCAQEAnzyis1ZjfNB0bBgKFMSvvkTtwlvBsaJq7S5wA+kzeVOVpVWw
+	kWdVha4s38XM/pa/yr47av7+z3VTmvDRyAHcaT92whREFpLv9cj5lTeJSibyr/Mr
+	m/YtjCZVWgaOYIhwrXwKLqPr/11inWsAkfIytvHWTxZYEcXLgAXFuUuaS3uF9gEi
+	NQwzGTU1v0FqkqTBr4B8nW3HCN47XUu0t8Y0e+lf4s4OxQawWD79J9/5d3Ry0vbV
+	3Am1FtGJiJvOwRsIfVChDpYStTcHTCMqtvWbV6L11BWkpzGXSW4Hv43qa+GSYOD2
+	QU68Mb59oSk2OB+BtOLpJofmbGEGgvmwyCI9MwIDAQABAoIBACiARq2wkltjtcjs
+	kFvZ7w1JAORHbEufEO1Eu27zOIlqbgyAcAl7q+/1bip4Z/x1IVES84/yTaM8p0go
+	amMhvgry/mS8vNi1BN2SAZEnb/7xSxbflb70bX9RHLJqKnp5GZe2jexw+wyXlwaM
+	+bclUCrh9e1ltH7IvUrRrQnFJfh+is1fRon9Co9Li0GwoN0x0byrrngU8Ak3Y6D9
+	D8GjQA4Elm94ST3izJv8iCOLSDBmzsPsXfcCUZfmTfZ5DbUDMbMxRnSo3nQeoKGC
+	0Lj9FkWcfmLcpGlSXTO+Ww1L7EGq+PT3NtRae1FZPwjddQ1/4V905kyQFLamAA5Y
+	lSpE2wkCgYEAy1OPLQcZt4NQnQzPz2SBJqQN2P5u3vXl+zNVKP8w4eBv0vWuJJF+
+	hkGNnSxXQrTkvDOIUddSKOzHHgSg4nY6K02ecyT0PPm/UZvtRpWrnBjcEVtHEJNp
+	bU9pLD5iZ0J9sbzPU/LxPmuAP2Bs8JmTn6aFRspFrP7W0s1Nmk2jsm0CgYEAyH0X
+	+jpoqxj4efZfkUrg5GbSEhf+dZglf0tTOA5bVg8IYwtmNk/pniLG/zI7c+GlTc9B
+	BwfMr59EzBq/eFMI7+LgXaVUsM/sS4Ry+yeK6SJx/otIMWtDfqxsLD8CPMCRvecC
+	2Pip4uSgrl0MOebl9XKp57GoaUWRWRHqwV4Y6h8CgYAZhI4mh4qZtnhKjY4TKDjx
+	QYufXSdLAi9v3FxmvchDwOgn4L+PRVdMwDNms2bsL0m5uPn104EzM6w1vzz1zwKz
+	5pTpPI0OjgWN13Tq8+PKvm/4Ga2MjgOgPWQkslulO/oMcXbPwWC3hcRdr9tcQtn9
+	Imf9n2spL/6EDFId+Hp/7QKBgAqlWdiXsWckdE1Fn91/NGHsc8syKvjjk1onDcw0
+	NvVi5vcba9oGdElJX3e9mxqUKMrw7msJJv1MX8LWyMQC5L6YNYHDfbPF1q5L4i8j
+	8mRex97UVokJQRRA452V2vCO6S5ETgpnad36de3MUxHgCOX3qL382Qx9/THVmbma
+	3YfRAoGAUxL/Eu5yvMK8SAt/dJK6FedngcM3JEFNplmtLYVLWhkIlNRGDwkg3I5K
+	y18Ae9n7dHVueyslrb6weq7dTkYDi3iOYRW8HRkIQh06wEdbxt0shTzAJvvCQfrB
+	jg/3747WSsf/zBTcHihTRBdAv6OmdhV4/dD5YBfLAkLrd+mX7iE=
+	-----END RSA PRIVATE KEY-----
 	*/
-	idToken := "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdWQiOiJhdWQiLCJpc3MiOiJpc3MiLCJpYXQiOjE2MDczMzI1MzksIm5iZiI6MTYwNzMzMjUzOSwiZXhwIjoxNjA3MzM2Mjg1LCJhbXIiOlsibWZhIl0sImZhbWlseV9uYW1lIjoiVXNlciIsImdpdmVuX25hbWUiOiJUZXN0IiwiZ3JvdXBzIjpbInVzZXJfZ3JvdXAiXSwiaXBhZGRyIjoiMTkyLjE2OC4xNy41IiwibmFtZSI6IlRlc3QgVXNlciAoQUQpIiwib2lkIjoib2JqZWN0X2lkIiwicmgiOiJyaCIsInN1YiI6InN1YnNjcmlwdGlvbiIsInRpZCI6InRlbmFudF9pZCIsInVuaXF1ZV9uYW1lIjoidGVzdHVzZXJAb2F1dGgyLmNvbSIsInVwbiI6InRlc3R1c2VyQG9hdXRoMi5jb20iLCJ1dGkiOiJ1dGkiLCJ2ZXIiOiIxLjAiLCJqdGkiOiI4ZTA3MDhlNS1jODg3LTRhZWUtYjdjMS04YjAzOThhODUxMWIifQ.aReJV2o8ukOCC_ddQDj3e0olZ9fGyT5aTNKPLAb8rGw"
+	idToken := "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJhdWQiLCJpc3MiOiJpc3MiLCJpYXQiOjE2MDczMzI1MzksIm5iZiI6MTYwNzMzMjUzOSwiZXhwIjoxNjA3MzMyNTY1LCJhbXIiOlsibWZhIl0sImZhbWlseV9uYW1lIjoiVXNlciIsImdpdmVuX25hbWUiOiJUZXN0IiwiZ3JvdXBzIjpbInVzZXJfZ3JvdXAiXSwiaXBhZGRyIjoiMTkyLjE2OC4xNy41IiwibmFtZSI6IlRlc3QgVXNlciAoQUQpIiwib2lkIjoib2JqZWN0X2lkIiwicmgiOiJyaCIsInN1YiI6InN1YnNjcmlwdGlvbiIsInRpZCI6InRlbmFudF9pZCIsInVuaXF1ZV9uYW1lIjoidGVzdHVzZXJAb2F1dGgyLmNvbSIsInVwbiI6InRlc3R1c2VyQG9hdXRoMi5jb20iLCJ1dGkiOiJ1dGkiLCJ2ZXIiOiIxLjAifQ.XnF9lMHViBK4wyfE6_X2c2iFlZD62WLUHJFQ7iPuvMkFb0XNBS3nVuWONkqCdQ4IFyYvzJHUQ0YH_hN5Zs8ho4fuzLcfcjjqhrLKvdY5UEAWwqeYQAWnGFc1cAwyEECwf2EcjU7ZBPVKardGTOUYyENUH_-Bdd29l_RlRyUtvnGc8WVmLaqS2EKij2oC7RbanlBUHbpLoINCpgVJrrwr87XpA8OPKqzG384AgYCvPwjCoofeXBOpz0EZw49mFQ4qdWaIjoG0wDcoZq-wKmnzly0L-sTdcYJchoXvP1ha3UXg092HK9mLuGo76DlZK6SE5FkHp2X-mP6dGWQWPo65eg"
 	b := testAzureBackend(fmt.Sprintf(`{ "access_token": "some_access_token", "refresh_token": "some_refresh_token", "expires_on": "1136239445", "id_token": "%s" }`, idToken))
 	defer b.Close()
 	timestamp, _ := time.Parse(time.RFC3339, "2006-01-02T22:04:05Z")

--- a/providers/azure_test.go
+++ b/providers/azure_test.go
@@ -384,7 +384,6 @@ func TestAzureProviderRefreshWhenExpired(t *testing.T) {
 	assert.Equal(t, timestamp, session.ExpiresOn.UTC())
 }
 
-
 func TestAzureProviderGetGroupsEmpty(t *testing.T) {
 	b := testAzureBackend(`{ "access_token": "some_access_token", "refresh_token": "some_refresh_token", "expires_on": "1136239445", "id_token": "some_id_token" }`)
 	defer b.Close()

--- a/providers/provider_default.go
+++ b/providers/provider_default.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/logger"
 	"net/url"
 	"time"
 
@@ -119,9 +118,6 @@ func (p *ProviderData) Authorize(_ context.Context, s *sessions.SessionState) (b
 		}
 	}
 
-	logger.Errorf("" +
-		"None of the users groups '%v' are allowed for this resource.\n" +
-		"Allowed groups are '%v'", s.Groups, p.AllowedGroups)
 	return false, nil
 }
 

--- a/providers/provider_default.go
+++ b/providers/provider_default.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/logger"
 	"net/url"
 	"time"
 
@@ -118,6 +119,9 @@ func (p *ProviderData) Authorize(_ context.Context, s *sessions.SessionState) (b
 		}
 	}
 
+	logger.Errorf("" +
+		"None of the users groups '%v' are allowed for this resource.\n" +
+		"Allowed groups are '%v'", s.Groups, p.AllowedGroups)
 	return false, nil
 }
 


### PR DESCRIPTION
## Description

The azure oauth server can provide additional claims in the id token which is a jwt.

In azure, you can configure additional claims for a service principal in general as described here
[https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-optional-claims](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-optional-claims).

The `groups` claim is a bit special, as its value comes from an existing value for the user and not a single static value 
[https://docs.microsoft.com/en-us/azure/active-directory/hybrid/how-to-connect-fed-group-claims](https://docs.microsoft.com/en-us/azure/active-directory/hybrid/how-to-connect-fed-group-claims)  

This pull request adds code to
- extract this `groups` claim from the jwt inside the `EnrichSession` method by
  - splitting the token into the 3 jwt parts
  - base64 decoding the center part
  - parsing that part into a json structure
  - extract the value for the key `groups` from it
  - assigns that value to `session.Groups`

## Motivation and Context

- In a project I work for I want to grant access to a specific domain for some groups but not others
- I want to use a single azure oauth server to manage all users and groups that might have access to some parts of my application
- I want to then grant or deny access to certain routes based on the group using `allowed_groups`

This has already been requested by another user here: https://github.com/oauth2-proxy/oauth2-proxy/issues/1040
So I implemented this and deployed and tested it for my use case.

## How Has This Been Tested?

- Added a test `TestAzureProviderGetGroupsFromJWT` in `azure_test.go` to test and debug the jwt parsing
- Built the docker image using from this branch and deployed it into a kubernetes cluster like this
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: oauth2-proxy
  namespace: default
spec:
  template:
    spec:
      containers:
      - args:
        - --http-address=0.0.0.0:4180
        - --email-domain=*
        - --cookie-secret=$(COOKIE_PASSWORD)
        - --reverse-proxy=true
        - --upstream=http://127.0.0.1:8080/
        - --session-store-type=redis
        - --redis-connection-url=redis://redis-master.storage/
        - --redis-password=$(REDIS_PASSWORD)
        - --config=/etc/oauth2_proxy/oauth2_proxy.cfg
```
- Created an ingress to grant access to a grafana based on azure group
```
kind: Ingress
  metadata:
    name: grafana-grafana-oauth2
    namespace: monitoring
    labels:
    annotations:
      kubernetes.io/ingress.class: "monitoring-cluster"
      nginx.ingress.kubernetes.io/auth-signin: "https://grafana.daddona.de/oauth2/sign_in"
      nginx.ingress.kubernetes.io/auth-url: "https://grafana.daddona.de/oauth2/auth?allowed_groups=a,b"
  spec:
    tls:
      - hosts:
        - grafana.daddona.de
        secretName: grafana.daddona.de
    rules:
     - host: grafana.daddona.de
       http:
         paths:
           - path: /
             backend:
               serviceName: grafana
               servicePort: 80
```
- Created azure groups `a`, `b`, and `c`
- Add azure account to group `a` and try that access works
- Add azure account to group `c` but not `a` and try that access is denied 

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
