### PR TITLE
Add groups and usernames to Nextcloud provider

### DIFF
--- a/providers/nextcloud.go
+++ b/providers/nextcloud.go
@@ -37,6 +37,12 @@ func (p *NextcloudProvider) EnrichSession(ctx context.Context, s *sessions.Sessi
 
 	data := json.Get("ocs").Get("data")
 
+	id, err := data.Get("id").String()
+	if err != nil {
+		return err
+	}
+	s.User = id
+
 	email, err := data.Get("email").String()
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR pulls out groups and usernames from the Nextcloud authentication response as well as just pulling the user's email. As a side effect of that, it also switches the provider to EnrichSession

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This allows for proper authentication from a Nextcloud instance based not only on the presence of a user in the Nextcloud, but also on their inclusion in a group. It also permits applications protected by oauth2-proxy to get a username, rather than just an email address, meaning the experience is more seamless.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The changes here are pretty small, but of course I have tested them with my own live Nextcloud instance, and verified that they are working. I have also updated the Nextcloud provider tests, and verified that they are working.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG. **(I don't think it does, but advice on that would be gratefully received!)**
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
