### PR TITLE
[RFC] Add Open Policy Agent based authorization to the Nginx auth request endpoint

### DIFF
--- a/contrib/local-environment/Makefile
+++ b/contrib/local-environment/Makefile
@@ -8,7 +8,7 @@ up:
 
 .PHONY: alpha-config-up
 alpha-config-up:
-	docker-compose -f docker-compose.yaml -f docker-compose-alpha-config.yaml up -d
+	docker-compose -f docker-compose.yaml -f docker-compose-alpha-config.yaml up --build -d
 
 .PHONY: alpha-config-%
 alpha-config-%:
@@ -16,7 +16,7 @@ alpha-config-%:
 
 .PHONY: nginx-up
 nginx-up:
-	docker-compose -f docker-compose.yaml -f docker-compose-nginx.yaml up -d
+	docker-compose -f docker-compose.yaml -f docker-compose-nginx.yaml up --build -d
 
 .PHONY: nginx-%
 nginx-%:
@@ -24,7 +24,7 @@ nginx-%:
 
 .PHONY: keycloak-up
 keycloak-up:
-	docker-compose -f docker-compose-keycloak.yaml up -d
+	docker-compose -f docker-compose-keycloak.yaml up --build -d
 
 .PHONY: keycloak-%
 keycloak-%:
@@ -41,7 +41,7 @@ kubernetes-down:
 
 .PHONY: traefik-up
 traefik-up:
-	docker-compose -f docker-compose.yaml -f docker-compose-traefik.yaml up -d
+	docker-compose -f docker-compose.yaml -f docker-compose-traefik.yaml up --build -d
 
 .PHONY: traefik-%
 traefik-%:

--- a/contrib/local-environment/Makefile
+++ b/contrib/local-environment/Makefile
@@ -46,3 +46,11 @@ traefik-up:
 .PHONY: traefik-%
 traefik-%:
 	docker-compose -f docker-compose.yaml -f docker-compose-traefik.yaml $*
+
+.PHONY: opa-up
+opa-up:
+	docker-compose -f docker-compose.yaml -f docker-compose-opa.yaml up --build -d
+
+.PHONY: opa-%
+opa-%:
+	docker-compose -f docker-compose.yaml -f docker-compose-nginx.yaml $*

--- a/contrib/local-environment/dex.yaml
+++ b/contrib/local-environment/dex.yaml
@@ -20,7 +20,7 @@ staticClients:
   redirectURIs:
   # These redirect URIs point to the `--redirect-url` for OAuth2 proxy.
   - 'http://localhost:4180/oauth2/callback' # For basic proxy example.
-  - 'http://oauth2-proxy.oauth2-proxy.localhost/oauth2/callback' # For nginx and traefik example.
+  - 'http://oauth2-proxy.oauth2-proxy.localhost:8080/oauth2/callback' # For nginx and traefik example.
   name: 'OAuth2 Proxy'
   secret: b2F1dGgyLXByb3h5LWNsaWVudC1zZWNyZXQK
 enablePasswordDB: true

--- a/contrib/local-environment/docker-compose-nginx.yaml
+++ b/contrib/local-environment/docker-compose-nginx.yaml
@@ -12,13 +12,13 @@
 #    - http://oauth2-proxy.localhost
 #    - http://httpbin.oauth2-proxy.localhost
 #
-# The OAuth2 Proxy itself is hosted at http://oauth2-proxy.oauth2-proxy.localhost
+# The OAuth2 Proxy itself is hosted at http://oauth2-proxy.oauth2-proxy.localhost:8080
 #
 # Note, the above URLs should work with Chrome, but you may need to add hosts
 # entries for other browsers
-#    127.0.0.1 oauth2-proxy.localhost
-#    127.0.0.1 httpbin.oauth2-proxy.localhost
-#    127.0.0.1 oauth2-proxy.oauth2-proxy.localhost
+#    127.0.0.1 oauth2-proxy.localhost:8080
+#    127.0.0.1 httpbin.oauth2-proxy.localhost:8080
+#    127.0.0.1 oauth2-proxy.oauth2-proxy.localhost:8080
 version: '3.0'
 services:
   oauth2-proxy:
@@ -32,7 +32,7 @@ services:
     container_name: nginx
     image: nginx:1.18
     ports:
-      - 80:80/tcp
+      - 8080:8080/tcp
     hostname: nginx
     volumes:
       - "./nginx.conf:/etc/nginx/conf.d/default.conf"

