### PR TITLE
Add headers to skipped routes as well as authenticated ones

### DIFF
--- a/docs/docs/configuration/overview.md
+++ b/docs/docs/configuration/overview.md
@@ -20,6 +20,7 @@ An example [oauth2-proxy.cfg](https://github.com/oauth2-proxy/oauth2-proxy/blob/
 | Option | Type | Description | Default |
 | ------ | ---- | ----------- | ------- |
 | `--acr-values` | string | optional, see [docs](https://openid.net/specs/openid-connect-eap-acr-values-1_0.html#acrValues) | `""` |
+| `--add-headers-to-skipped` | bool | normally the various `--pass-*` options only pass request headers through to backend routes that require authentication - skipped routes do not receive the user information even if there is a valid cookie or JWT. Setting this option `true` causes `--pass-*` options to apply to all routes including skipped ones. | false |
 | `--approval-prompt` | string | OAuth approval_prompt | `"force"` |
 | `--auth-logging` | bool | Log authentication attempts | true |
 | `--auth-logging-format` | string | Template for authentication log lines | see [Logging Configuration](#logging-configuration) |

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -911,6 +911,8 @@ func (p *OAuthProxy) AuthOnly(rw http.ResponseWriter, req *http.Request) {
 
 // SkipAuthProxy proxies allowlisted requests and skips authentication
 func (p *OAuthProxy) SkipAuthProxy(rw http.ResponseWriter, req *http.Request) {
+	// set the "session optional" flag on this request
+	middlewareapi.GetRequestScope(req).SessionRequired = false
 	if p.addHeadersToSkipped {
 		session, err := p.getAuthenticatedSession(rw, req)
 		if err == nil {

--- a/pkg/apis/middleware/scope.go
+++ b/pkg/apis/middleware/scope.go
@@ -25,6 +25,10 @@ type RequestScope struct {
 	// Otherwise a random UUID is set.
 	RequestID string
 
+	// Is a session required for this request, or optional (e.g. it's a
+	// skipped route)
+	SessionRequired bool
+
 	// Session details the authenticated users information (if it exists).
 	Session *sessions.SessionState
 

--- a/pkg/apis/options/options.go
+++ b/pkg/apis/options/options.go
@@ -73,6 +73,7 @@ type Options struct {
 	SkipProviderButton    bool     `flag:"skip-provider-button" cfg:"skip_provider_button"`
 	SSLInsecureSkipVerify bool     `flag:"ssl-insecure-skip-verify" cfg:"ssl_insecure_skip_verify"`
 	SkipAuthPreflight     bool     `flag:"skip-auth-preflight" cfg:"skip_auth_preflight"`
+	AddHeadersToSkipped   bool     `flag:"add-headers-to-skipped" cfg:"add_headers_to_skipped"`
 
 	// These options allow for other providers besides Google, with
 	// potential overrides.
@@ -171,6 +172,7 @@ func NewFlagSet() *pflag.FlagSet {
 	flagSet.Bool("skip-auth-preflight", false, "will skip authentication for OPTIONS requests")
 	flagSet.Bool("ssl-insecure-skip-verify", false, "skip validation of certificates presented when using HTTPS providers")
 	flagSet.Bool("skip-jwt-bearer-tokens", false, "will skip requests that have verified JWT bearer tokens (default false)")
+	flagSet.Bool("add-headers-to-skipped", false, "normally when a request is skipped its request headers are left untouched, even when an authenticated session is available. Set this option true to inject headers into all requests where authentication is available, even if it is not necessarily required")
 	flagSet.StringSlice("extra-jwt-issuers", []string{}, "if skip-jwt-bearer-tokens is set, a list of extra JWT issuer=audience pairs (where the issuer URL has a .well-known/openid-configuration or a .well-known/jwks.json)")
 
 	flagSet.StringSlice("email-domain", []string{}, "authenticate emails with the specified domain (may be given multiple times). Use * to authenticate any email")

--- a/pkg/middleware/scope.go
+++ b/pkg/middleware/scope.go
@@ -12,8 +12,9 @@ func NewScope(reverseProxy bool, idHeader string) alice.Constructor {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 			scope := &middlewareapi.RequestScope{
-				ReverseProxy: reverseProxy,
-				RequestID:    genRequestID(req, idHeader),
+				ReverseProxy:    reverseProxy,
+				RequestID:       genRequestID(req, idHeader),
+				SessionRequired: true,
 			}
 			req = middlewareapi.AddRequestScope(req, scope)
 			next.ServeHTTP(rw, req)

--- a/pkg/middleware/stored_session.go
+++ b/pkg/middleware/stored_session.go
@@ -73,7 +73,10 @@ func (s *storedSessionLoader) loadSession(next http.Handler) http.Handler {
 		if err != nil {
 			// In the case when there was an error loading the session,
 			// we should clear the session
-			logger.Errorf("Error loading cookied session: %v, removing session", err)
+			if scope.SessionRequired {
+				// log error because session is required but we didn't find one
+				logger.Errorf("Error loading cookied session: %v, removing session", err)
+			}
 			err = s.store.Clear(rw, req)
 			if err != nil {
 				logger.Errorf("Error removing session: %v", err)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds a new option `--add-headers-to-skipped` to make the `--pass-*` options apply to "skipped" requests as well as to those requiring authentication.

## Motivation and Context

As discussed in #992, currently the various options to pass additional request headers to upstream (`--pass-user-headers`, `--pass-basic-auth`, etc., and their equivalent `injectRequestHeaders` settings in the alpha config format) apply only to requests that _require_ authentication.  Requests that are skipped by `--skip-auth-route` and friends are passed through untouched, and do not have headers injected _even_ if there is a valid session (cookie or JWT bearer token) available.

There are use cases where certain back end pages should not require authentication, but if the user _is_ authenticated then the upstream wants to know about it so it can adapt the content it returns, e.g. when the upstream manages a mixture of "widgets" some of which are public for all visitors with or without authentication and some of which are restricted, and the "list widgets" page needs to work for both anonymous and authenticated users returning the appropriate list for each.

## How Has This Been Tested?

Manual testing shows the expected behaviour, with skipped route receiving headers if an auth cookie is in place and not otherwise.  All existing unit tests run successfully both as-is, and after setting `opts.AddHeadersToSkipped = true` in `baseTestOptions`.

However I'm not really clear how to properly unit test the new functionality - I'd need to set up some sort of test fixture with a skipped route and then exercise that with and without a session in place to see the difference in request headers.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
  - (updated documentation but not yet changelog)
- [x] I have created a feature (non-master) branch for my PR.
