### PR TITLE
Reinstate preferEmailToUser behaviour for basic auth sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ## Changes since v7.0.1
 
+- [#1116](https://github.com/oauth2-proxy/oauth2-proxy/pull/1116) Reinstate preferEmailToUser behaviour for basic auth sessions (@JoelSpeed)
 - [#1115](https://github.com/oauth2-proxy/oauth2-proxy/pull/1115) Fix upstream proxy appending ? to requests (@JoelSpeed)
 - [#1117](https://github.com/oauth2-proxy/oauth2-proxy/pull/1117)  Deprecate GCP HealthCheck option (@JoelSpeed)
 - [#1104](https://github.com/oauth2-proxy/oauth2-proxy/pull/1104) Allow custom robots text pages (@JoelSpeed)

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -343,7 +343,7 @@ func buildSessionChain(opts *options.Options, sessionStore sessionsapi.SessionSt
 	}
 
 	if validator != nil {
-		chain = chain.Append(middleware.NewBasicAuthSessionLoader(validator, opts.HtpasswdUserGroups))
+		chain = chain.Append(middleware.NewBasicAuthSessionLoader(validator, opts.HtpasswdUserGroups, opts.LegacyPreferEmailToUser))
 	}
 
 	chain = chain.Append(middleware.NewStoredSessionLoader(&middleware.StoredSessionLoaderOptions{

--- a/pkg/apis/options/legacy_options.go
+++ b/pkg/apis/options/legacy_options.go
@@ -67,6 +67,8 @@ func (l *LegacyOptions) ToOptions() (*Options, error) {
 	l.Options.InjectRequestHeaders, l.Options.InjectResponseHeaders = l.LegacyHeaders.convert()
 	l.Options.Server, l.Options.MetricsServer = l.LegacyServer.convert()
 
+	l.Options.LegacyPreferEmailToUser = l.LegacyHeaders.PreferEmailToUser
+
 	return &l.Options, nil
 }
 

--- a/pkg/apis/options/options.go
+++ b/pkg/apis/options/options.go
@@ -104,6 +104,9 @@ type Options struct {
 	PubJWKURL       string `flag:"pubjwk-url" cfg:"pubjwk_url"`
 	GCPHealthChecks bool   `flag:"gcp-healthchecks" cfg:"gcp_healthchecks"`
 
+	// This is used for backwards compatibility for basic auth users
+	LegacyPreferEmailToUser bool `cfg:",internal"`
+
 	// internal values that are set after config validation
 	redirectURL        *url.URL
 	provider           providers.Provider

--- a/pkg/middleware/basic_session_test.go
+++ b/pkg/middleware/basic_session_test.go
@@ -26,6 +26,7 @@ var _ = Describe("Basic Auth Session Suite", func() {
 
 		type basicAuthSessionLoaderTableInput struct {
 			authorizationHeader string
+			preferEmail         bool
 			sessionGroups       []string
 			existingSession     *sessionsapi.SessionState
 			expectedSession     *sessionsapi.SessionState
@@ -55,7 +56,7 @@ var _ = Describe("Basic Auth Session Suite", func() {
 				// Create the handler with a next handler that will capture the session
 				// from the scope
 				var gotSession *sessionsapi.SessionState
-				handler := NewBasicAuthSessionLoader(validator, in.sessionGroups)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				handler := NewBasicAuthSessionLoader(validator, in.sessionGroups, in.preferEmail)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					gotSession = middlewareapi.GetRequestScope(r).Session
 				}))
 				handler.ServeHTTP(rw, req)
@@ -117,6 +118,12 @@ var _ = Describe("Basic Auth Session Suite", func() {
 				sessionGroups:       []string{"a", "b"},
 				existingSession:     nil,
 				expectedSession:     &sessionsapi.SessionState{User: "admin", Groups: []string{"a", "b"}},
+			}),
+			Entry("Basic Base64(user1:<user1Password>) (with PreferEmailToUser)", basicAuthSessionLoaderTableInput{
+				authorizationHeader: "Basic dXNlcjE6VXNFck9uM1A0NTU=",
+				preferEmail:         true,
+				existingSession:     nil,
+				expectedSession:     &sessionsapi.SessionState{User: "user1", Email: "user1"},
 			}),
 		)
 	})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
When we changed the way that headers were injected, we lost the ability for a basic auth session to respect the preferEmailToUser option. This should fix that by copying the user to the email field when the option is supplied

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1079 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
