### PR TITLE
Fix Metrics cfg option naming typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ## Changes since v7.1.2
 
+- [#1168](https://github.com/oauth2-proxy/oauth2-proxy/pull/1168) Fix incorrect `cfg` name in Metrics TLS flags (@NickMeves)
 - [#967](https://github.com/oauth2-proxy/oauth2-proxy/pull/967) Set & verify a nonce with OIDC providers (@NickMeves)
 - [#1136](https://github.com/oauth2-proxy/oauth2-proxy/pull/1136) Add clock package for better time mocking in tests (@NickMeves)
 - [#947](https://github.com/oauth2-proxy/oauth2-proxy/pull/947) Multiple provider ingestion and validation in alpha options (first stage: [#926](https://github.com/oauth2-proxy/oauth2-proxy/issues/926)) (@yanasega)

--- a/pkg/apis/options/legacy_options.go
+++ b/pkg/apis/options/legacy_options.go
@@ -442,8 +442,8 @@ func getXAuthRequestAccessTokenHeader() Header {
 type LegacyServer struct {
 	MetricsAddress       string `flag:"metrics-address" cfg:"metrics_address"`
 	MetricsSecureAddress string `flag:"metrics-secure-address" cfg:"metrics_secure_address"`
-	MetricsTLSCertFile   string `flag:"metrics-tls-cert-file" cfg:"tls_cert_file"`
-	MetricsTLSKeyFile    string `flag:"metrics-tls-key-file" cfg:"tls_key_file"`
+	MetricsTLSCertFile   string `flag:"metrics-tls-cert-file" cfg:"metrics_tls_cert_file"`
+	MetricsTLSKeyFile    string `flag:"metrics-tls-key-file" cfg:"metrics_tls_key_file"`
 	HTTPAddress          string `flag:"http-address" cfg:"http_address"`
 	HTTPSAddress         string `flag:"https-address" cfg:"https_address"`
 	TLSCertFile          string `flag:"tls-cert-file" cfg:"tls_cert_file"`


### PR DESCRIPTION
https://github.com/oauth2-proxy/oauth2-proxy/issues/1163

## How Has This Been Tested?

Unit Tests & `contrib/local-environment` manual testing

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
