### PR TITLE
Deprecate GCP HealthCheck option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,16 @@
 - [#1103](https://github.com/oauth2-proxy/oauth2-proxy/pull/1103) Upstream request signatures via `--signature-key` is
   deprecated. Support will be removed completely in v8.0.0.
 - [1087](https://github.com/oauth2-proxy/oauth2-proxy/pull/1087) The default logging templates have been updated to include {{.RequestID}}
+- [#1117](https://github.com/oauth2-proxy/oauth2-proxy/pull/1117) The `--gcp-healthchecks` option is now deprecated. It will be removed in a future release.
+  - To migrate, you can change your application health checks for OAuth2 Proxy to point to
+    the `--ping-path` value.
+  - You can also migrate the user agent based health check using the `--ping-user-agent` option. Set it to `GoogleHC/1.0` to allow health checks on the path `/` from the Google health checker.
 
 ## Breaking Changes
 
 ## Changes since v7.0.1
 
+- [#1117](https://github.com/oauth2-proxy/oauth2-proxy/pull/1117)  Deprecate GCP HealthCheck option (@JoelSpeed)
 - [#1104](https://github.com/oauth2-proxy/oauth2-proxy/pull/1104) Allow custom robots text pages (@JoelSpeed)
 - [#1045](https://github.com/oauth2-proxy/oauth2-proxy/pull/1045) Ensure redirect URI always has a scheme (@JoelSpeed)
 - [#1103](https://github.com/oauth2-proxy/oauth2-proxy/pull/1103) Deprecate upstream request signatures (@NickMeves)

--- a/docs/docs/configuration/overview.md
+++ b/docs/docs/configuration/overview.md
@@ -50,7 +50,6 @@ An example [oauth2-proxy.cfg](https://github.com/oauth2-proxy/oauth2-proxy/blob/
 | `--force-https` | bool | enforce https redirect | `false` |
 | `--banner` | string | custom (html) banner string. Use `"-"` to disable default banner. | |
 | `--footer` | string | custom (html) footer string. Use `"-"` to disable default footer. | |
-| `--gcp-healthchecks` | bool | will enable `/liveness_check`, `/readiness_check`, and `/` (with the proper user-agent) endpoints that will make it work well with GCP App Engine and GKE Ingresses | false |
 | `--github-org` | string | restrict logins to members of this organisation | |
 | `--github-team` | string | restrict logins to members of any of these teams (slug), separated by a comma | |
 | `--github-repo` | string | restrict logins to collaborators of this repository formatted as `orgname/repo` | |

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -302,6 +302,7 @@ func buildPreAuthChain(opts *options.Options) (alice.Chain, error) {
 	healthCheckPaths := []string{opts.PingPath}
 	healthCheckUserAgents := []string{opts.PingUserAgent}
 	if opts.GCPHealthChecks {
+		logger.Printf("WARNING: GCP HealthChecks are now deprecated: Reconfigure apps to use the ping path for liveness and readiness checks, set the ping user agent to \"GoogleHC/1.0\" to preserve existing behaviour")
 		healthCheckPaths = append(healthCheckPaths, "/liveness_check", "/readiness_check")
 		healthCheckUserAgents = append(healthCheckUserAgents, "GoogleHC/1.0")
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
The GCP health check option currently just acts as preconfiguration for the ping path and ping user agent options, we should remove this as we don't need this to be that specific. Users can configure their app health checks to the ping path explicitly.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #614 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
