### PR TITLE
Fix upstream proxy appending `?` to requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ## Changes since v7.0.1
 
+- [#1115](https://github.com/oauth2-proxy/oauth2-proxy/pull/1115) Fix upstream proxy appending ? to requests (@JoelSpeed)
 - [#1117](https://github.com/oauth2-proxy/oauth2-proxy/pull/1117)  Deprecate GCP HealthCheck option (@JoelSpeed)
 - [#1104](https://github.com/oauth2-proxy/oauth2-proxy/pull/1104) Allow custom robots text pages (@JoelSpeed)
 - [#1045](https://github.com/oauth2-proxy/oauth2-proxy/pull/1045) Ensure redirect URI always has a scheme (@JoelSpeed)

--- a/pkg/upstream/http.go
+++ b/pkg/upstream/http.go
@@ -116,11 +116,11 @@ func newReverseProxy(target *url.URL, upstream options.Upstream, errorHandler Pr
 		}
 	}
 
-	// Set the request director based on the PassHostHeader option
+	// Ensure we always pass the original request path
+	setProxyDirector(proxy)
+
 	if upstream.PassHostHeader != nil && !*upstream.PassHostHeader {
 		setProxyUpstreamHostHeader(proxy, target)
-	} else {
-		setProxyDirector(proxy)
 	}
 
 	// Set the error handler so that upstream connection failures render the
@@ -137,10 +137,7 @@ func setProxyUpstreamHostHeader(proxy *httputil.ReverseProxy, target *url.URL) {
 	director := proxy.Director
 	proxy.Director = func(req *http.Request) {
 		director(req)
-		// use RequestURI so that we aren't unescaping encoded slashes in the request path
 		req.Host = target.Host
-		req.URL.Opaque = req.RequestURI
-		req.URL.RawQuery = ""
 	}
 }
 

--- a/pkg/upstream/http.go
+++ b/pkg/upstream/http.go
@@ -153,6 +153,7 @@ func setProxyDirector(proxy *httputil.ReverseProxy) {
 		// use RequestURI so that we aren't unescaping encoded slashes in the request path
 		req.URL.Opaque = req.RequestURI
 		req.URL.RawQuery = ""
+		req.URL.ForceQuery = false
 	}
 }
 

--- a/pkg/upstream/http_test.go
+++ b/pkg/upstream/http_test.go
@@ -140,6 +140,29 @@ var _ = Describe("HTTP Upstream Suite", func() {
 			},
 			expectedUpstream: "encodedSlashes",
 		}),
+		Entry("request a path with an empty query string", &httpUpstreamTableInput{
+			id:           "default",
+			serverAddr:   &serverAddr,
+			target:       "http://example.localhost/foo?",
+			method:       "GET",
+			body:         []byte{},
+			errorHandler: nil,
+			expectedResponse: testHTTPResponse{
+				code: 200,
+				header: map[string][]string{
+					contentType: {applicationJSON},
+				},
+				request: testHTTPRequest{
+					Method:     "GET",
+					URL:        "http://example.localhost/foo?",
+					Header:     map[string][]string{},
+					Body:       []byte{},
+					Host:       "example.localhost",
+					RequestURI: "http://example.localhost/foo?",
+				},
+			},
+			expectedUpstream: "default",
+		}),
 		Entry("when the request has a body", &httpUpstreamTableInput{
 			id:           "requestWithBody",
 			serverAddr:   &serverAddr,

--- a/pkg/upstream/http_test.go
+++ b/pkg/upstream/http_test.go
@@ -30,16 +30,17 @@ var _ = Describe("HTTP Upstream Suite", func() {
 	falsum := false
 
 	type httpUpstreamTableInput struct {
-		id               string
-		serverAddr       *string
-		target           string
-		method           string
-		body             []byte
-		signatureData    *options.SignatureData
-		existingHeaders  map[string]string
-		expectedResponse testHTTPResponse
-		expectedUpstream string
-		errorHandler     ProxyErrorHandler
+		id                     string
+		serverAddr             *string
+		target                 string
+		method                 string
+		body                   []byte
+		passUpstreamHostHeader bool
+		signatureData          *options.SignatureData
+		existingHeaders        map[string]string
+		expectedResponse       testHTTPResponse
+		expectedUpstream       string
+		errorHandler           ProxyErrorHandler
 	}
 
 	DescribeTable("HTTP Upstream ServeHTTP",
@@ -52,6 +53,9 @@ var _ = Describe("HTTP Upstream Suite", func() {
 			for key, value := range in.existingHeaders {
 				req.Header.Add(key, value)
 			}
+			if host := req.Header.Get("Host"); host != "" {
+				req.Host = host
+			}
 
 			req = middlewareapi.AddRequestScope(req, &middlewareapi.RequestScope{})
 			rw := httptest.NewRecorder()
@@ -60,7 +64,7 @@ var _ = Describe("HTTP Upstream Suite", func() {
 
 			upstream := options.Upstream{
 				ID:                    in.id,
-				PassHostHeader:        &truth,
+				PassHostHeader:        &in.passUpstreamHostHeader,
 				ProxyWebSockets:       &falsum,
 				InsecureSkipTLSVerify: false,
 				FlushInterval:         &flush,
@@ -279,6 +283,33 @@ var _ = Describe("HTTP Upstream Suite", func() {
 				},
 			},
 			expectedUpstream: "existingHeaders",
+		}),
+		Entry("when passing the existing host header", &httpUpstreamTableInput{
+			id:                     "passExistingHostHeader",
+			serverAddr:             &serverAddr,
+			target:                 "/existingHostHeader",
+			method:                 "GET",
+			body:                   []byte{},
+			errorHandler:           nil,
+			passUpstreamHostHeader: true,
+			existingHeaders: map[string]string{
+				"Host": "existing-host",
+			},
+			expectedResponse: testHTTPResponse{
+				code: 200,
+				header: map[string][]string{
+					contentType: {applicationJSON},
+				},
+				request: testHTTPRequest{
+					Method:     "GET",
+					URL:        "/existingHostHeader",
+					Header:     map[string][]string{},
+					Body:       []byte{},
+					Host:       "existing-host",
+					RequestURI: "/existingHostHeader",
+				},
+			},
+			expectedUpstream: "passExistingHostHeader",
 		}),
 	)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Overwrite force query in the proxy director to prevent it appending a `?` to every request that ends with `?`

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When a URL is parsed, if it ends with `?`, the URL gets the force query param set.
When the string is converted back to a string, if force query is set, then a `?` is added to the end no matter what the query string is.

Since we use the opaque request in the director and overwrite the query (to prevent it being appended), we also need to set force query to false.

Fixes #1112 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests and local testing environment

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
