### PR TITLE
Update Changelog for release v7.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 ## Important Notes
 
+## Breaking Changes
+
+## Changes since v7.1.3
+
+# V7.1.3
+
+## Release Highlights
+
+- Fixed typos in the metrics server TLS config names
+
+## Important Notes
+
 - [#967](https://github.com/oauth2-proxy/oauth2-proxy/pull/967) `--insecure-oidc-skip-nonce` is currently `true` by default in case
   any existing OIDC Identity Providers don't support it. The default will switch to `false` in a future version.
 

--- a/contrib/local-environment/docker-compose-keycloak.yaml
+++ b/contrib/local-environment/docker-compose-keycloak.yaml
@@ -15,7 +15,7 @@ services:
 
   oauth2-proxy:
     container_name: oauth2-proxy
-    image: quay.io/oauth2-proxy/oauth2-proxy:v7.1.2
+    image: quay.io/oauth2-proxy/oauth2-proxy:v7.1.3
     command: --config /oauth2-proxy.cfg
     hostname: oauth2-proxy
     volumes:

--- a/contrib/local-environment/docker-compose.yaml
+++ b/contrib/local-environment/docker-compose.yaml
@@ -13,7 +13,7 @@ version: '3.0'
 services:
   oauth2-proxy:
     container_name: oauth2-proxy
-    image: quay.io/oauth2-proxy/oauth2-proxy:2
+    image: quay.io/oauth2-proxy/oauth2-proxy:v7.1.3
     command: --config /oauth2-proxy.cfg
     ports:
       - 4180:4180/tcp

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -6,7 +6,7 @@ slug: /
 
 1.  Choose how to deploy:
 
-    a. Download [Prebuilt Binary](https://github.com/oauth2-proxy/oauth2-proxy/releases) (current release is `v7.1.2`)
+    a. Download [Prebuilt Binary](https://github.com/oauth2-proxy/oauth2-proxy/releases) (current release is `v7.1.3`)
 
     b. Build with `$ go get github.com/oauth2-proxy/oauth2-proxy/v7` which will put the binary in `$GOPATH/bin`
 

--- a/docs/versioned_docs/version-7.1.x/installation.md
+++ b/docs/versioned_docs/version-7.1.x/installation.md
@@ -6,7 +6,7 @@ slug: /
 
 1.  Choose how to deploy:
 
-    a. Download [Prebuilt Binary](https://github.com/oauth2-proxy/oauth2-proxy/releases) (current release is `v7.1.2`)
+    a. Download [Prebuilt Binary](https://github.com/oauth2-proxy/oauth2-proxy/releases) (current release is `v7.1.3`)
 
     b. Build with `$ go get github.com/oauth2-proxy/oauth2-proxy/v7` which will put the binary in `$GOPATH/bin`
 


### PR DESCRIPTION
Bug release fixing another issue in the Metrics configuration.

## Motivation and Context

Envvar & config users of the new metrics functionality can't enable TLS.

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
