### PR TITLE
Properly skip preflight checks in auth-only (no proxy) mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [#1142](https://github.com/oauth2-proxy/oauth2-proxy/pull/1142) Add pagewriter to upstream proxy (@JoelSpeed)
 - [#1181](https://github.com/oauth2-proxy/oauth2-proxy/pull/1181) Fix incorrect `cfg` name in show-debug-on-error flag (@iTaybb)
 - [#1207](https://github.com/oauth2-proxy/oauth2-proxy/pull/1207) Fix URI fragment handling on sign-in page, regression introduced in 7.1.0 (@tarvip)
+- [#1236](https://github.com/oauth2-proxy/oauth2-proxy/pull/1236) Properly skip preflight checks in auth-only (no proxy) mode (@codablock)
 
 
 # V7.1.3


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Right now, all requests that give true for IsAllowedRequest are passed
to upstream, even if the request is for "/oauth2/auth". This is fine when
oauth2-proxy is used in reverse proxy mode, but gives unexpected 404 errors
for auto-only mode.

This PR fixes this by properly handing /oauth2/auth in SkipAuthProxy by
not passing it to upstream and instead returning 202.
<!--- Describe your changes in detail -->

## Motivation and Context

See description

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

We have this fix deployed in our test systems.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
