### PR TITLE
Fix - Refresh Session not working for multiple cookies (#1209)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ## Breaking Changes
 
 ## Changes since v7.1.3
-
+- [#1227](https://github.com/oauth2-proxy/oauth2-proxy/pull/1227) Fix Refresh Session not working for multiple cookies (@rishi1111)
 - [#1063](https://github.com/oauth2-proxy/oauth2-proxy/pull/1063) Add Redis lock feature to lock persistent sessions (@Bibob7)
 - [#1108](https://github.com/oauth2-proxy/oauth2-proxy/pull/1108) Add alternative ways to generate cookie secrets to docs (@JoelSpeed)
 - [#1142](https://github.com/oauth2-proxy/oauth2-proxy/pull/1142) Add pagewriter to upstream proxy (@JoelSpeed)

--- a/pkg/middleware/headers.go
+++ b/pkg/middleware/headers.go
@@ -43,7 +43,7 @@ func newStripHeaders(headers []options.Header) alice.Constructor {
 
 func flattenHeaders(headers http.Header) {
 	for name, values := range headers {
-		if len(values) > 1 {
+		if len(values) > 1 && name != "Set-Cookie" {
 			headers.Set(name, strings.Join(values, ","))
 		}
 	}

--- a/pkg/middleware/headers.go
+++ b/pkg/middleware/headers.go
@@ -43,6 +43,7 @@ func newStripHeaders(headers []options.Header) alice.Constructor {
 
 func flattenHeaders(headers http.Header) {
 	for name, values := range headers {
+		// Set-Cookie should not be flattened, ref: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie
 		if len(values) > 1 && name != "Set-Cookie" {
 			headers.Set(name, strings.Join(values, ","))
 		}

--- a/pkg/middleware/headers_test.go
+++ b/pkg/middleware/headers_test.go
@@ -253,6 +253,42 @@ var _ = Describe("Headers Suite", func() {
 			},
 			expectedErr: "",
 		}),
+
+		Entry("with flattenHeaders (set-cookie and any other)", headersTableInput{
+			headers: []options.Header{
+				{
+					Name: "Set-Cookie",
+					Values: []options.HeaderValue{
+						{
+							SecretSource: &options.SecretSource{
+								Value: []byte("_oauth2_proxy=ey123123123"),
+							},
+						},
+					},
+				},
+				{
+					Name: "X-Auth-User",
+					Values: []options.HeaderValue{
+						{
+							SecretSource: &options.SecretSource{
+								Value: []byte("oauth_user"),
+							},
+						},
+					},
+				},
+			},
+			initialHeaders: http.Header{
+				"Set-Cookie":  []string{"cookie1=value1", "cookie2=value2"},
+				"X-Auth-User": []string{"oauth_user_1"},
+			},
+
+			expectedHeaders: http.Header{
+				"Set-Cookie":  []string{"cookie1=value1", "cookie2=value2", "_oauth2_proxy=ey123123123"},
+				"X-Auth-User": []string{"oauth_user_1,oauth_user"},
+			},
+			expectedErr: "",
+		}),
+
 		Entry("with a claim valued header", headersTableInput{
 			headers: []options.Header{
 				{


### PR DESCRIPTION

## Description

The "Set-Cookie" header was getting flattened in the flattenHeader code. This causes the cookie to be invalid in case of multiple cookies.

## Motivation and Context

Session cookie becomes invalid as the Set-Cookie Header only sets the first cookie correcttly

## How Has This Been Tested?

Added a test case, verifying that the Set-Cookie header is a list of strings, whereas any other cookie will be a comma-separated string.
Verified on a personal test environment

## Checklist:



- [x] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
