### PR TITLE
Keycloak + Bearer tokens: make sure groups are added to the session

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -934,6 +934,12 @@ func (p *OAuthProxy) getAuthenticatedSession(rw http.ResponseWriter, req *http.R
 		return nil, ErrNeedsLogin
 	}
 
+	// Make sure groups and email data is set, even if we believe it (should) already exist here
+	err := p.provider.EnrichSession(req.Context(), session)
+	if err != nil {
+		logger.Errorf("Unable to enrich session: %+v", err)
+	}
+
 	invalidEmail := session.Email != "" && !p.Validator(session.Email)
 	authorized, err := p.provider.Authorize(req.Context(), session)
 	if err != nil {


### PR DESCRIPTION
## Description

This service account script that gets a bearer token:

```
CLIENT_ID=kubernetes
USERNAME=REDACTED
PASSWORD=$(kubectl -n REDACTED get secret api-password -o json | jq -r '.data["api.secret"]' | base64 -d)

CLIENT_SECRET=$(kubectl -n kube-system get secret keycloak-client-secret -o json | jq -r '.data["keycloak_client_secret.secret"]' | base64 -d)

TOKEN=$(curl -X POST \
  https://REDACTED/auth/realms/master/protocol/openid-connect/token \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -d "grant_type=password" \
  -d "username=$USERNAME" \
  -d "password=$PASSWORD" \
  -d "client_id=$CLIENT_ID" \
  -d "client_secret=$CLIENT_SECRET" 2>/dev/null)

ACCESS_TOKEN=$(echo $TOKEN | jq -r '.access_token')

curl -I -X GET \
  REDACTED \
  -H "Authorization: Bearer $ACCESS_TOKEN"
```

Kept triggering this oauth2-proxy error and would be thrown into a 302 loop trying to log in:

```
REDACTED - 05e5c1deb16ba6dd4f8fdc0a8c5375a9 - REDACTED [2021/08/04 10:21:21] [AuthFailure] Invalid authorization via session: removing session Session{email:REDACTED user:e661bae4-62b7-4fd8-8ea8-9ef9b6bd18d7 PreferredUsername:api token:true id_token:true expires:2021-08-04 10:22:20 +0000 UTC}
```

## Motivation and Context

As you can see, no group information has been discovered from the bearer token, so after we enforced groups on Keycloak the above script no longer worked.

I believe the session created by keycloak vs a bearer token created by keycloak is what is causing this issue, by adding the `EnrichSession` call just before we check groups we make sure groups are actually set.

## How Has This Been Tested?

We have deployed an updated version of oauth2-proxy with this change into our environment and verified the user data with logs:

```
keycloak json: &{data:map[email:REDACTED email_verified:true family_name:Account given_name:Service groups:[/kubernetes] name:Service Account preferred_username:api sub:e661bae4-62b7-4fd8-8ea8-9ef9b6bd18d7 user_name:api]}
```

It now contains groups, and no error is returned.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
