### PR TITLE
Make preferred username claim name configurable

### DIFF
--- a/docs/docs/configuration/alpha_config.md
+++ b/docs/docs/configuration/alpha_config.md
@@ -269,6 +269,7 @@ make up the header value
 | `jwksURL` | _string_ | JwksURL is the OpenID Connect JWKS URL<br/>eg: https://www.googleapis.com/oauth2/v3/certs |
 | `emailClaim` | _string_ | EmailClaim indicates which claim contains the user email,<br/>default set to 'email' |
 | `groupsClaim` | _string_ | GroupsClaim indicates which claim contains the user groups<br/>default set to 'groups' |
+| `preferredUsernameClaim` | _string_ | PreferredUsernameClaim indicates which claim contains the preferred username<br/>default set to 'preferred_username' |
 | `userIDClaim` | _string_ | UserIDClaim indicates which claim contains the user ID<br/>default set to 'email' |
 
 ### Provider

--- a/docs/docs/configuration/overview.md
+++ b/docs/docs/configuration/overview.md
@@ -135,6 +135,7 @@ An example [oauth2-proxy.cfg](https://github.com/oauth2-proxy/oauth2-proxy/blob/
 | `--oidc-jwks-url` | string | OIDC JWKS URI for token verification; required if OIDC discovery is disabled | |
 | `--oidc-email-claim` | string | which OIDC claim contains the user's email | `"email"` |
 | `--oidc-groups-claim` | string | which OIDC claim contains the user groups | `"groups"` |
+| `--oidc-preferred-username-claim` | string | which OIDC claim contains the preferred username | `"preferred_username"` |
 | `--pass-access-token` | bool | pass OAuth access_token to upstream via X-Forwarded-Access-Token header. When used with `--set-xauthrequest` this adds the X-Auth-Request-Access-Token header to the response | false |
 | `--pass-authorization-header` | bool | pass OIDC IDToken to upstream via Authorization Bearer header | false |
 | `--pass-basic-auth` | bool | pass HTTP Basic Auth, X-Forwarded-User, X-Forwarded-Email and X-Forwarded-Preferred-Username information to upstream | true |

--- a/main_test.go
+++ b/main_test.go
@@ -69,6 +69,7 @@ providers:
     tenant: common
   oidcConfig:
     groupsClaim: groups
+    preferredUsernameClaim: preferred_username
     emailClaim: email
     userIDClaim: email
     insecureSkipNonce: true
@@ -139,10 +140,11 @@ redirect_url="http://localhost:4180/oauth2/callback"
 					Tenant: "common",
 				},
 				OIDCConfig: options.OIDCOptions{
-					GroupsClaim:       "groups",
-					EmailClaim:        "email",
-					UserIDClaim:       "email",
-					InsecureSkipNonce: true,
+					GroupsClaim:            "groups",
+					PreferredUsernameClaim: "preferred_username",
+					EmailClaim:             "email",
+					UserIDClaim:            "email",
+					InsecureSkipNonce:      true,
 				},
 				ApprovalPrompt: "force",
 			},
@@ -230,7 +232,7 @@ redirect_url="http://localhost:4180/oauth2/callback"
 			configContent:      testCoreConfig,
 			alphaConfigContent: testAlphaConfig + ":",
 			expectedOptions:    func() *options.Options { return nil },
