### PR TITLE
added userprincipalname as user for Azure session enrichment

### DIFF
--- a/providers/azure.go
+++ b/providers/azure.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/bitly/go-simplejson"
@@ -372,7 +373,8 @@ func getUserFromJSON(json *simplejson.Json) (string, error) {
 	var user string
 	var err error
 
-	user, err = json.Get("userPrincipalName").String()
+	userEmail, err := json.Get("userPrincipalName").String()
+	user = strings.Split(userEmail, "@")[0]
 
 	if err != nil || user == "" {
 		otherMails, otherMailsErr := json.Get("otherMails").Array()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
adds userprincipal ID as user for Azure
## Description

in Azure AD, user field is usually empty because we're not using userprincipalname to fill in. This can potentially help for authentication servers using the username and not email.

<!--- Describe your changes in detail -->

Added two functions almost identical to `getEmailFromJson` and `getEmailFromProfileAPI` and re-ordered the prefrence of getting the data in. 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It adds more context to auth headers that some apps require.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I've used this patch for almost 6 months in my env to facilitate a login to one of my servers that relied on this header to be present and it's been working fine. 


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
