### PR TITLE
OIDC Refresh Session Field Safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 ## Breaking Changes
 
 ## Changes since v7.1.3
+
+- [#1251](https://github.com/oauth2-proxy/oauth2-proxy/pull/1251) Add safety checks to OIDC session fields during refresh (@NickMeves)
 - [#1233](https://github.com/oauth2-proxy/oauth2-proxy/pull/1233) Extend email-domain validation with sub-domain capability (@morarucostel)
 - [#1060](https://github.com/oauth2-proxy/oauth2-proxy/pull/1060) Implement RewriteTarget to allow requests to be rewritten before proxying to upstream servers (@JoelSpeed)
 - [#1086](https://github.com/oauth2-proxy/oauth2-proxy/pull/1086) Refresh sessions before token expiration if configured (@NickMeves)

--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -196,6 +196,11 @@ func replaceSession(s *sessions.SessionState, newSession *sessions.SessionState)
 	// If it doesn't it's probably better to retain the old one
 	if newSession.IDToken != "" {
 		s.IDToken = newSession.IDToken
+
+		// Override groups even if empty to prevent a user removed
+		// from all groups retaining access after refresh
+		// Only override if IDToken was present to set Groups.
+		s.Groups = newSession.Groups
 	}
 
 	// Only copy over fields if they are present. Otherwise they might've
@@ -206,9 +211,6 @@ func replaceSession(s *sessions.SessionState, newSession *sessions.SessionState)
 	}
 	if newSession.User != "" {
 		s.User = newSession.User
-	}
-	if newSession.Groups != nil {
-		s.Groups = newSession.Groups
 	}
 	if newSession.PreferredUsername != "" {
 		s.PreferredUsername = newSession.PreferredUsername

--- a/providers/oidc_test.go
+++ b/providers/oidc_test.go
@@ -464,7 +464,7 @@ func TestOIDCProvider_EnrichSession(t *testing.T) {
 	}
 }
 
-func TestOIDCProviderRefreshSessionIfNeededWithoutIdToken(t *testing.T) {
+func TestOIDCProviderRefreshSessionWithoutIdToken(t *testing.T) {
 
 	idToken, _ := newSignedTestIDToken(defaultIDToken)
 	body, _ := json.Marshal(redeemTokenResponse{
@@ -497,7 +497,7 @@ func TestOIDCProviderRefreshSessionIfNeededWithoutIdToken(t *testing.T) {
 	assert.Equal(t, "11223344", existingSession.User)
 }
 
-func TestOIDCProviderRefreshSessionIfNeededWithIdToken(t *testing.T) {
+func TestOIDCProviderRefreshSessionWithIdToken(t *testing.T) {
 
 	idToken, _ := newSignedTestIDToken(defaultIDToken)
 	body, _ := json.Marshal(redeemTokenResponse{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`EnrichSession` calls the ProfileURL/Userinfo endpoint in case any fields are missing from the IDToken claim.
RefreshSession as implemented today would clobber those with empty values. This adds safety and only uses RefreshSession returned IDToken fields if they aren't empty.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Noticed the potential bug while digging into RefreshSession vs EnrichSession issues on other related OIDC based providers.

## How Has This Been Tested?

Unit Tests

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
