### PR TITLE
Add alternative ways to generate cookie secrets to docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Changes since v7.1.3
 
+- [#1108](https://github.com/oauth2-proxy/oauth2-proxy/pull/1108) Add alternative ways to generate cookie secrets to docs (@JoelSpeed)
 - [#1142](https://github.com/oauth2-proxy/oauth2-proxy/pull/1142) Add pagewriter to upstream proxy (@JoelSpeed)
 - [#1181](https://github.com/oauth2-proxy/oauth2-proxy/pull/1181) Fix incorrect `cfg` name in show-debug-on-error flag (@iTaybb)
 

--- a/docs/docs/configuration/overview.md
+++ b/docs/docs/configuration/overview.md
@@ -7,7 +7,62 @@ title: Overview
 
 ### Generating a Cookie Secret
 
-To generate a strong cookie secret use `python -c 'import os,base64; print(base64.urlsafe_b64encode(os.urandom(16)).decode())'`
+To generate a strong cookie secret use one of the below commands:
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs
+  defaultValue="python"
+  values={[
+    {label: 'Python', value: 'python'},
+    {label: 'Bash', value: 'bash'},
+    {label: 'OpenSSL', value: 'openssl'},
+    {label: 'PowerShell', value: 'powershell'},
+    {label: 'Terraform', value: 'terraform'},
+  ]}>
+  <TabItem value="python">
+
+  ```shell
+  python -c 'import os,base64; print(base64.urlsafe_b64encode(os.urandom(32)).decode())'
+  ```
+
+  </TabItem>
+  <TabItem value="bash">
+
+  ```shell
+  cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1 | base64
+  ```
+
+  </TabItem>
+  <TabItem value="openssl">
+
+  ```shell
+  openssl rand -base64 32 | tr -- '+/' '-_'
+  ```
+
+  </TabItem>
+  <TabItem value="powershell">
+
+  ```shell
+  # Add System.Web assembly to session, just in case
+  Add-Type -AssemblyName System.Web
+  [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes([System.Web.Security.Membership]::GeneratePassword(32,4))).Replace("+","-").Replace("/","_")
+  ```
+
+  </TabItem>
+  <TabItem value="terraform">
+
+  ```shell
+  # Valid 32 Byte Base64 URL encoding set that will decode to 24 []byte AES-192 secret
+  resource "random_password" "cookie_secret" {
+    length           = 32
+    override_special = "-_"
+  }
+  ```
+
+  </TabItem>
+</Tabs>
 
 ### Config File
 

--- a/docs/versioned_docs/version-6.1.x/configuration/overview.md
+++ b/docs/versioned_docs/version-6.1.x/configuration/overview.md
@@ -7,7 +7,62 @@ title: Overview
 
 ### Generating a Cookie Secret
 
-To generate a strong cookie secret use `python -c 'import os,base64; print(base64.urlsafe_b64encode(os.urandom(16)).decode())'`
+To generate a strong cookie secret use one of the below commands:
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs
+  defaultValue="python"
+  values={[
+    {label: 'Python', value: 'python'},
+    {label: 'Bash', value: 'bash'},
+    {label: 'OpenSSL', value: 'openssl'},
+    {label: 'PowerShell', value: 'powershell'},
+    {label: 'Terraform', value: 'terraform'},
+  ]}>
+  <TabItem value="python">
+
+  ```shell
+  python -c 'import os,base64; print(base64.urlsafe_b64encode(os.urandom(32)).decode())'
+  ```
+
+  </TabItem>
+  <TabItem value="bash">
+
+  ```shell
+  cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1 | base64
+  ```
+
+  </TabItem>
+  <TabItem value="openssl">
+
+  ```shell
+  openssl rand -base64 32 | tr -- '+/' '-_'
+  ```
+
+  </TabItem>
+  <TabItem value="powershell">
+
+  ```shell
+  # Add System.Web assembly to session, just in case
+  Add-Type -AssemblyName System.Web
+  [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes([System.Web.Security.Membership]::GeneratePassword(32,4))).Replace("+","-").Replace("/","_")
+  ```
+
+  </TabItem>
+  <TabItem value="terraform">
+
+  ```shell
+  # Valid 32 Byte Base64 URL encoding set that will decode to 24 []byte AES-192 secret
+  resource "random_password" "cookie_secret" {
+    length           = 32
+    override_special = "-_"
+  }
+  ```
+
+  </TabItem>
+</Tabs>
 
 ### Config File
 

--- a/docs/versioned_docs/version-7.0.x/configuration/overview.md
+++ b/docs/versioned_docs/version-7.0.x/configuration/overview.md
@@ -7,7 +7,62 @@ title: Overview
 
 ### Generating a Cookie Secret
 
-To generate a strong cookie secret use `python -c 'import os,base64; print(base64.urlsafe_b64encode(os.urandom(16)).decode())'`
+To generate a strong cookie secret use one of the below commands:
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs
+  defaultValue="python"
+  values={[
+    {label: 'Python', value: 'python'},
+    {label: 'Bash', value: 'bash'},
+    {label: 'OpenSSL', value: 'openssl'},
+    {label: 'PowerShell', value: 'powershell'},
+    {label: 'Terraform', value: 'terraform'},
+  ]}>
+  <TabItem value="python">
+
+  ```shell
+  python -c 'import os,base64; print(base64.urlsafe_b64encode(os.urandom(32)).decode())'
+  ```
+
+  </TabItem>
+  <TabItem value="bash">
+
+  ```shell
+  cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1 | base64
+  ```
+
+  </TabItem>
+  <TabItem value="openssl">
+
+  ```shell
+  openssl rand -base64 32 | tr -- '+/' '-_'
+  ```
+
+  </TabItem>
+  <TabItem value="powershell">
+
+  ```shell
+  # Add System.Web assembly to session, just in case
+  Add-Type -AssemblyName System.Web
+  [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes([System.Web.Security.Membership]::GeneratePassword(32,4))).Replace("+","-").Replace("/","_")
+  ```
+
+  </TabItem>
+  <TabItem value="terraform">
+
+  ```shell
+  # Valid 32 Byte Base64 URL encoding set that will decode to 24 []byte AES-192 secret
+  resource "random_password" "cookie_secret" {
+    length           = 32
+    override_special = "-_"
+  }
+  ```
+
+  </TabItem>
+</Tabs>
 
 ### Config File
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Add bash and openssl alternatives to python to allow users to generate cookie secrets if they do not have python available.
I don't have a windows machine handy right now (or much knowledge of powershell) but would be good to add a powershell example too.

If we are happy with the content, I will copy this to the other docs versions too

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Not everyone will have Python, we can try and help them out with some alternative examples.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`yarn start` in the docs folder to check it all compiles and renders correctly

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
