### PR TITLE
Fix metrics server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [#1129](https://github.com/oauth2-proxy/oauth2-proxy/pull/1129) Rewrite OpenRedirect tests in ginkgo (@JoelSpeed)
 - [#1127](https://github.com/oauth2-proxy/oauth2-proxy/pull/1127) Remove unused fields from OAuthProxy (@JoelSpeed)
+- [#1141](https://github.com/oauth2-proxy/oauth2-proxy/pull/1141) Fix metrics server bind address initialization
 
 # V7.1.1
 

--- a/docs/versioned_docs/version-7.1.x/configuration/overview.md
+++ b/docs/versioned_docs/version-7.1.x/configuration/overview.md
@@ -92,7 +92,10 @@ An example [oauth2-proxy.cfg](https://github.com/oauth2-proxy/oauth2-proxy/blob/
 | `--provider-display-name` | string | Override the provider's name with the given string; used for the sign-in page | (depends on provider) |
 | `--ping-path` | string | the ping endpoint that can be used for basic health checks | `"/ping"` |
 | `--ping-user-agent` | string | a User-Agent that can be used for basic health checks | `""` (don't check user agent) |
-| `--metrics-address` | string | the address prometheus metrics will be scraped from | `""` |
+| `--metrics-address` | string | the address /metrics will be served on | `""` |
+| `--metrics-secure-address` | string | the address /metrics will be served on via HTTPS | `""` |
+| `--metrics-tls-cert-file` | string | path to certificate file for secure metrics server | `""` |
+| `--metrics-tls-key-file` | string | path to private key file for secure metrics server | `""` |
 | `--proxy-prefix` | string | the url root path that this proxy should be nested under (e.g. /`<oauth2>/sign_in`) | `"/oauth2"` |
 | `--proxy-websockets` | bool | enables WebSocket proxying | true |
 | `--pubjwk-url` | string | JWK pubkey access endpoint: required by login.gov | |

--- a/pkg/apis/options/legacy_options.go
+++ b/pkg/apis/options/legacy_options.go
@@ -419,7 +419,7 @@ func getXAuthRequestAccessTokenHeader() Header {
 
 type LegacyServer struct {
 	MetricsAddress       string `flag:"metrics-address" cfg:"metrics_address"`
-	MetricsSecureAddress string `flag:"metrics-secure-address" cfg:"metrics_address"`
+	MetricsSecureAddress string `flag:"metrics-secure-address" cfg:"metrics_secure_address"`
 	MetricsTLSCertFile   string `flag:"metrics-tls-cert-file" cfg:"tls_cert_file"`
 	MetricsTLSKeyFile    string `flag:"metrics-tls-key-file" cfg:"tls_key_file"`
 	HTTPAddress          string `flag:"http-address" cfg:"http_address"`


### PR DESCRIPTION
## Description

Follow up to #1133 - the config struct still had the wrong `cfg`, making it impossible for me to configure a metrics endpoint via the config file (and command line file. Not sure if #1133 actually fixed the issue at all).

I also added the rest of the metrics cfg flags to the docs.

## How Has This Been Tested?


Ran it locally via `go run`, metrics were exposed as specified by the command line flag.
The cfg parsing and startup code could probably use some general tests but that's probably out of scope for this PR.


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

Not sure if this should be added to the changelog (again), 7.1.1 was already about fixing the metrics server.
Let me know if I should add it.

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
