### PR TITLE
Add a clock package for better time mocking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Changes since v7.1.2
 
+- [#1136](https://github.com/oauth2-proxy/oauth2-proxy/pull/1136) Add clock package for better time mocking in tests (@NickMeves)
 - [#947](https://github.com/oauth2-proxy/oauth2-proxy/pull/947) Multiple provider ingestion and validation in alpha options (first stage: [#926](https://github.com/oauth2-proxy/oauth2-proxy/issues/926)) (@yanasega)
 
 # V7.1.2

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/Bose/minisentinel v0.0.0-20200130220412-917c5a9223bb
 	github.com/alicebob/miniredis/v2 v2.13.0
-	github.com/benbjohnson/clock v1.1.1-0.20210213131748-c97fc7b6bee0 // indirect
+	github.com/benbjohnson/clock v1.1.1-0.20210213131748-c97fc7b6bee0
 	github.com/bitly/go-simplejson v0.5.0
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/coreos/go-oidc v2.2.1+incompatible

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/Bose/minisentinel v0.0.0-20200130220412-917c5a9223bb
 	github.com/alicebob/miniredis/v2 v2.13.0
+	github.com/benbjohnson/clock v1.1.1-0.20210213131748-c97fc7b6bee0 // indirect
 	github.com/bitly/go-simplejson v0.5.0
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/coreos/go-oidc v2.2.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a/go.mod h1:DAHtR1m6l
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
+github.com/benbjohnson/clock v1.1.1-0.20210213131748-c97fc7b6bee0 h1:ROGOOFsMU1fh3kR94itIWlWiPLtgd4TA/qWi4+lL0GM=
+github.com/benbjohnson/clock v1.1.1-0.20210213131748-c97fc7b6bee0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/pkg/clock/clock.go
+++ b/pkg/clock/clock.go
@@ -55,7 +55,7 @@ func Reset() {
 // package.
 type Clock struct {
 	mock *clockapi.Mock
-	sync.RWMutex
+	sync.Mutex
 }
 
 // Set sets the Clock to a clock.Mock at the given time.Time
@@ -91,8 +91,6 @@ func (c *Clock) After(d time.Duration) <-chan time.Time {
 	if c.mock == nil {
 		return globalClock.After(d)
 	}
-	c.RLock()
-	defer c.RUnlock()
 	return c.mock.After(d)
 }
 
@@ -100,8 +98,6 @@ func (c *Clock) AfterFunc(d time.Duration, f func()) *clockapi.Timer {
 	if c.mock == nil {
 		return globalClock.AfterFunc(d, f)
 	}
-	c.RLock()
-	defer c.RUnlock()
 	return c.mock.AfterFunc(d, f)
 }
 
@@ -109,8 +105,6 @@ func (c *Clock) Now() time.Time {
 	if c.mock == nil {
 		return globalClock.Now()
 	}
-	c.RLock()
-	defer c.RUnlock()
 	return c.mock.Now()
 }
 
@@ -118,8 +112,6 @@ func (c *Clock) Since(t time.Time) time.Duration {
 	if c.mock == nil {
 		return globalClock.Since(t)
 	}
-	c.RLock()
-	defer c.RUnlock()
 	return c.mock.Since(t)
 }
 
@@ -128,8 +120,6 @@ func (c *Clock) Sleep(d time.Duration) {
 		globalClock.Sleep(d)
 		return
 	}
-	c.RLock()
-	defer c.RUnlock()
 	c.mock.Sleep(d)
 }
 
@@ -137,8 +127,6 @@ func (c *Clock) Tick(d time.Duration) <-chan time.Time {
 	if c.mock == nil {
 		return globalClock.Tick(d)
 	}
-	c.RLock()
-	defer c.RUnlock()
 	return c.mock.Tick(d)
 }
 
@@ -146,8 +134,6 @@ func (c *Clock) Ticker(d time.Duration) *clockapi.Ticker {
 	if c.mock == nil {
 		return globalClock.Ticker(d)
 	}
-	c.RLock()
-	defer c.RUnlock()
 	return c.mock.Ticker(d)
 }
 
@@ -155,7 +141,5 @@ func (c *Clock) Timer(d time.Duration) *clockapi.Timer {
 	if c.mock == nil {
 		return globalClock.Timer(d)
 	}
-	c.RLock()
-	defer c.RUnlock()
 	return c.mock.Timer(d)
 }

--- a/pkg/clock/clock.go
+++ b/pkg/clock/clock.go
@@ -53,34 +53,13 @@ func Reset() {
 //
 // If nothing is stubbed, it defaults to default time behavior in the time
 // package.
-type Clock interface {
-	After(time.Duration) <-chan time.Time
-	AfterFunc(time.Duration, func()) *clockapi.Timer
-	Now() time.Time
-	Since(time.Time) time.Duration
-	Sleep(time.Duration)
-	Tick(time.Duration) <-chan time.Time
-	Ticker(time.Duration) *clockapi.Ticker
-	Timer(time.Duration) *clockapi.Timer
-
-	Set(time.Time)
-	Add(time.Duration) error
-	Reset()
-}
-
-type clock struct {
+type Clock struct {
 	mock *clockapi.Mock
-	sync.Mutex
-}
-
-// New returns a Clock that defaults to generic `time` functionality.
-// It can be stubbed locally or fall back to package-level clock mocks.
-func New() Clock {
-	return &clock{}
+	sync.RWMutex
 }
 
 // Set sets the Clock to a clock.Mock at the given time.Time
-func (c *clock) Set(t time.Time) {
+func (c *Clock) Set(t time.Time) {
 	c.Lock()
 	defer c.Unlock()
 	if c.mock == nil {
@@ -91,7 +70,7 @@ func (c *clock) Set(t time.Time) {
 
 // Add moves clock forward time.Duration if it is mocked. It will error
 // if the clock is not mocked.
-func (c *clock) Add(d time.Duration) error {
+func (c *Clock) Add(d time.Duration) error {
 	c.Lock()
 	defer c.Unlock()
 	if c.mock == nil {
@@ -102,65 +81,81 @@ func (c *clock) Add(d time.Duration) error {
 }
 
 // Reset removes local clock.Mock
-func (c *clock) Reset() {
+func (c *Clock) Reset() {
 	c.Lock()
 	defer c.Unlock()
 	c.mock = nil
 }
 
-func (c *clock) After(d time.Duration) <-chan time.Time {
+func (c *Clock) After(d time.Duration) <-chan time.Time {
 	if c.mock == nil {
 		return globalClock.After(d)
 	}
+	c.RLock()
+	defer c.RUnlock()
 	return c.mock.After(d)
 }
 
-func (c *clock) AfterFunc(d time.Duration, f func()) *clockapi.Timer {
+func (c *Clock) AfterFunc(d time.Duration, f func()) *clockapi.Timer {
 	if c.mock == nil {
 		return globalClock.AfterFunc(d, f)
 	}
+	c.RLock()
+	defer c.RUnlock()
 	return c.mock.AfterFunc(d, f)
 }
 
-func (c *clock) Now() time.Time {
+func (c *Clock) Now() time.Time {
 	if c.mock == nil {
 		return globalClock.Now()
 	}
+	c.RLock()
+	defer c.RUnlock()
 	return c.mock.Now()
 }
 
-func (c *clock) Since(t time.Time) time.Duration {
+func (c *Clock) Since(t time.Time) time.Duration {
 	if c.mock == nil {
 		return globalClock.Since(t)
 	}
+	c.RLock()
+	defer c.RUnlock()
 	return c.mock.Since(t)
 }
 
-func (c *clock) Sleep(d time.Duration) {
+func (c *Clock) Sleep(d time.Duration) {
 	if c.mock == nil {
 		globalClock.Sleep(d)
 		return
 	}
+	c.RLock()
+	defer c.RUnlock()
 	c.mock.Sleep(d)
 }
 
-func (c *clock) Tick(d time.Duration) <-chan time.Time {
+func (c *Clock) Tick(d time.Duration) <-chan time.Time {
 	if c.mock == nil {
 		return globalClock.Tick(d)
 	}
+	c.RLock()
+	defer c.RUnlock()
 	return c.mock.Tick(d)
 }
 
-func (c *clock) Ticker(d time.Duration) *clockapi.Ticker {
+func (c *Clock) Ticker(d time.Duration) *clockapi.Ticker {
 	if c.mock == nil {
 		return globalClock.Ticker(d)
 	}
+	c.RLock()
+	defer c.RUnlock()
 	return c.mock.Ticker(d)
 }
 
-func (c *clock) Timer(d time.Duration) *clockapi.Timer {
+func (c *Clock) Timer(d time.Duration) *clockapi.Timer {
 	if c.mock == nil {
 		return globalClock.Timer(d)
 	}
+	c.RLock()
+	defer c.RUnlock()
 	return c.mock.Timer(d)
 }

--- a/pkg/clock/clock.go
+++ b/pkg/clock/clock.go
@@ -1,0 +1,166 @@
+package clock
+
+import (
+	"errors"
+	"sync"
+	"time"
+
+	clockapi "github.com/benbjohnson/clock"
+)
+
+var (
+	globalClock = clockapi.New()
+	mu          sync.Mutex
+)
+
+// Set the global clock to a clockapi.Mock with the given time.Time
+func Set(t time.Time) {
+	mu.Lock()
+	defer mu.Unlock()
+	mock, ok := globalClock.(*clockapi.Mock)
+	if !ok {
+		mock = clockapi.NewMock()
+	}
+	mock.Set(t)
+	globalClock = mock
+}
+
+// Add moves the mocked global clock forward the given duration. It will error
+// if the global clock is not mocked.
+func Add(d time.Duration) error {
+	mu.Lock()
+	defer mu.Unlock()
+	mock, ok := globalClock.(*clockapi.Mock)
+	if !ok {
+		return errors.New("time not mocked")
+	}
+	mock.Add(d)
+	return nil
+}
+
+// Reset sets the global clock to a pure time implementation
+func Reset() {
+	mu.Lock()
+	defer mu.Unlock()
+	globalClock = clockapi.New()
+}
+
+// Clock is a non-package level wrapper around time that supports stubbing.
+// It will use its localized stubs (allowing for parallelized unit tests
+// where package level stubbing would cause issues). It falls back to any
+// package level time stubs for non-parallel, cross-package integration
+// testing scenarios.
+//
+// If nothing is stubbed, it defaults to default time behavior in the time
+// package.
+type Clock interface {
+	After(time.Duration) <-chan time.Time
+	AfterFunc(time.Duration, func()) *clockapi.Timer
+	Now() time.Time
+	Since(time.Time) time.Duration
+	Sleep(time.Duration)
+	Tick(time.Duration) <-chan time.Time
+	Ticker(time.Duration) *clockapi.Ticker
+	Timer(time.Duration) *clockapi.Timer
+
+	Set(time.Time)
+	Add(time.Duration) error
+	Reset()
+}
+
+type clock struct {
+	mock *clockapi.Mock
+	sync.Mutex
+}
+
+// New returns a Clock that defaults to generic `time` functionality.
+// It can be stubbed locally or fall back to package-level clock mocks.
+func New() Clock {
+	return &clock{}
+}
+
+// Set sets the Clock to a clock.Mock at the given time.Time
+func (c *clock) Set(t time.Time) {
+	c.Lock()
+	defer c.Unlock()
+	if c.mock == nil {
+		c.mock = clockapi.NewMock()
+	}
+	c.mock.Set(t)
+}
+
+// Add moves clock forward time.Duration if it is mocked. It will error
+// if the clock is not mocked.
+func (c *clock) Add(d time.Duration) error {
+	c.Lock()
+	defer c.Unlock()
+	if c.mock == nil {
+		return errors.New("clock not mocked")
+	}
+	c.mock.Add(d)
+	return nil
+}
+
+// Reset removes local clock.Mock
+func (c *clock) Reset() {
+	c.Lock()
+	defer c.Unlock()
+	c.mock = nil
+}
+
+func (c *clock) After(d time.Duration) <-chan time.Time {
+	if c.mock == nil {
+		return globalClock.After(d)
+	}
+	return c.mock.After(d)
+}
+
+func (c *clock) AfterFunc(d time.Duration, f func()) *clockapi.Timer {
+	if c.mock == nil {
+		return globalClock.AfterFunc(d, f)
+	}
+	return c.mock.AfterFunc(d, f)
+}
+
+func (c *clock) Now() time.Time {
+	if c.mock == nil {
+		return globalClock.Now()
+	}
+	return c.mock.Now()
+}
+
+func (c *clock) Since(t time.Time) time.Duration {
+	if c.mock == nil {
+		return globalClock.Since(t)
+	}
+	return c.mock.Since(t)
+}
+
+func (c *clock) Sleep(d time.Duration) {
+	if c.mock == nil {
+		globalClock.Sleep(d)
+		return
+	}
+	c.mock.Sleep(d)
+}
+
+func (c *clock) Tick(d time.Duration) <-chan time.Time {
+	if c.mock == nil {
+		return globalClock.Tick(d)
+	}
+	return c.mock.Tick(d)
+}
+
+func (c *clock) Ticker(d time.Duration) *clockapi.Ticker {
+	if c.mock == nil {
+		return globalClock.Ticker(d)
+	}
+	return c.mock.Ticker(d)
+}
+
+func (c *clock) Timer(d time.Duration) *clockapi.Timer {
+	if c.mock == nil {
+		return globalClock.Timer(d)
+	}
+	return c.mock.Timer(d)
+}

--- a/pkg/clock/clock_suite_test.go
+++ b/pkg/clock/clock_suite_test.go
@@ -1,0 +1,17 @@
+package clock_test
+
+import (
+	"testing"
+
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/logger"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestClockSuite(t *testing.T) {
+	logger.SetOutput(GinkgoWriter)
+	logger.SetErrOutput(GinkgoWriter)
+
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Clock")
+}

--- a/pkg/clock/clock_test.go
+++ b/pkg/clock/clock_test.go
@@ -1,0 +1,375 @@
+package clock_test
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/clock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	testGlobalEpoch = 1000000000
+	testLocalEpoch  = 1234567890
+)
+
+var _ = Describe("Clock suite", func() {
+	var testClock = clock.Clock{}
+
+	AfterEach(func() {
+		clock.Reset()
+		testClock.Reset()
+	})
+
+	Context("Global time not overridden", func() {
+		It("errors when trying to Add", func() {
+			err := clock.Add(123 * time.Hour)
+			Expect(err).To(HaveOccurred())
+		})
+
+		Context("Clock not mocked via Set", func() {
+			It("uses time.After for After", func() {
+				var tolerance bool
+				go func() {
+					time.Sleep(10 * time.Millisecond)
+					tolerance = true
+				}()
+				go func() {
+					time.Sleep(30 * time.Millisecond)
+					tolerance = false
+				}()
+
+				Expect(tolerance).To(BeFalse())
+
+				<-testClock.After(20 * time.Millisecond)
+				Expect(tolerance).To(BeTrue())
+
+				<-testClock.After(20 * time.Millisecond)
+				Expect(tolerance).To(BeFalse())
+			})
+
+			It("uses time.AfterFunc for AfterFunc", func() {
+				var tolerance bool
+				go func() {
+					time.Sleep(10 * time.Millisecond)
+					tolerance = true
+				}()
+				go func() {
+					time.Sleep(30 * time.Millisecond)
+					tolerance = false
+				}()
+
+				Expect(tolerance).To(BeFalse())
+
+				var wg sync.WaitGroup
+				wg.Add(1)
+				testClock.AfterFunc(20*time.Millisecond, func() {
+					wg.Done()
+				})
+				wg.Wait()
+				Expect(tolerance).To(BeTrue())
+
+				wg.Add(1)
+				testClock.AfterFunc(20*time.Millisecond, func() {
+					wg.Done()
+				})
+				wg.Wait()
+				Expect(tolerance).To(BeFalse())
+			})
+
+			It("uses time.Now for Now", func() {
+				a := time.Now()
+				b := testClock.Now()
+				Expect(b.Sub(a).Round(10 * time.Millisecond)).To(Equal(0 * time.Millisecond))
+			})
+
+			It("uses time.Since for Since", func() {
+				past := time.Now().Add(-60 * time.Second)
+				Expect(time.Since(past).Round(10 * time.Millisecond)).
+					To(Equal(60 * time.Second))
+			})
+
+			It("uses time.Sleep for Sleep", func() {
+				var tolerance bool
+				go func() {
+					time.Sleep(10 * time.Millisecond)
+					tolerance = true
+				}()
+				go func() {
+					time.Sleep(30 * time.Millisecond)
+					tolerance = false
+				}()
+
+				Expect(tolerance).To(BeFalse())
+
+				testClock.Sleep(20 * time.Millisecond)
+				Expect(tolerance).To(BeTrue())
+
+				testClock.Sleep(20 * time.Millisecond)
+				Expect(tolerance).To(BeFalse())
+			})
+
+			It("uses time.Tick for Tick", func() {
+				var tolerance bool
+				go func() {
+					time.Sleep(10 * time.Millisecond)
+					tolerance = true
+				}()
+				go func() {
+					time.Sleep(50 * time.Millisecond)
+					tolerance = false
+				}()
+
+				ch := testClock.Tick(20 * time.Millisecond)
+				Expect(tolerance).To(BeFalse())
+				<-ch
+				Expect(tolerance).To(BeTrue())
+				<-ch
+				Expect(tolerance).To(BeTrue())
+				<-ch
+				Expect(tolerance).To(BeFalse())
+			})
+
+			It("uses time.Ticker for Ticker", func() {
+				var tolerance bool
+				go func() {
+					time.Sleep(10 * time.Millisecond)
+					tolerance = true
+				}()
+				go func() {
+					time.Sleep(50 * time.Millisecond)
+					tolerance = false
+				}()
+
+				ticker := testClock.Ticker(20 * time.Millisecond)
+				Expect(tolerance).To(BeFalse())
+				<-ticker.C
+				Expect(tolerance).To(BeTrue())
+				<-ticker.C
+				Expect(tolerance).To(BeTrue())
+				<-ticker.C
+				Expect(tolerance).To(BeFalse())
+			})
+
+			It("errors if Add is used", func() {
+				err := testClock.Add(100 * time.Second)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		Context("Clock mocked via Set", func() {
+			var now = time.Unix(testLocalEpoch, 0)
+
+			BeforeEach(func() {
+				testClock.Set(now)
+			})
+
+			It("mocks After", func() {
+				var after int32
+				ready := make(chan struct{})
+				ch := testClock.After(10 * time.Second)
+				go func(ch <-chan time.Time) {
+					close(ready)
+					<-ch
+					atomic.StoreInt32(&after, 1)
+				}(ch)
+				<-ready
+
+				err := testClock.Add(9 * time.Second)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(atomic.LoadInt32(&after)).To(Equal(int32(0)))
+
+				err = testClock.Add(1 * time.Second)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(atomic.LoadInt32(&after)).To(Equal(int32(1)))
+			})
+
+			It("mocks AfterFunc", func() {
+				var after int32
+				testClock.AfterFunc(10*time.Second, func() {
+					atomic.StoreInt32(&after, 1)
+				})
+
+				err := testClock.Add(9 * time.Second)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(atomic.LoadInt32(&after)).To(Equal(int32(0)))
+
+				err = testClock.Add(1 * time.Second)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(atomic.LoadInt32(&after)).To(Equal(int32(1)))
+			})
+
+			It("mocks AfterFunc with a stopped timer", func() {
+				var after int32
+				timer := testClock.AfterFunc(10*time.Second, func() {
+					atomic.StoreInt32(&after, 1)
+				})
+				timer.Stop()
+
+				err := testClock.Add(11 * time.Second)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(atomic.LoadInt32(&after)).To(Equal(int32(0)))
+			})
+
+			It("mocks Now", func() {
+				Expect(testClock.Now()).To(Equal(now))
+				err := testClock.Add(123 * time.Hour)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(testClock.Now()).To(Equal(now.Add(123 * time.Hour)))
+			})
+
+			It("mocks Since", func() {
+				Expect(testClock.Since(time.Unix(testLocalEpoch-100, 0))).
+					To(Equal(100 * time.Second))
+			})
+
+			It("mocks Sleep", func() {
+				var after int32
+				ready := make(chan struct{})
+				go func() {
+					close(ready)
+					testClock.Sleep(10 * time.Second)
+					atomic.StoreInt32(&after, 1)
+				}()
+				<-ready
+
+				err := testClock.Add(9 * time.Second)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(atomic.LoadInt32(&after)).To(Equal(int32(0)))
+
+				err = testClock.Add(1 * time.Second)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(atomic.LoadInt32(&after)).To(Equal(int32(1)))
+			})
+
+			It("mocks Tick", func() {
+				var ticks int32
+				ready := make(chan struct{})
+				go func() {
+					close(ready)
+					tick := testClock.Tick(10 * time.Second)
+					for ticks < 5 {
+						<-tick
+						atomic.AddInt32(&ticks, 1)
+					}
+				}()
+				<-ready
+
+				Expect(atomic.LoadInt32(&ticks)).To(Equal(int32(0)))
+
+				err := testClock.Add(9 * time.Second)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(atomic.LoadInt32(&ticks)).To(Equal(int32(0)))
+
+				err = testClock.Add(1 * time.Second)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(atomic.LoadInt32(&ticks)).To(Equal(int32(1)))
+
+				err = testClock.Add(30 * time.Second)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(atomic.LoadInt32(&ticks)).To(Equal(int32(4)))
+
+				err = testClock.Add(10 * time.Second)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(atomic.LoadInt32(&ticks)).To(Equal(int32(5)))
+			})
+
+			It("mocks Ticker", func() {
+				var ticks int32
+				ready := make(chan struct{})
+				go func() {
+					ticker := testClock.Ticker(10 * time.Second)
+					close(ready)
+					for ticks < 5 {
+						<-ticker.C
+						atomic.AddInt32(&ticks, 1)
+					}
+				}()
+				<-ready
+
+				Expect(atomic.LoadInt32(&ticks)).To(Equal(int32(0)))
+
+				err := testClock.Add(9 * time.Second)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(atomic.LoadInt32(&ticks)).To(Equal(int32(0)))
+
+				err = testClock.Add(1 * time.Second)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(atomic.LoadInt32(&ticks)).To(Equal(int32(1)))
+
+				err = testClock.Add(30 * time.Second)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(atomic.LoadInt32(&ticks)).To(Equal(int32(4)))
+
+				err = testClock.Add(10 * time.Second)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(atomic.LoadInt32(&ticks)).To(Equal(int32(5)))
+			})
+
+			It("mocks Timer", func() {
+				var after int32
+				ready := make(chan struct{})
+				go func() {
+					timer := testClock.Timer(10 * time.Second)
+					close(ready)
+					<-timer.C
+					atomic.AddInt32(&after, 1)
+				}()
+				<-ready
+
+				err := testClock.Add(9 * time.Second)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(atomic.LoadInt32(&after)).To(Equal(int32(0)))
+
+				err = testClock.Add(1 * time.Second)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(atomic.LoadInt32(&after)).To(Equal(int32(1)))
+			})
+		})
+	})
+
+	Context("Global time overridden", func() {
+		var (
+			globalNow = time.Unix(testGlobalEpoch, 0)
+			localNow  = time.Unix(testLocalEpoch, 0)
+		)
+
+		BeforeEach(func() {
+			clock.Set(globalNow)
+		})
+
+		Context("Clock not mocked via Set", func() {
+			It("uses globally mocked Now", func() {
+				Expect(testClock.Now()).To(Equal(globalNow))
+				err := clock.Add(123 * time.Hour)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(testClock.Now()).To(Equal(globalNow.Add(123 * time.Hour)))
+			})
+
+			It("errors when Add is called on the local Clock", func() {
+				err := testClock.Add(100 * time.Hour)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		Context("Clock is mocked via Set", func() {
+			BeforeEach(func() {
+				testClock.Set(localNow)
+			})
+
+			It("uses the local mock and ignores the global", func() {
+				Expect(testClock.Now()).To(Equal(localNow))
+
+				err := clock.Add(456 * time.Hour)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = testClock.Add(123 * time.Hour)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(testClock.Now()).To(Equal(localNow.Add(123 * time.Hour)))
+			})
+		})
+	})
+})

--- a/pkg/clock/clock_test.go
+++ b/pkg/clock/clock_test.go
@@ -30,38 +30,43 @@ var _ = Describe("Clock suite", func() {
 		})
 
 		Context("Clock not mocked via Set", func() {
+			const (
+				outsideTolerance = int32(0)
+				withinTolerance  = int32(1)
+			)
+
 			It("uses time.After for After", func() {
-				var tolerance bool
+				var tolerance int32
 				go func() {
 					time.Sleep(10 * time.Millisecond)
-					tolerance = true
+					atomic.StoreInt32(&tolerance, withinTolerance)
 				}()
 				go func() {
 					time.Sleep(30 * time.Millisecond)
-					tolerance = false
+					atomic.StoreInt32(&tolerance, outsideTolerance)
 				}()
 
-				Expect(tolerance).To(BeFalse())
+				Expect(atomic.LoadInt32(&tolerance)).To(Equal(outsideTolerance))
 
 				<-testClock.After(20 * time.Millisecond)
-				Expect(tolerance).To(BeTrue())
+				Expect(atomic.LoadInt32(&tolerance)).To(Equal(withinTolerance))
 
 				<-testClock.After(20 * time.Millisecond)
-				Expect(tolerance).To(BeFalse())
+				Expect(atomic.LoadInt32(&tolerance)).To(Equal(outsideTolerance))
 			})
 
 			It("uses time.AfterFunc for AfterFunc", func() {
-				var tolerance bool
+				var tolerance int32
 				go func() {
 					time.Sleep(10 * time.Millisecond)
-					tolerance = true
+					atomic.StoreInt32(&tolerance, withinTolerance)
 				}()
 				go func() {
 					time.Sleep(30 * time.Millisecond)
-					tolerance = false
+					atomic.StoreInt32(&tolerance, outsideTolerance)
 				}()
 
-				Expect(tolerance).To(BeFalse())
+				Expect(atomic.LoadInt32(&tolerance)).To(Equal(outsideTolerance))
 
 				var wg sync.WaitGroup
 				wg.Add(1)
@@ -69,14 +74,14 @@ var _ = Describe("Clock suite", func() {
 					wg.Done()
 				})
 				wg.Wait()
-				Expect(tolerance).To(BeTrue())
+				Expect(atomic.LoadInt32(&tolerance)).To(Equal(withinTolerance))
 
 				wg.Add(1)
 				testClock.AfterFunc(20*time.Millisecond, func() {
 					wg.Done()
 				})
 				wg.Wait()
-				Expect(tolerance).To(BeFalse())
+				Expect(atomic.LoadInt32(&tolerance)).To(Equal(outsideTolerance))
 			})
 
 			It("uses time.Now for Now", func() {
@@ -92,65 +97,65 @@ var _ = Describe("Clock suite", func() {
 			})
 
 			It("uses time.Sleep for Sleep", func() {
-				var tolerance bool
+				var tolerance int32
 				go func() {
 					time.Sleep(10 * time.Millisecond)
-					tolerance = true
+					atomic.StoreInt32(&tolerance, withinTolerance)
 				}()
 				go func() {
 					time.Sleep(30 * time.Millisecond)
-					tolerance = false
+					atomic.StoreInt32(&tolerance, outsideTolerance)
 				}()
 
-				Expect(tolerance).To(BeFalse())
+				Expect(atomic.LoadInt32(&tolerance)).To(Equal(outsideTolerance))
 
 				testClock.Sleep(20 * time.Millisecond)
-				Expect(tolerance).To(BeTrue())
+				Expect(atomic.LoadInt32(&tolerance)).To(Equal(withinTolerance))
 
 				testClock.Sleep(20 * time.Millisecond)
-				Expect(tolerance).To(BeFalse())
+				Expect(atomic.LoadInt32(&tolerance)).To(Equal(outsideTolerance))
 			})
 
 			It("uses time.Tick for Tick", func() {
-				var tolerance bool
+				var tolerance int32
 				go func() {
 					time.Sleep(10 * time.Millisecond)
-					tolerance = true
+					atomic.StoreInt32(&tolerance, withinTolerance)
 				}()
 				go func() {
 					time.Sleep(50 * time.Millisecond)
-					tolerance = false
+					atomic.StoreInt32(&tolerance, outsideTolerance)
 				}()
 
 				ch := testClock.Tick(20 * time.Millisecond)
-				Expect(tolerance).To(BeFalse())
+				Expect(atomic.LoadInt32(&tolerance)).To(Equal(outsideTolerance))
 				<-ch
-				Expect(tolerance).To(BeTrue())
+				Expect(atomic.LoadInt32(&tolerance)).To(Equal(withinTolerance))
 				<-ch
-				Expect(tolerance).To(BeTrue())
+				Expect(atomic.LoadInt32(&tolerance)).To(Equal(withinTolerance))
 				<-ch
-				Expect(tolerance).To(BeFalse())
+				Expect(atomic.LoadInt32(&tolerance)).To(Equal(outsideTolerance))
 			})
 
 			It("uses time.Ticker for Ticker", func() {
-				var tolerance bool
+				var tolerance int32
 				go func() {
 					time.Sleep(10 * time.Millisecond)
-					tolerance = true
+					atomic.StoreInt32(&tolerance, withinTolerance)
 				}()
 				go func() {
 					time.Sleep(50 * time.Millisecond)
-					tolerance = false
+					atomic.StoreInt32(&tolerance, outsideTolerance)
 				}()
 
 				ticker := testClock.Ticker(20 * time.Millisecond)
-				Expect(tolerance).To(BeFalse())
+				Expect(atomic.LoadInt32(&tolerance)).To(Equal(outsideTolerance))
 				<-ticker.C
-				Expect(tolerance).To(BeTrue())
+				Expect(atomic.LoadInt32(&tolerance)).To(Equal(withinTolerance))
 				<-ticker.C
-				Expect(tolerance).To(BeTrue())
+				Expect(atomic.LoadInt32(&tolerance)).To(Equal(withinTolerance))
 				<-ticker.C
-				Expect(tolerance).To(BeFalse())
+				Expect(atomic.LoadInt32(&tolerance)).To(Equal(outsideTolerance))
 			})
 
 			It("errors if Add is used", func() {


### PR DESCRIPTION
Provide a mechanism to better mock time in unit tests. Support a localized clock object to mock time in unit tests without breaking parallel testing support. Also allow mocking time globally to provide inter-package integration tests (this is not safe for parallel tests though).

## Description

Adds a `clock.Clock` object to add to any functionality that uses the `time` library. It is a distinct object that can be mocked that will fall back to default `time` methods (e.g Now, Since, Sleep...).

If the `clock.Clock` doesn't override time, it attempts to see if `clock.globalClock` was overriden at a package level before falling back to `time` implementations.

## Motivation and Context

Support better unit testing around time (especially around edge timing cases like session refreshing, cookie expiration, etc).

## How Has This Been Tested?

Unit Tests

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
