### PR TITLE
Fixed .CustomLogin </form> tag placement for login page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 - [#1207](https://github.com/oauth2-proxy/oauth2-proxy/pull/1207) Fix URI fragment handling on sign-in page, regression introduced in 7.1.0 (@tarvip)
 - [#1210](https://github.com/oauth2-proxy/oauth2-proxy/pull/1210) New Keycloak OIDC Provider (@pb82)
 - [#1244](https://github.com/oauth2-proxy/oauth2-proxy/pull/1244) Update Alpine image version to 3.14 (@ahovgaard)
-
+- [#1317](https://github.com/oauth2-proxy/oauth2-proxy/pull/1317) Fix incorrect `</form>` tag on the sing_in page when *not* using a custom template (@jord1e)
 
 # V7.1.3
 

--- a/pkg/app/pagewriter/sign_in.html
+++ b/pkg/app/pagewriter/sign_in.html
@@ -60,8 +60,8 @@
           </div>
         </div>
         <button class="button is-primary">Sign in</button>
-        {{ end }}
-    </form>
+      </form>
+      {{ end }}
     </div>
   </section>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The template `{{ end }}` tag was in the wrong place, causing an extra closing `</form>` tag:

![Showcase of the extra closing form tag](https://user-images.githubusercontent.com/30464310/129032524-14b60308-133f-40cc-95b5-4052b5fef7ee.png)

## Motivation and Context

I found it a minor annoyance 😋.

## How Has This Been Tested?

I ran the HTML through the [W3C Markup Validation Service](https://validator.w3.org/#validate_by_input).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
