### PR TITLE
Remove finicky encryption test

### DIFF
--- a/pkg/apis/sessions/session_state_test.go
+++ b/pkg/apis/sessions/session_state_test.go
@@ -264,22 +264,6 @@ func TestEncodeAndDecodeSessionState(t *testing.T) {
 					}
 				})
 			}
-
-			t.Run("Mixed cipher types cause errors", func(t *testing.T) {
-				for testName, ss := range testCases {
-					t.Run(testName, func(t *testing.T) {
-						cfbEncoded, err := ss.EncodeSessionState(cfb, false)
-						assert.NoError(t, err)
-						_, err = DecodeSessionState(cfbEncoded, gcm, false)
-						assert.Error(t, err)
-
-						gcmEncoded, err := ss.EncodeSessionState(gcm, false)
-						assert.NoError(t, err)
-						_, err = DecodeSessionState(gcmEncoded, cfb, false)
-						assert.Error(t, err)
-					})
-				}
-			})
 		})
 	}
 }


### PR DESCRIPTION
AES-CFB is unauthenticated, in rare circumstances it won't error while trying to decrypt AES-GCM encrypted payloads

<!--- Provide a general summary of your changes in the Title above -->

## Description

We removed the Session type safety overhead to improve speed now that the migration is significantly in the past.
This test case isn't needed anymore and will fail ~1% of the time absent the previous protection overhead in sessions.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Stable master branch tests

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