--- a/contrib/local-environment/docker-compose-opa.yaml
+++ b/contrib/local-environment/docker-compose-opa.yaml
@@ -1,0 +1,47 @@
+# This docker-compose file can be used to bring up an example instance of oauth2-proxy
+# for manual testing and exploration of features.
+# Alongside OAuth2-Proxy, this file also starts Dex to act as the identity provider,
+# etcd for storage for Dex, Open Policy Agent as a access controller and other http
+# services for upstreams
+#
+# This file is an extension of the main compose file and must be used with it
+#    docker-compose -f docker-compose.yaml -f docker-compose-opa.yaml <command>
+# Alternatively:
+#    make opa-<command> (eg make nginx-up, make nginx-down)
+#
+# Access one of the following URLs to initiate a login flow:
+#    - http://oauth2-proxy.localhost
+#    - http://httpbin.oauth2-proxy.localhost
+#
+# The OAuth2 Proxy itself is hosted at http://oauth2-proxy.oauth2-proxy.localhost:8080
+#
+# Note, the above URLs should work with Chrome, but you may need to add hosts
+# entries for other browsers
+#    127.0.0.1 oauth2-proxy.localhost:8080
+#    127.0.0.1 httpbin.oauth2-proxy.localhost:8080
+#    127.0.0.1 oauth2-proxy.oauth2-proxy.localhost:8080
+version: '3.0'
+services:
+  oauth2-proxy:
+    volumes:
+      - "./oauth2-proxy-opa.cfg:/oauth2-proxy.cfg"
+    networks:
+      oauth2-proxy: {}
+  opa:
+    container_name: opa
+    image: openpolicyagent/opa
+    ports:
+      - 8181:8181/tcp
+    hostname: opa
+    command:
+      - "run"
+      - "--log-format=json-pretty"
+      - "--log-level=debug"
+      - "--server"
+      - "/etc/opa.rego"
+    volumes:
+      - ./opa.rego:/etc/opa.rego
+    networks:
+      oauth2-proxy: {}
+networks:
+  oauth2-proxy: {}

--- a/contrib/local-environment/docker-compose-traefik.yaml
+++ b/contrib/local-environment/docker-compose-traefik.yaml
@@ -9,16 +9,16 @@
 #    make traefik-<command> (eg. make traefik-up, make traefik-down)
 #
 # Access one of the following URLs to initiate a login flow:
-#    - http://oauth2-proxy.localhost
-#    - http://httpbin.oauth2-proxy.localhost
+#    - http://oauth2-proxy.localhost:8080
+#    - http://httpbin.oauth2-proxy.localhost:8080
 #
-# The OAuth2 Proxy itself is hosted at http://oauth2-proxy.oauth2-proxy.localhost
+# The OAuth2 Proxy itself is hosted at http://oauth2-proxy.oauth2-proxy.localhost:8080
 #
 # Note, the above URLs should work with Chrome, but you may need to add hosts
 # entries for other browsers
-#    127.0.0.1 oauth2-proxy.localhost
-#    127.0.0.1 httpbin.oauth2-proxy.localhost
-#    127.0.0.1 oauth2-proxy.oauth2-proxy.localhost
+#    127.0.0.1 oauth2-proxy.localhost:8080
+#    127.0.0.1 httpbin.oauth2-proxy.localhost:8080
+#    127.0.0.1 oauth2-proxy.oauth2-proxy.localhost:8080
 version: '3.0'
 services:
 

--- a/contrib/local-environment/docker-compose.yaml
+++ b/contrib/local-environment/docker-compose.yaml
@@ -13,7 +13,8 @@ version: '3.0'
 services:
   oauth2-proxy:
     container_name: oauth2-proxy
-    image: quay.io/oauth2-proxy/oauth2-proxy:v7.1.3
+#    image: quay.io/oauth2-proxy/oauth2-proxy:v7.1.3
+    build: ../../
     command: --config /oauth2-proxy.cfg
     ports:
       - 4180:4180/tcp

