### PR TITLE
fix: SHOW_DEBUG_ON_ERROR environment variable not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Changes since v7.1.3
 
+- [#1181](https://github.com/oauth2-proxy/oauth2-proxy/pull/1181) Fix incorrect `cfg` name in show-debug-on-error flag (@iTaybb)
+
 # V7.1.3
 
 ## Release Highlights

--- a/pkg/apis/options/app.go
+++ b/pkg/apis/options/app.go
@@ -33,7 +33,7 @@ type Templates struct {
 	// It is not advised to use this in production as errors may contain sensitive
 	// information.
 	// Use only for diagnosing backend errors.
-	Debug bool `flag:"show-debug-on-error" cfg:"show-debug-on-error"`
+	Debug bool `flag:"show-debug-on-error" cfg:"show_debug_on_error"`
 }
 
 func templatesFlagSet() *pflag.FlagSet {


### PR DESCRIPTION
Fixes #1178

## Description

the cfg value should be with underscores instead of dashes.

## Motivation and Context

To fix issue #1178

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
