### PR TITLE
Use `upn` as EmailClaim throughout ADFSProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Changes since v7.2.0
 
+- [#1247](https://github.com/oauth2-proxy/oauth2-proxy/pull/1247) Use `upn` claim consistently in ADFSProvider (@NickMeves)
 - [#1447](https://github.com/oauth2-proxy/oauth2-proxy/pull/1447) Fix docker build/push issues found during last release (@JoelSpeed)
 - [#1433](https://github.com/oauth2-proxy/oauth2-proxy/pull/1433) Let authentication fail when session validation fails (@stippi2)
 - [#1445](https://github.com/oauth2-proxy/oauth2-proxy/pull/1445) Fix docker container multi arch build issue by passing GOARCH details to make build (@jkandasa)

--- a/providers/adfs.go
+++ b/providers/adfs.go
@@ -48,7 +48,7 @@ func NewADFSProvider(p *ProviderData) *ADFSProvider {
 
 	oidcProvider := &OIDCProvider{
 		ProviderData: p,
-		SkipNonce:    true,
+		SkipNonce:    false,
 	}
 
 	return &ADFSProvider{

--- a/providers/adfs.go
+++ b/providers/adfs.go
@@ -84,11 +84,8 @@ func (p *ADFSProvider) GetLoginURL(redirectURI, state, nonce string) string {
 // from the claims. If Email is missing, falls back to ADFS `upn` claim.
 func (p *ADFSProvider) EnrichSession(ctx context.Context, s *sessions.SessionState) error {
 	err := p.oidcEnrichFunc(ctx, s)
-	if err != nil {
-		return err
-	}
-
-	if s.Email == "" {
+	if err != nil || s.Email == "" {
+		// OIDC only errors if email is missing
 		return p.fallbackUPN(ctx, s)
 	}
 	return nil

--- a/providers/adfs_test.go
+++ b/providers/adfs_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/base64"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -247,6 +248,16 @@ var _ = Describe("ADFS Provider Tests", func() {
 			It("falls back to UPN claim if Email is missing", func() {
 				p.oidcEnrichFunc = func(_ context.Context, s *sessions.SessionState) error {
 					return nil
+				}
+
+				err := p.EnrichSession(context.Background(), session)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(session.Email).To(Equal("upn@company.com"))
+			})
+
+			It("falls back to UPN claim on errors", func() {
+				p.oidcEnrichFunc = func(_ context.Context, s *sessions.SessionState) error {
+					return errors.New("neither the id_token nor the profileURL set an email")
 				}
 
 				err := p.EnrichSession(context.Background(), session)

--- a/providers/adfs_test.go
+++ b/providers/adfs_test.go
@@ -134,8 +134,8 @@ var _ = Describe("ADFS Provider Tests", func() {
 			idToken, err := p.Verifier.Verify(context.Background(), rawIDToken)
 			Expect(err).To(BeNil())
 			session, err := p.buildSessionFromClaims(idToken)
-			session.IDToken = rawIDToken
 			Expect(err).To(BeNil())
+			session.IDToken = rawIDToken
 			err = p.EnrichSession(context.Background(), session)
 			Expect(session.Email).To(Equal("janed@me.com"))
 			Expect(err).To(BeNil())
@@ -149,7 +149,7 @@ var _ = Describe("ADFS Provider Tests", func() {
 				ProtectedResource: resource,
 				Scope:             "",
 			})
-			p.SkipScope = true
+			p.skipScope = true
 
 			result := p.GetLoginURL("https://example.com/adfs/oauth2/", "", "")
 			Expect(result).NotTo(ContainSubstring("scope="))

--- a/providers/adfs_test.go
+++ b/providers/adfs_test.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 
 	"github.com/coreos/go-oidc/v3/oidc"
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt"
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/sessions"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
By only overriding `EmailClaim` to `upn` in the `EnrichSession` call that is only post login, any Refresh calls would've overriden it with the `email` claim, changing the underlying session.Email mid session.

## Motivation and Context

Noticed the potential bug while working a similar logic bug here: https://github.com/oauth2-proxy/oauth2-proxy/pull/1239

## How Has This Been Tested?

Unit test

HELP NEEDED: Community ADFS user interactive testing.

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
