### PR TITLE
Improve layer sharing in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM golang:1.16-buster AS builder
-ARG VERSION
 
 # Copy sources
 WORKDIR $GOPATH/src/github.com/oauth2-proxy/oauth2-proxy
@@ -10,6 +9,8 @@ RUN GO111MODULE=on go mod download
 
 # Now pull in our code
 COPY . .
+
+ARG VERSION
 
 # Build binary and make sure there is at least an empty key file.
 #  This is useful for GCP App Engine custom runtime builds, because

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,5 +1,4 @@
 FROM golang:1.16-buster AS builder
-ARG VERSION
 
 # Copy sources
 WORKDIR $GOPATH/src/github.com/oauth2-proxy/oauth2-proxy
@@ -10,6 +9,8 @@ RUN GO111MODULE=on go mod download
 
 # Now pull in our code
 COPY . .
+
+ARG VERSION
 
 # Build binary and make sure there is at least an empty key file.
 #  This is useful for GCP App Engine custom runtime builds, because

--- a/Dockerfile.armv6
+++ b/Dockerfile.armv6
@@ -1,5 +1,4 @@
 FROM golang:1.16-buster AS builder
-ARG VERSION
 
 # Copy sources
 WORKDIR $GOPATH/src/github.com/oauth2-proxy/oauth2-proxy
@@ -10,6 +9,8 @@ RUN GO111MODULE=on go mod download
 
 # Now pull in our code
 COPY . .
+
+ARG VERSION
 
 # Build binary and make sure there is at least an empty key file.
 #  This is useful for GCP App Engine custom runtime builds, because


### PR DESCRIPTION
The Docker build as currently configured is forced to re-run `go mod download` more frequently than necessary.

<!--- Provide a general summary of your changes in the Title above -->

## Description

This commit is a tiny change to the `Dockerfile` to allow Docker to use the cached results of `go mod download` from the previous build any time that `go.mod` and `go.sum` are unchanged - previously it would re-run this whenever the computed `VERSION` argument changes, even if the dependency definitions have not changed.

<!--- Describe your changes in detail -->

## Motivation and Context

Motivation - to speed up the `docker build` process and reduce the amount of data downloaded when running multiple builds over time without changes to the module dependencies.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
