### PR TITLE
Simplify sha256sum checking example

### DIFF
--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -17,7 +17,7 @@ slug: /
 Prebuilt binaries can be validated by extracting the file and verifying it against the `sha256sum.txt` checksum file provided for each release starting with version `v3.0.0`.
 
 ```
-$ sha256sum -c sha256sum.txt 2>&1 | grep OK
+$ sha256sum -c sha256sum.txt
 oauth2-proxy-x.y.z.linux-amd64: OK
 ```
 


### PR DESCRIPTION
The previous code didn't consider other languages and hid the output of failures. Removing the redirection and pipe into grep, it's clearer what's working and what's not. For example

```
$ LANG=es_ES.UTF-8 sha256sum -c sha256sum.txt
oauth2-proxy-v7.1.3.linux-amd64/oauth2-proxy: La suma coincide
```

and

```
$ sha256sum -c BADsha256sum.txt 2>&1 | grep OK
$
```