### PR TITLE
Metrics server should be constructed with secure bind address for TLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Changes since v7.1.0
 
+- [#1133](https://github.com/oauth2-proxy/oauth2-proxy/pull/1133) Metrics server should be constructed with secure bind address for TLS (@JoelSpeed)
+
 # V7.1.0
 
 ## Release Highlights

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -274,7 +274,7 @@ func (p *OAuthProxy) setupServer(opts *options.Options) error {
 	metricsServer, err := proxyhttp.NewServer(proxyhttp.Opts{
 		Handler:           middleware.DefaultMetricsHandler,
 		BindAddress:       opts.MetricsServer.BindAddress,
-		SecureBindAddress: opts.MetricsServer.BindAddress,
+		SecureBindAddress: opts.MetricsServer.SecureBindAddress,
 		TLS:               opts.MetricsServer.TLS,
 	})
 	if err != nil {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
The metrics server secure bind address should be created from the metrics server secure bind address in the opts, there was a typo so it was trying to build from the insecure bind address

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1132 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It hasn't but I know this should fix the code, having recently written the server implementation.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