--- a/contrib/local-environment/nginx.conf
+++ b/contrib/local-environment/nginx.conf
@@ -1,6 +1,6 @@
 # Reverse proxy to oauth2-proxy
 server {
-  listen       80;
+  listen       8080;
   server_name  oauth2-proxy.oauth2-proxy.localhost;
 
   location / {
@@ -13,17 +13,17 @@ server {
 
 # Reverse proxy to httpbin
 server {
-  listen      80;
+  listen      8080;
   server_name httpbin.oauth2-proxy.localhost;
 
   auth_request /internal-auth/oauth2/auth;
 
   # If the auth_request denies the request (401), redirect to the sign_in page
   # and include the final rd URL back to the user's original request.
-  error_page 401 = http://oauth2-proxy.oauth2-proxy.localhost/oauth2/sign_in?rd=$scheme://$host$request_uri;
+  error_page 401 = http://oauth2-proxy.oauth2-proxy.localhost:8080/oauth2/sign_in?rd=$scheme://$host$request_uri;
 
   # Alternatively send the request to `start` to skip the provider button
-  # error_page 401 = http://oauth2-proxy.oauth2-proxy.localhost/oauth2/start?rd=$scheme://$host$request_uri;
+  # error_page 401 = http://oauth2-proxy.oauth2-proxy.localhost:8080/oauth2/start?rd=$scheme://$host$request_uri;
 
   location / {
     proxy_pass http://httpbin/;
@@ -45,7 +45,7 @@ server {
 
 # Statically serve the nginx welcome
 server {
-  listen       80;
+  listen       8080;
   server_name  oauth2-proxy.localhost;
 
   location / {
@@ -53,10 +53,10 @@ server {
 
     # If the auth_request denies the request (401), redirect to the sign_in page
     # and include the final rd URL back to the user's original request.
-    error_page 401 = http://oauth2-proxy.oauth2-proxy.localhost/oauth2/sign_in?rd=$scheme://$host$request_uri;
+    error_page 401 = http://oauth2-proxy.oauth2-proxy.localhost:8080/oauth2/sign_in?rd=$scheme://$host$request_uri;
 
     # Alternatively send the request to `start` to skip the provider button
-    # error_page 401 = http://oauth2-proxy.oauth2-proxy.localhost/oauth2/start?rd=$scheme://$host$request_uri;
+    # error_page 401 = http://oauth2-proxy.oauth2-proxy.localhost:8080/oauth2/start?rd=$scheme://$host$request_uri;
 
 
     root   /usr/share/nginx/html;

--- a/contrib/local-environment/oauth2-proxy-nginx.cfg
+++ b/contrib/local-environment/oauth2-proxy-nginx.cfg
@@ -7,6 +7,6 @@ client_secret="b2F1dGgyLXByb3h5LWNsaWVudC1zZWNyZXQK"
 client_id="oauth2-proxy"
 cookie_secure="false"
 
-redirect_url="http://oauth2-proxy.oauth2-proxy.localhost/oauth2/callback"
-cookie_domains=".oauth2-proxy.localhost" # Required so cookie can be read on all subdomains.
-whitelist_domains=".oauth2-proxy.localhost" # Required to allow redirection back to original requested target.
+redirect_url="http://oauth2-proxy.oauth2-proxy.localhost:8080/oauth2/callback"
+cookie_domains=".oauth2-proxy.localhost:8080" # Required so cookie can be read on all subdomains.
+whitelist_domains=".oauth2-proxy.localhost:8080" # Required to allow redirection back to original requested target.

--- a/contrib/local-environment/oauth2-proxy-opa.cfg
+++ b/contrib/local-environment/oauth2-proxy-opa.cfg
@@ -1,0 +1,13 @@
+http_address="0.0.0.0:4180"
+cookie_secret="OQINaROshtE9TcZkNAm-5Zs2Pv3xaWytBmc5W7sPX7w="
+provider="oidc"
+email_domains="example.com"
+oidc_issuer_url="http://dex.localhost:4190/dex"
+client_secret="b2F1dGgyLXByb3h5LWNsaWVudC1zZWNyZXQK"
+client_id="oauth2-proxy"
+cookie_secure="false"
+
+redirect_url="http://localhost:4180/oauth2/callback"
+upstreams="http://httpbin"
+
+open_policy_agent_url="http://opa:8181/v1/data/oauth2proxy/authz"

--- a/contrib/local-environment/oauth2-proxy-traefik.cfg
+++ b/contrib/local-environment/oauth2-proxy-traefik.cfg
@@ -7,7 +7,7 @@ client_secret="b2F1dGgyLXByb3h5LWNsaWVudC1zZWNyZXQK"
 client_id="oauth2-proxy"
 cookie_secure="false"
 
-redirect_url="http://oauth2-proxy.oauth2-proxy.localhost/oauth2/callback"
+redirect_url="http://oauth2-proxy.oauth2-proxy.localhost:8080/oauth2/callback"
 cookie_domains=".oauth2-proxy.localhost" # Required so cookie can be read on all subdomains.
 whitelist_domains=".oauth2-proxy.localhost" # Required to allow redirection back to original requested target.
 

--- a/contrib/local-environment/opa.rego
+++ b/contrib/local-environment/opa.rego
@@ -1,0 +1,18 @@
+# This configuration is intended to be used with the docker-compose testing
+# environment.
+# This should configure OPA to run on port 8181 and provides static
+# authorization
+package oauth2proxy.authz
+
+default allow = false
+
+allow {
+	[_, token, _] := io.jwt.decode(input.token)
+	path := split(trim(input.query.path, "/"), "/")
+
+	token.name == "admin"
+	input.query.method == "GET"
+
+	path[0] == "test"
+	path[1] == "a"
+}

--- a/contrib/local-environment/traefik/dynamic.yaml
+++ b/contrib/local-environment/traefik/dynamic.yaml
@@ -1,22 +1,22 @@
 http:
   routers:
     oauth2-proxy-route:
-      rule: "Host(`oauth2-proxy.oauth2-proxy.localhost`)"
+      rule: "Host(`oauth2-proxy.oauth2-proxy.localhost:8080`)"
       middlewares:
         - auth-headers
       service: oauth-backend
     httpbin-route:
-      rule: "Host(`httpbin.oauth2-proxy.localhost`)"
+      rule: "Host(`httpbin.oauth2-proxy.localhost:8080`)"
       service: httpbin-service
       middlewares:
         - oauth-auth-redirect # redirects all unauthenticated to oauth2 signin    
     httpbin-route-2:
-      rule: "Host(`httpbin.oauth2-proxy.localhost`) && PathPrefix(`/no-auto-redirect`)"
+      rule: "Host(`httpbin.oauth2-proxy.localhost:8080`) && PathPrefix(`/no-auto-redirect`)"
       service: httpbin-service
       middlewares:
         - oauth-auth-wo-redirect # unauthenticated session will return a 401
     services-oauth2-route:
-      rule: "Host(`httpbin.oauth2-proxy.localhost`) && PathPrefix(`/oauth2/`)"
+      rule: "Host(`httpbin.oauth2-proxy.localhost:8080`) && PathPrefix(`/oauth2/`)"
       middlewares:
         - auth-headers
       service: oauth-backend

--- a/pkg/apis/options/options.go
+++ b/pkg/apis/options/options.go
@@ -33,6 +33,7 @@ type Options struct {
 	WhitelistDomains        []string `flag:"whitelist-domain" cfg:"whitelist_domains"`
 	HtpasswdFile            string   `flag:"htpasswd-file" cfg:"htpasswd_file"`
 	HtpasswdUserGroups      []string `flag:"htpasswd-user-group" cfg:"htpasswd_user_groups"`
+	OpenPolicyAgentURL      string   `flag:"open-policy-agent-url" cfg:"open_policy_agent_url"`
 
 	Cookie    Cookie         `cfg:",squash"`
 	Session   SessionOptions `cfg:",squash"`
@@ -143,6 +144,7 @@ func NewFlagSet() *pflag.FlagSet {
 	flagSet.StringSlice("redis-sentinel-connection-urls", []string{}, "List of Redis sentinel connection URLs (eg redis://HOST[:PORT]). Used in conjunction with --redis-use-sentinel")
 	flagSet.Bool("redis-use-cluster", false, "Connect to redis cluster. Must set --redis-cluster-connection-urls to use this feature")
 	flagSet.StringSlice("redis-cluster-connection-urls", []string{}, "List of Redis cluster connection URLs (eg redis://HOST[:PORT]). Used in conjunction with --redis-use-cluster")
+	flagSet.String("open-policy-agent-url", "", "URL of Open Policy Agent server for Nginx subrequest authorization (eg: http://HOST[:PORT])/v1/data/authz")
 
 	flagSet.String("signature-key", "", "GAP-Signature request signature key (algorithm:secretkey)")
 	flagSet.Bool("gcp-healthchecks", false, "Enable GCP/GKE healthcheck endpoints")


### PR DESCRIPTION
Request for Comments to add [Open Policy Agent](https://www.openpolicyagent.org/) based authorization to the Nginx auth request (`/oauth2/auth`) endpoint.

## Description

This change allows Nginx to pass arbitrary data to Open Policy Agent via the query of the Nginx auth request endpoint. A map of the query and the JWT token are passed to the Open Policy Agent via a `input.json`. Depending on the `allow` value inside the Open Policy Agent response the Nginx endpoint returns a `200 OK` or `403 Forbidden`.

## Motivation and Context
The oauth2-proxy could only authorize request via groups. This change allows arbitrary authorization via Open Policy Agent.

## How Has This Been Tested?
Tests via docker containers inside `contrib/ local-environment` and `oauth2/auth` endpoint.
## Checklist:
- [x] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
