### PR TITLE
Optionally forward the tracing headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [#1039](https://github.com/oauth2-proxy/oauth2-proxy/pull/1039) Ensure errors in tests are logged to the GinkgoWriter (@JoelSpeed)
 - [#980](https://github.com/oauth2-proxy/oauth2-proxy/pull/980) Add Prometheus metrics endpoint
 - [#1023](https://github.com/oauth2-proxy/oauth2-proxy/pull/1023) Update docs on Traefik ForwardAuth support without the use of Traefik 'errors' middleware
+- [#1076](https://github.com/oauth2-proxy/oauth2-proxy/pull/1076) Add distributed tracing headers forwarding support
 
 # V7.0.1
 

--- a/docs/docs/configuration/overview.md
+++ b/docs/docs/configuration/overview.md
@@ -48,6 +48,7 @@ An example [oauth2-proxy.cfg](https://github.com/oauth2-proxy/oauth2-proxy/blob/
 | `--exclude-logging-paths` | string | comma separated list of paths to exclude from logging, e.g. `"/ping,/path2"` |`""` (no paths excluded) |
 | `--flush-interval` | duration | period between flushing response buffers when streaming responses | `"1s"` |
 | `--force-https` | bool | enforce https redirect | `false` |
+| `--forward-tracing-headers` | bool | forwards zipkin/jaeger compatible headers from the upstream to the downstreams | `false` |
 | `--banner` | string | custom (html) banner string. Use `"-"` to disable default banner. | |
 | `--footer` | string | custom (html) footer string. Use `"-"` to disable default footer. | |
 | `--gcp-healthchecks` | bool | will enable `/liveness_check`, `/readiness_check`, and `/` (with the proper user-agent) endpoints that will make it work well with GCP App Engine and GKE Ingresses | false |

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -489,7 +489,7 @@ func (p *OAuthProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 func (p *OAuthProxy) serveHTTP(rw http.ResponseWriter, req *http.Request) {
 	var ctx context.Context
 	if p.forwardTracingHeaders {
-		ctx = tracing.NewTracingContext(req)
+		ctx = tracing.NewContext(req)
 	} else {
 		ctx = req.Context()
 	}

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -421,7 +421,7 @@ func Test_redeemCode(t *testing.T) {
 	}
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	_, err = proxy.redeemCode(req)
+	_, err = proxy.redeemCode(context.Background(), req)
 	assert.Equal(t, providers.ErrMissingCode, err)
 }
 

--- a/pkg/apis/options/options.go
+++ b/pkg/apis/options/options.go
@@ -106,6 +106,8 @@ type Options struct {
 	PubJWKURL       string `flag:"pubjwk-url" cfg:"pubjwk_url"`
 	GCPHealthChecks bool   `flag:"gcp-healthchecks" cfg:"gcp_healthchecks"`
 
+	ForwardTracingHeaders bool `flag:"forward-tracing-headers" cfg:"forward_tracing_headers"`
+
 	// internal values that are set after config validation
 	redirectURL        *url.URL
 	provider           providers.Provider

--- a/pkg/apis/options/options.go
+++ b/pkg/apis/options/options.go
@@ -170,6 +170,7 @@ func NewFlagSet() *pflag.FlagSet {
 	flagSet.String("real-client-ip-header", "X-Real-IP", "Header used to determine the real IP of the client (one of: X-Forwarded-For, X-Real-IP, or X-ProxyUser-IP)")
 	flagSet.StringSlice("trusted-ip", []string{}, "list of IPs or CIDR ranges to allow to bypass authentication. WARNING: trusting by IP has inherent security flaws, read the configuration documentation for more information.")
 	flagSet.Bool("force-https", false, "force HTTPS redirect for HTTP requests")
+	flagSet.Bool("forward-tracing-headers", false, "forward zipkin/jaeger compatible headers from the upstream to the downstreams")
 	flagSet.String("tls-cert-file", "", "path to certificate file")
 	flagSet.String("tls-key-file", "", "path to private key file")
 	flagSet.String("redirect-url", "", "the OAuth Redirect URL. ie: \"https://internalapp.yourcompany.com/oauth2/callback\"")

--- a/pkg/requests/builder.go
+++ b/pkg/requests/builder.go
@@ -49,7 +49,7 @@ func (r *builder) WithContext(ctx context.Context) Builder {
 }
 
 func (r *builder) injectTracingHeaders(ctx context.Context) Builder {
-	headers, ok := tracing.TracingFromContext(ctx)
+	headers, ok := tracing.FromContext(ctx)
 	if !ok {
 		return r
 	}

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -9,7 +9,7 @@ type key int
 
 var tracingHeadersKey key
 
-func NewTracingContext(req *http.Request) context.Context {
+func NewContext(req *http.Request) context.Context {
 	headers := http.Header{}
 	addHeader := func(header string) {
 		if val := req.Header.Get(header); val != "" {
@@ -30,7 +30,7 @@ func NewTracingContext(req *http.Request) context.Context {
 	return context.WithValue(req.Context(), tracingHeadersKey, &headers)
 }
 
-func TracingFromContext(ctx context.Context) (*http.Header, bool) {
+func FromContext(ctx context.Context) (*http.Header, bool) {
 	u, ok := ctx.Value(tracingHeadersKey).(*http.Header)
 	return u, ok
 }

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -1,0 +1,36 @@
+package tracing
+
+import (
+	"context"
+	"net/http"
+)
+
+type key int
+
+var tracingHeadersKey key
+
+func NewTracingContext(req *http.Request) context.Context {
+	headers := http.Header{}
+	addHeader := func(header string) {
+		if val := req.Header.Get(header); val != "" {
+			headers.Set(header, val)
+		}
+	}
+
+	// https://istio.io/latest/faq/distributed-tracing/#how-to-support-tracing
+	addHeader("x-request-id")
+	addHeader("x-b3-traceid")
+	addHeader("x-b3-spanid")
+	addHeader("x-b3-parentspanid")
+	addHeader("x-b3-sampled")
+	addHeader("x-b3-flags")
+	addHeader("b3")
+	addHeader("x-ot-span-context")
+
+	return context.WithValue(req.Context(), tracingHeadersKey, &headers)
+}
+
+func TracingFromContext(ctx context.Context) (*http.Header, bool) {
+	u, ok := ctx.Value(tracingHeadersKey).(*http.Header)
+	return u, ok
+}


### PR DESCRIPTION
Adds an option to forward any incoming distributed tracing headers to the upstream.

## Description

This follows the generic [istio guidelines](https://istio.io/latest/faq/distributed-tracing/#how-to-support-tracing) on tracing and forwards the relevant headers. It will work with any other zipkin/jaeger tracer too, however this change doesn't make oauth2-proxy generate its own spans, so the relevant traces must be forwarded by the downstream and upstream.

## Motivation and Context

This allows to see the detailed traces going through the auth chain:

![image](https://user-images.githubusercontent.com/693/109502409-d5749a00-7a90-11eb-8495-bc675dacaa32.png)

## How Has This Been Tested?

As there's little code logic to test, this change was tested on a live istio cluster with ingress & egress gateways, verifying that the relevant spans are present.

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
