### PR TITLE
Multiarch builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ MINIMUM_SUPPORTED_GO_MAJOR_VERSION = 1
 MINIMUM_SUPPORTED_GO_MINOR_VERSION = 15
 GO_VERSION_VALIDATION_ERR_MSG = Golang version is not supported, please update to at least $(MINIMUM_SUPPORTED_GO_MAJOR_VERSION).$(MINIMUM_SUPPORTED_GO_MINOR_VERSION)
 
-DOCKER_BUILD := docker build --build-arg VERSION=${VERSION}
+DOCKER_BUILD := docker buildx build --platform linux/amd64,linux/arm64 --build-arg VERSION=${VERSION}
 
 ifeq ($(COVER),true)
 TESTCOVER ?= -coverprofile c.out


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Hey gang, 

Love the project. In fact, I'd love to use it on my `arm64` clusters. I've modified the makefile to switch to docker's buildx plugin that leverages [buildkit](https://docs.docker.com/buildx/working-with-buildx/#build-multi-platform-images) to build multiplatform images.

I've built and published this image at (docker hub) `hartje/oauth2-proxy`, deployed it to my local cluster, and went through the auth flow as a confirmation.

Adding or extending the list to support other architectures should be somewhat trivial. Would the project consider enabling this change? It would help a lot of us `arm64` folks out. 

Appreciate any feedback.

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