-			expectedErr:        errors.New("failed to load alpha options: error unmarshalling config: error converting YAML to JSON: yaml: line 49: did not find expected key"),
+			expectedErr:        errors.New("failed to load alpha options: error unmarshalling config: error converting YAML to JSON: yaml: line 50: did not find expected key"),
 		}),
 		Entry("with alpha configuration and bad core configuration", loadConfigurationTableInput{
 			configContent:      testCoreConfig + "unknown_field=\"something\"",

--- a/pkg/apis/options/legacy_options.go
+++ b/pkg/apis/options/legacy_options.go
@@ -48,13 +48,14 @@ func NewLegacyOptions() *LegacyOptions {
 		},
 
 		LegacyProvider: LegacyProvider{
-			ProviderType:          "google",
-			AzureTenant:           "common",
-			ApprovalPrompt:        "force",
-			UserIDClaim:           "email",
-			OIDCEmailClaim:        "email",
-			OIDCGroupsClaim:       "groups",
-			InsecureOIDCSkipNonce: true,
+			ProviderType:               "google",
+			AzureTenant:                "common",
+			ApprovalPrompt:             "force",
+			UserIDClaim:                "email",
+			OIDCEmailClaim:             "email",
+			OIDCGroupsClaim:            "groups",
+			OIDCPreferredUsernameClaim: "preferred_username",
+			InsecureOIDCSkipNonce:      true,
 		},
 
 		Options: *NewOptions(),
@@ -498,6 +499,7 @@ type LegacyProvider struct {
 	OIDCJwksURL                        string   `flag:"oidc-jwks-url" cfg:"oidc_jwks_url"`
 	OIDCEmailClaim                     string   `flag:"oidc-email-claim" cfg:"oidc_email_claim"`
 	OIDCGroupsClaim                    string   `flag:"oidc-groups-claim" cfg:"oidc_groups_claim"`
+	OIDCPreferredUsernameClaim         string   `flag:"oidc-preferred-username-claim" cfg:"oidc_preferred_username_claim"`
 	LoginURL                           string   `flag:"login-url" cfg:"login_url"`
 	RedeemURL                          string   `flag:"redeem-url" cfg:"redeem_url"`
 	ProfileURL                         string   `flag:"profile-url" cfg:"profile_url"`
@@ -546,6 +548,7 @@ func legacyProviderFlagSet() *pflag.FlagSet {
 	flagSet.Bool("skip-oidc-discovery", false, "Skip OIDC discovery and use manually supplied Endpoints")
 	flagSet.String("oidc-jwks-url", "", "OpenID Connect JWKS URL (ie: https://www.googleapis.com/oauth2/v3/certs)")
 	flagSet.String("oidc-groups-claim", providers.OIDCGroupsClaim, "which OIDC claim contains the user groups")
+	flagSet.String("oidc-preferred-username-claim", providers.OIDCPreferredUsernameClaim, "which OIDC claim contains the preferred username")
 	flagSet.String("oidc-email-claim", providers.OIDCEmailClaim, "which OIDC claim contains the user's email")
 	flagSet.String("login-url", "", "Authentication endpoint")
 	flagSet.String("redeem-url", "", "Token redemption endpoint")
@@ -639,6 +642,7 @@ func (l *LegacyProvider) convert() (Providers, error) {
 		UserIDClaim:                    l.UserIDClaim,
 		EmailClaim:                     l.OIDCEmailClaim,
 		GroupsClaim:                    l.OIDCGroupsClaim,
+		PreferredUsernameClaim:         l.OIDCPreferredUsernameClaim,
 	}
 
 	// This part is out of the switch section because azure has a default tenant

--- a/pkg/apis/options/load_test.go
+++ b/pkg/apis/options/load_test.go
@@ -36,13 +36,14 @@ var _ = Describe("Load", func() {
 		},
 
 		LegacyProvider: LegacyProvider{
-			ProviderType:          "google",
-			AzureTenant:           "common",
-			ApprovalPrompt:        "force",
-			UserIDClaim:           "email",
-			OIDCEmailClaim:        "email",
-			OIDCGroupsClaim:       "groups",
-			InsecureOIDCSkipNonce: true,
+			ProviderType:               "google",
+			AzureTenant:                "common",
+			ApprovalPrompt:             "force",
+			UserIDClaim:                "email",
+			OIDCEmailClaim:             "email",
+			OIDCGroupsClaim:            "groups",
+			OIDCPreferredUsernameClaim: "preferred_username",
+			InsecureOIDCSkipNonce:      true,
 		},
 
 		Options: Options{

--- a/pkg/apis/options/providers.go
+++ b/pkg/apis/options/providers.go
@@ -150,6 +150,9 @@ type OIDCOptions struct {
 	// GroupsClaim indicates which claim contains the user groups
 	// default set to 'groups'
 	GroupsClaim string `json:"groupsClaim,omitempty"`
+	// PreferredUsernameClaim indicates which claim contains the preferred username
+	// default set to 'preferred_username'
+	PreferredUsernameClaim string `json:"preferredUsernameClaim,omitempty"`
 	// UserIDClaim indicates which claim contains the user ID
 	// default set to 'email'
 	UserIDClaim string `json:"userIDClaim,omitempty"`
@@ -180,6 +183,7 @@ func providerDefaults() Providers {
 				UserIDClaim:                  providers.OIDCEmailClaim, // Deprecated: Use OIDCEmailClaim
 				EmailClaim:                   providers.OIDCEmailClaim,
 				GroupsClaim:                  providers.OIDCGroupsClaim,
+				PreferredUsernameClaim:       providers.OIDCPreferredUsernameClaim,
 			},
 		},
 	}

--- a/pkg/validation/options.go
+++ b/pkg/validation/options.go
@@ -215,6 +215,7 @@ func parseProviderInfo(o *options.Options, msgs []string) []string {
 	p.AllowUnverifiedEmail = o.Providers[0].OIDCConfig.InsecureAllowUnverifiedEmail
 	p.EmailClaim = o.Providers[0].OIDCConfig.EmailClaim
 	p.GroupsClaim = o.Providers[0].OIDCConfig.GroupsClaim
+	p.PreferredUsernameClaim = o.Providers[0].OIDCConfig.PreferredUsernameClaim
 	p.Verifier = o.GetOIDCVerifier()
 
 	// TODO (@NickMeves) - Remove This

--- a/providers/provider_data.go
+++ b/providers/provider_data.go
@@ -16,8 +16,9 @@ import (
 )
 
 const (
-	OIDCEmailClaim  = "email"
-	OIDCGroupsClaim = "groups"
+	OIDCEmailClaim             = "email"
+	OIDCGroupsClaim            = "groups"
+	OIDCPreferredUsernameClaim = "preferred_username"
 )
 
 // ProviderData contains information required to configure all implementations
@@ -40,10 +41,11 @@ type ProviderData struct {
 	Prompt           string
 
 	// Common OIDC options for any OIDC-based providers to consume
-	AllowUnverifiedEmail bool
-	EmailClaim           string
-	GroupsClaim          string
-	Verifier             *oidc.IDTokenVerifier
+	AllowUnverifiedEmail   bool
+	EmailClaim             string
+	GroupsClaim            string
+	PreferredUsernameClaim string
+	Verifier               *oidc.IDTokenVerifier
 
 	// Universal Group authorization data structure
 	// any provider can set to consume
@@ -157,7 +159,7 @@ func (p *ProviderData) buildSessionFromClaims(idToken *oidc.IDToken) (*sessions.
 	ss.Groups = claims.Groups
 
 	// TODO (@NickMeves) Deprecate for dynamic claim to session mapping
-	if pref, ok := claims.raw["preferred_username"].(string); ok {
+	if pref, ok := claims.raw[p.PreferredUsernameClaim].(string); ok {
 		ss.PreferredUsername = pref
 	}
 


### PR DESCRIPTION
Introduces option `--oidc-preferred-username-claim`, analoguous to the already existing options for `email` and `groups` claim.

## Motivation and Context

We're using oauth2-proxy in an nginx auth request setup, and want to pass on both the email adress and the real name of the authenticated user to the application. The latter is contained in the `name` claim in the ID token -- actually, the openid spec defines about 20 [standard claims](https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims) that may be transmitted in the ID token. So ideally, oauth2-proxy would implement the [Deprecate for dynamic claim to session mapping](https://github.com/oauth2-proxy/oauth2-proxy/blob/7eeaea0/providers/provider_data.go#L159) TODO comment, so clients could easily map any desired claim to any desired request header. Currently however, as far as I can tell, clients are restricted to create headers from the 8 or so claims that are modelled in the oauth2-proxy [SessionState](https://github.com/oauth2-proxy/oauth2-proxy/blob/7eeaea0b3f563c7e14f213e47dfda82b40f3fca1/pkg/apis/sessions/session_state.go#L75), but only 3 of those are informational (`email`, `user`, `preferred_username`) -- and of those, for only 1 (`email`) can the claim name be configured, currently.

So this change is a stopgap that allows us to (ab)use the modelled `preferred_username` property to create a header for _one more_ configurable ID token claim. Since the names of the `email` and `groups` claim are already configurable, this change doesn't feel completely wrong, per se, but I'd understand if you didn't want to merge this, in favor of a more generalized solution (for which I myself definitely do not have enough golang chops, sorry).

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
