### PR TITLE
Load groups claim from issuers in --extra-jwt-issuers 

### DIFF
--- a/pkg/apis/middleware/session.go
+++ b/pkg/apis/middleware/session.go
@@ -24,6 +24,9 @@ func CreateTokenToSessionFunc(verify VerifyFunc) TokenToSessionFunc {
 			Email             string `json:"email"`
 			Verified          *bool  `json:"email_verified"`
 			PreferredUsername string `json:"preferred_username"`
+                        // TODO:  It's unclear whether the claim from --oidc-groups-claim should be here.
+                        //        It appears to be hard-coded elsewhere in oauth2-proxy.
+                        Groups            []string `json:"groups,omitempty"`
 		}
 
 		idToken, err := verify(ctx, token)
@@ -45,6 +48,7 @@ func CreateTokenToSessionFunc(verify VerifyFunc) TokenToSessionFunc {
 
 		newSession := &sessionsapi.SessionState{
 			Email:             claims.Email,
+                        Groups:            claims.Groups,
 			User:              claims.Subject,
 			PreferredUsername: claims.PreferredUsername,
 			AccessToken:       token,


### PR DESCRIPTION
## Description

Currently, the groups claim is not loaded at all from issuers in `--extra-jwt-issuers`.  This change fixes that.

## Motivation and Context

We have several trusted JWT issuers, each recognizing the same set of user groups.  In particular, CLI users and users of third-party applications must be able to provide a bearer token with their group membership.  For more information, see [Issue 1243](https://github.com/oauth2-proxy/oauth2-proxy/issues/1243)

## How Has This Been Tested?

This is a two-line change that was tested by creating a custom docker image then testing the desired behavior in a realistic environment.

## Checklist:

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
