### PR TITLE
Panic with GitLab project repository auth

### DIFF
--- a/providers/gitlab.go
+++ b/providers/gitlab.go
@@ -329,9 +329,14 @@ func (p *GitLabProvider) addProjectsToSession(ctx context.Context, s *sessions.S
 			if perms == nil {
 				// use group project access as fallback
 				perms = projectInfo.Permissions.GroupAccess
+				// group project access is not set for this user then we give up
+				if perms == nil {
+					logger.Errorf("Warning: user %q has no project level access to %s", s.Email, project.Name)
+					continue
+				}
 			}
 
-			if perms.AccessLevel >= project.AccessLevel {
+			if perms != nil && perms.AccessLevel >= project.AccessLevel {
 				s.Groups = append(s.Groups, fmt.Sprintf("project:%s", project.Name))
 			} else {
 				logger.Errorf("Warning: user %q does not have the minimum required access level for project %q", s.Email, project.Name)


### PR DESCRIPTION
* /api/v4/projects/:id can return nil permissions

Signed-off-by: Piers Harding <piers@ompka.net>

## Description

Check project API payload for `nil` in GroupAccess value.

fixes #1111 

## Motivation and Context

This PR addresses #1111 - where the GitLab projects API (https://docs.gitlab.com/ee/api/projects.html) does not necessarily return a GroupAccess value.  The resulting permissions are now checked for `nil` to mitigate this.

## How Has This Been Tested?

The change has been tested with setting `--gitlab-project=ska-telescope/ska-tango-images=30`, and running against the patched image registry.gitlab.com/piersharding/oauth2-proxy:latest .


## Checklist:

(not too sure about these settings)

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
