### PR TITLE
Keycloak OIDC Provider

### DIFF
--- a/pkg/apis/options/options.go
+++ b/pkg/apis/options/options.go
@@ -33,7 +33,6 @@ type Options struct {
 
 	AuthenticatedEmailsFile  string   `flag:"authenticated-emails-file" cfg:"authenticated_emails_file"`
 	KeycloakGroups           []string `flag:"keycloak-group" cfg:"keycloak_groups"`
-	KeycloakRoles            []string `flag:"keycloak-role" cfg:"keycloak_roles"`
 	AzureTenant              string   `flag:"azure-tenant" cfg:"azure_tenant"`
 	BitbucketTeam            string   `flag:"bitbucket-team" cfg:"bitbucket_team"`
 	BitbucketRepository      string   `flag:"bitbucket-repository" cfg:"bitbucket_repository"`
@@ -97,6 +96,7 @@ type Options struct {
 	ApprovalPrompt                     string   `flag:"approval-prompt" cfg:"approval_prompt"` // Deprecated by OIDC 1.0
 	UserIDClaim                        string   `flag:"user-id-claim" cfg:"user_id_claim"`
 	AllowedGroups                      []string `flag:"allowed-group" cfg:"allowed_groups"`
+	AllowedRoles                       []string `flag:"allowed-role" cfg:"allowed_roles"`
 
 	SignatureKey    string `flag:"signature-key" cfg:"signature_key"`
 	AcrValues       string `flag:"acr-values" cfg:"acr_values"`
@@ -174,7 +174,6 @@ func NewFlagSet() *pflag.FlagSet {
 	flagSet.StringSlice("email-domain", []string{}, "authenticate emails with the specified domain (may be given multiple times). Use * to authenticate any email")
 	flagSet.StringSlice("whitelist-domain", []string{}, "allowed domains for redirection after authentication. Prefix domain with a . to allow subdomains (eg .example.com)")
 	flagSet.StringSlice("keycloak-group", []string{}, "restrict logins to members of these groups (may be given multiple times)")
-	flagSet.StringSlice("keycloak-role", []string{}, "restrict logins to members of these roles (may be given multiple times)")
 	flagSet.String("azure-tenant", "common", "go to a tenant-specific or common (tenant-independent) endpoint.")
 	flagSet.String("bitbucket-team", "", "restrict logins to members of this team")
 	flagSet.String("bitbucket-repository", "", "restrict logins to user with access to this repository")
@@ -238,6 +237,7 @@ func NewFlagSet() *pflag.FlagSet {
 
 	flagSet.String("user-id-claim", providers.OIDCEmailClaim, "(DEPRECATED for `oidc-email-claim`) which claim contains the user ID")
 	flagSet.StringSlice("allowed-group", []string{}, "restrict logins to members of this group (may be given multiple times)")
+	flagSet.StringSlice("allowed-role", []string{}, "(keycloak-oidc) restrict logins to members of these roles (may be given multiple times)")
 
 	flagSet.AddFlagSet(cookieFlagSet())
 	flagSet.AddFlagSet(loggingFlagSet())

--- a/pkg/apis/options/options.go
+++ b/pkg/apis/options/options.go
@@ -33,6 +33,7 @@ type Options struct {
 
 	AuthenticatedEmailsFile  string   `flag:"authenticated-emails-file" cfg:"authenticated_emails_file"`
 	KeycloakGroups           []string `flag:"keycloak-group" cfg:"keycloak_groups"`
+	KeycloakRoles            []string `flag:"keycloak-role" cfg:"keycloak_roles"`
 	AzureTenant              string   `flag:"azure-tenant" cfg:"azure_tenant"`
 	BitbucketTeam            string   `flag:"bitbucket-team" cfg:"bitbucket_team"`
 	BitbucketRepository      string   `flag:"bitbucket-repository" cfg:"bitbucket_repository"`
@@ -173,6 +174,7 @@ func NewFlagSet() *pflag.FlagSet {
 	flagSet.StringSlice("email-domain", []string{}, "authenticate emails with the specified domain (may be given multiple times). Use * to authenticate any email")
 	flagSet.StringSlice("whitelist-domain", []string{}, "allowed domains for redirection after authentication. Prefix domain with a . to allow subdomains (eg .example.com)")
 	flagSet.StringSlice("keycloak-group", []string{}, "restrict logins to members of these groups (may be given multiple times)")
+	flagSet.StringSlice("keycloak-role", []string{}, "restrict logins to members of these roles (may be given multiple times)")
 	flagSet.String("azure-tenant", "common", "go to a tenant-specific or common (tenant-independent) endpoint.")
 	flagSet.String("bitbucket-team", "", "restrict logins to members of this team")
 	flagSet.String("bitbucket-repository", "", "restrict logins to user with access to this repository")

--- a/pkg/validation/options.go
+++ b/pkg/validation/options.go
@@ -272,16 +272,7 @@ func parseProviderInfo(o *options.Options, msgs []string) []string {
 		if p.Verifier == nil {
 			msgs = append(msgs, "keycloak-oidc provider requires an oidc issuer URL")
 		}
-
-		// Backwards compatibility with `--keycloak-group` option
-		if len(o.KeycloakGroups) > 0 {
-			// Maybe already added with `--allowed-group` flag
-			if !strings.Contains(o.Scope, " groups") {
-				o.Scope += " groups"
-			}
-			p.SetAllowedGroups(o.KeycloakGroups)
-		}
-		p.AddAllowedRoles(o.KeycloakRoles)
+		p.AddAllowedRoles(o.AllowedRoles)
 	case *providers.GoogleProvider:
 		if o.GoogleServiceAccountJSON != "" {
 			file, err := os.Open(o.GoogleServiceAccountJSON)

--- a/pkg/validation/options.go
+++ b/pkg/validation/options.go
@@ -268,6 +268,19 @@ func parseProviderInfo(o *options.Options, msgs []string) []string {
 		if len(o.KeycloakGroups) > 0 {
 			p.SetAllowedGroups(o.KeycloakGroups)
 		}
+	case *providers.KeycloakOIDCProvider:
+		if p.Verifier == nil {
+			msgs = append(msgs, "keycloak-oidc provider requires an oidc issuer URL")
+		}
+
+		// Backwards compatibility with `--keycloak-group` option
+		if len(o.KeycloakGroups) > 0 {
+			// Maybe already added with proper `--allowed-group` flag
+			if !strings.Contains(o.Scope, " groups") {
+				o.Scope += " groups"
+			}
+			p.SetAllowedGroups(o.KeycloakGroups)
+		}
 	case *providers.GoogleProvider:
 		if o.GoogleServiceAccountJSON != "" {
 			file, err := os.Open(o.GoogleServiceAccountJSON)
@@ -286,10 +299,6 @@ func parseProviderInfo(o *options.Options, msgs []string) []string {
 	case *providers.BitbucketProvider:
 		p.SetTeam(o.BitbucketTeam)
 		p.SetRepository(o.BitbucketRepository)
-	case *providers.OIDCProvider:
-		if p.Verifier == nil {
-			msgs = append(msgs, "oidc provider requires an oidc issuer URL")
-		}
 	case *providers.GitLabProvider:
 		p.Groups = o.GitLabGroup
 		err := p.AddProjects(o.GitlabProjects)
@@ -344,6 +353,10 @@ func parseProviderInfo(o *options.Options, msgs []string) []string {
 			} else {
 				p.JWTKey = signKey
 			}
+		}
+	case *providers.OIDCProvider:
+		if p.Verifier == nil {
+			msgs = append(msgs, "oidc provider requires an oidc issuer URL")
 		}
 	}
 	return msgs

--- a/pkg/validation/options.go
+++ b/pkg/validation/options.go
@@ -275,12 +275,13 @@ func parseProviderInfo(o *options.Options, msgs []string) []string {
 
 		// Backwards compatibility with `--keycloak-group` option
 		if len(o.KeycloakGroups) > 0 {
-			// Maybe already added with proper `--allowed-group` flag
+			// Maybe already added with `--allowed-group` flag
 			if !strings.Contains(o.Scope, " groups") {
 				o.Scope += " groups"
 			}
 			p.SetAllowedGroups(o.KeycloakGroups)
 		}
+		p.AddAllowedRoles(o.KeycloakRoles)
 	case *providers.GoogleProvider:
 		if o.GoogleServiceAccountJSON != "" {
 			file, err := os.Open(o.GoogleServiceAccountJSON)

--- a/providers/keycloak_oidc.go
+++ b/providers/keycloak_oidc.go
@@ -2,8 +2,10 @@ package providers
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/sessions"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/logger"
 )
 
 const keycloakOIDCProviderName = "Keycloak OIDC"
@@ -25,6 +27,15 @@ func NewKeycloakOIDCProvider(p *ProviderData) *KeycloakOIDCProvider {
 
 var _ Provider = (*KeycloakOIDCProvider)(nil)
 
+// AddAllowedRoles sets Keycloak roles that are authorized.
+// Assumes `SetAllowedGroups` is already called on groups and appends to that
+// with `role:` prefixed roles.
+func (p *KeycloakOIDCProvider) AddAllowedRoles(roles []string) {
+	for _, role := range roles {
+		p.AllowedGroups[formatRole(role)] = struct{}{}
+	}
+}
+
 // EnrichSession is called after Redeem to allow providers to enrich session fields
 // such as User, Email, Groups with provider specific API calls.
 func (p *KeycloakOIDCProvider) EnrichSession(ctx context.Context, s *sessions.SessionState) error {
@@ -36,6 +47,83 @@ func (p *KeycloakOIDCProvider) EnrichSession(ctx context.Context, s *sessions.Se
 }
 
 func (p *KeycloakOIDCProvider) extractRoles(ctx context.Context, s *sessions.SessionState) error {
-	// TODO: Implement me with Access Token Role claim extraction logic
-	return ErrNotImplemented
+	claims, err := p.getAccessClaims(ctx, s)
+	if err != nil {
+		return err
+	}
+
+	var roles []string
+	roles = append(roles, claims.RealmAccess.Roles...)
+	roles = append(roles, getClientRoles(claims)...)
+
+	// Add to groups list with `role:` prefix to distinguish from groups
+	for _, role := range roles {
+		s.Groups = append(s.Groups, formatRole(role))
+	}
+	return nil
+}
+
+type realmAccess struct {
+	Roles []string `json:"roles"`
+}
+
+type accessClaims struct {
+	RealmAccess    realmAccess            `json:"realm_access"`
+	ResourceAccess map[string]interface{} `json:"resource_access"`
+}
+
+func (p *KeycloakOIDCProvider) getAccessClaims(ctx context.Context, s *sessions.SessionState) (*accessClaims, error) {
+	// HACK: This isn't an ID Token, but has similar structure & signing
+	token, err := p.Verifier.Verify(ctx, s.AccessToken)
+	if err != nil {
+		return nil, err
+	}
+
+	var claims *accessClaims
+	if err = token.Claims(&claims); err != nil {
+		return nil, err
+	}
+	return claims, nil
+}
+
+// getClientRoles extracts client roles from the `resource_access` claim with
+// the format `client:role`.
+//
+// ResourceAccess format:
+// "resource_access": {
+//   "clientA": {
+//     "roles": [
+//       "roleA"
+//     ]
+//   },
+//   "clientB": {
+//     "roles": [
+//       "roleA",
+//       "roleB",
+//       "roleC"
+//     ]
+//   }
+// }
+func getClientRoles(claims *accessClaims) []string {
+	var clientRoles []string
+	for clientName, access := range claims.ResourceAccess {
+		accessMap, ok := access.(map[string]interface{})
+		if !ok {
+			logger.Errorf("Unable to parse client roles from claims for client: %v", clientName)
+			continue
+		}
+
+		var roles interface{}
+		if roles, ok = accessMap["roles"]; !ok {
+			continue
+		}
+		for _, role := range roles.([]interface{}) {
+			clientRoles = append(clientRoles, fmt.Sprintf("%s:%s", clientName, role))
+		}
+	}
+	return clientRoles
+}
+
+func formatRole(role string) string {
+	return fmt.Sprintf("role:%s", role)
 }

--- a/providers/keycloak_oidc.go
+++ b/providers/keycloak_oidc.go
@@ -1,0 +1,41 @@
+package providers
+
+import (
+	"context"
+
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/sessions"
+)
+
+const keycloakOIDCProviderName = "Keycloak OIDC"
+
+// KeycloakOIDCProvider creates a Keycloak provider based on OIDCProvider
+type KeycloakOIDCProvider struct {
+	*OIDCProvider
+}
+
+// NewKeycloakOIDCProvider makes a KeycloakOIDCProvider using the ProviderData
+func NewKeycloakOIDCProvider(p *ProviderData) *KeycloakOIDCProvider {
+	p.ProviderName = keycloakOIDCProviderName
+	return &KeycloakOIDCProvider{
+		OIDCProvider: &OIDCProvider{
+			ProviderData: p,
+		},
+	}
+}
+
+var _ Provider = (*KeycloakOIDCProvider)(nil)
+
+// EnrichSession is called after Redeem to allow providers to enrich session fields
+// such as User, Email, Groups with provider specific API calls.
+func (p *KeycloakOIDCProvider) EnrichSession(ctx context.Context, s *sessions.SessionState) error {
+	err := p.OIDCProvider.EnrichSession(ctx, s)
+	if err != nil {
+		return err
+	}
+	return p.extractRoles(ctx, s)
+}
+
+func (p *KeycloakOIDCProvider) extractRoles(ctx context.Context, s *sessions.SessionState) error {
+	// TODO: Implement me with Access Token Role claim extraction logic
+	return ErrNotImplemented
+}

--- a/providers/keycloak_oidc_test.go
+++ b/providers/keycloak_oidc_test.go
@@ -1,0 +1,42 @@
+package providers
+
+import (
+	"net/url"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Keycloak OIDC Provider Tests", func() {
+	Context("New Provider Init", func() {
+		It("uses the passed ProviderData", func() {
+			p := NewKeycloakOIDCProvider(
+				&ProviderData{
+					LoginURL: &url.URL{
+						Scheme: "https",
+						Host:   "keycloak-oidc.com",
+						Path:   "/oauth/auth"},
+					RedeemURL: &url.URL{
+						Scheme: "https",
+						Host:   "keycloak-oidc.com",
+						Path:   "/oauth/token"},
+					ProfileURL: &url.URL{
+						Scheme: "https",
+						Host:   "keycloak-oidc.com",
+						Path:   "/api/v3/user"},
+					ValidateURL: &url.URL{
+						Scheme: "https",
+						Host:   "keycloak-oidc.com",
+						Path:   "/api/v3/user"},
+					Scope: "openid email profile"})
+			providerData := p.Data()
+
+			Expect(providerData.ProviderName).To(Equal(keycloakOIDCProviderName))
+			Expect(providerData.LoginURL.String()).To(Equal("https://keycloak-oidc.com/oauth/auth"))
+			Expect(providerData.RedeemURL.String()).To(Equal("https://keycloak-oidc.com/oauth/token"))
+			Expect(providerData.ProfileURL.String()).To(Equal("https://keycloak-oidc.com/api/v3/user"))
+			Expect(providerData.ValidateURL.String()).To(Equal("https://keycloak-oidc.com/api/v3/user"))
+			Expect(providerData.Scope).To(Equal("openid email profile"))
+		})
+	})
+})

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -31,6 +31,8 @@ func New(provider string, p *ProviderData) Provider {
 		return NewGitHubProvider(p)
 	case "keycloak":
 		return NewKeycloakProvider(p)
+	case "keycloak-oidc":
+		return NewKeycloakOIDCProvider(p)
 	case "azure":
 		return NewAzureProvider(p)
 	case "gitlab":


### PR DESCRIPTION
Make Keycloak Provider that completely uses OIDC functionality

## Description

Keycloak is OIDC and we should deprecate the OAuth based `keycloak` provider that supports limited functionality.

## Motivation and Context

We get all the feature sets we add to the OIDCProvider. Any Keycloak specific extensions (e.g. Roles from Access Token claims) can be layered on top of OIDC capabilities.

## How Has This Been Tested?

Unit Tests - Keycloak community testing & feedback desired.

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
