### PR TITLE
Add support for nested email/group claims

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -68,9 +68,9 @@ providers:
   azureConfig:
     tenant: common
   oidcConfig:
-    groupsClaim: groups
-    emailClaim: email
-    userIDClaim: email
+    groupsClaim: [groups]
+    emailClaim: [email]
+    userIDClaim: [email]
     insecureSkipNonce: true
 `
 
@@ -139,9 +139,9 @@ redirect_url="http://localhost:4180/oauth2/callback"
 					Tenant: "common",
 				},
 				OIDCConfig: options.OIDCOptions{
-					GroupsClaim:       "groups",
-					EmailClaim:        "email",
-					UserIDClaim:       "email",
+					GroupsClaim:       []string{"groups"},
+					EmailClaim:        []string{"email"},
+					UserIDClaim:       []string{"email"},
 					InsecureSkipNonce: true,
 				},
 				ApprovalPrompt: "force",

--- a/pkg/apis/options/legacy_options.go
+++ b/pkg/apis/options/legacy_options.go
@@ -51,9 +51,9 @@ func NewLegacyOptions() *LegacyOptions {
 			ProviderType:          "google",
 			AzureTenant:           "common",
 			ApprovalPrompt:        "force",
-			UserIDClaim:           "email",
-			OIDCEmailClaim:        "email",
-			OIDCGroupsClaim:       "groups",
+			UserIDClaim:           []string{"email"},
+			OIDCEmailClaim:        []string{"email"},
+			OIDCGroupsClaim:       []string{"groups"},
 			InsecureOIDCSkipNonce: true,
 		},
 
@@ -496,8 +496,8 @@ type LegacyProvider struct {
 	InsecureOIDCSkipNonce              bool     `flag:"insecure-oidc-skip-nonce" cfg:"insecure_oidc_skip_nonce"`
 	SkipOIDCDiscovery                  bool     `flag:"skip-oidc-discovery" cfg:"skip_oidc_discovery"`
 	OIDCJwksURL                        string   `flag:"oidc-jwks-url" cfg:"oidc_jwks_url"`
-	OIDCEmailClaim                     string   `flag:"oidc-email-claim" cfg:"oidc_email_claim"`
-	OIDCGroupsClaim                    string   `flag:"oidc-groups-claim" cfg:"oidc_groups_claim"`
+	OIDCEmailClaim                     []string `flag:"oidc-email-claim" cfg:"oidc_email_claim"`
+	OIDCGroupsClaim                    []string `flag:"oidc-groups-claim" cfg:"oidc_groups_claim"`
 	LoginURL                           string   `flag:"login-url" cfg:"login_url"`
 	RedeemURL                          string   `flag:"redeem-url" cfg:"redeem_url"`
 	ProfileURL                         string   `flag:"profile-url" cfg:"profile_url"`
@@ -506,7 +506,7 @@ type LegacyProvider struct {
 	Scope                              string   `flag:"scope" cfg:"scope"`
 	Prompt                             string   `flag:"prompt" cfg:"prompt"`
 	ApprovalPrompt                     string   `flag:"approval-prompt" cfg:"approval_prompt"` // Deprecated by OIDC 1.0
-	UserIDClaim                        string   `flag:"user-id-claim" cfg:"user_id_claim"`
+	UserIDClaim                        []string `flag:"user-id-claim" cfg:"user_id_claim"`
 	AllowedGroups                      []string `flag:"allowed-group" cfg:"allowed_groups"`
 	AllowedRoles                       []string `flag:"allowed-role" cfg:"allowed_roles"`
 
@@ -546,8 +546,8 @@ func legacyProviderFlagSet() *pflag.FlagSet {
 	flagSet.Bool("insecure-oidc-skip-nonce", true, "skip verifying the OIDC ID Token's nonce claim")
 	flagSet.Bool("skip-oidc-discovery", false, "Skip OIDC discovery and use manually supplied Endpoints")
 	flagSet.String("oidc-jwks-url", "", "OpenID Connect JWKS URL (ie: https://www.googleapis.com/oauth2/v3/certs)")
-	flagSet.String("oidc-groups-claim", providers.OIDCGroupsClaim, "which OIDC claim contains the user groups")
-	flagSet.String("oidc-email-claim", providers.OIDCEmailClaim, "which OIDC claim contains the user's email")
+	flagSet.StringSlice("oidc-groups-claim", []string{providers.OIDCGroupsClaim}, "which OIDC claim contains the user groups")
+	flagSet.StringSlice("oidc-email-claim", []string{providers.OIDCEmailClaim}, "which OIDC claim contains the user's email")
 	flagSet.String("login-url", "", "Authentication endpoint")
 	flagSet.String("redeem-url", "", "Token redemption endpoint")
 	flagSet.String("profile-url", "", "Profile access endpoint")
@@ -562,7 +562,7 @@ func legacyProviderFlagSet() *pflag.FlagSet {
 	flagSet.String("jwt-key-file", "", "path to the private key file in PEM format used to sign the JWT so that you can say something like -jwt-key-file=/etc/ssl/private/jwt_signing_key.pem: required by login.gov")
 	flagSet.String("pubjwk-url", "", "JWK pubkey access endpoint: required by login.gov")
 
-	flagSet.String("user-id-claim", providers.OIDCEmailClaim, "(DEPRECATED for `oidc-email-claim`) which claim contains the user ID")
+	flagSet.StringSlice("user-id-claim", []string{providers.OIDCEmailClaim}, "(DEPRECATED for `oidc-email-claim`) which claim contains the user ID")
 	flagSet.StringSlice("allowed-group", []string{}, "restrict logins to members of this group (may be given multiple times)")
 	flagSet.StringSlice("allowed-role", []string{}, "(keycloak-oidc) restrict logins to members of these roles (may be given multiple times)")
 

--- a/pkg/apis/options/load_test.go
+++ b/pkg/apis/options/load_test.go
@@ -39,9 +39,9 @@ var _ = Describe("Load", func() {
 			ProviderType:          "google",
 			AzureTenant:           "common",
 			ApprovalPrompt:        "force",
-			UserIDClaim:           "email",
-			OIDCEmailClaim:        "email",
-			OIDCGroupsClaim:       "groups",
+			UserIDClaim:           []string{"email"},
+			OIDCEmailClaim:        []string{"email"},
+			OIDCGroupsClaim:       []string{"groups"},
 			InsecureOIDCSkipNonce: true,
 		},
 

--- a/pkg/apis/options/providers.go
+++ b/pkg/apis/options/providers.go
@@ -157,13 +157,13 @@ type OIDCOptions struct {
 	JwksURL string `json:"jwksURL,omitempty"`
 	// EmailClaim indicates which claim contains the user email,
 	// default set to 'email'
-	EmailClaim string `json:"emailClaim,omitempty"`
+	EmailClaim []string `json:"emailClaim,omitempty"`
 	// GroupsClaim indicates which claim contains the user groups
 	// default set to 'groups'
-	GroupsClaim string `json:"groupsClaim,omitempty"`
+	GroupsClaim []string `json:"groupsClaim,omitempty"`
 	// UserIDClaim indicates which claim contains the user ID
 	// default set to 'email'
-	UserIDClaim string `json:"userIDClaim,omitempty"`
+	UserIDClaim []string `json:"userIDClaim,omitempty"`
 }
 
 type LoginGovOptions struct {
@@ -188,9 +188,9 @@ func providerDefaults() Providers {
 				InsecureAllowUnverifiedEmail: false,
 				InsecureSkipNonce:            true,
 				SkipDiscovery:                false,
-				UserIDClaim:                  providers.OIDCEmailClaim, // Deprecated: Use OIDCEmailClaim
-				EmailClaim:                   providers.OIDCEmailClaim,
-				GroupsClaim:                  providers.OIDCGroupsClaim,
+				UserIDClaim:                  []string{providers.OIDCEmailClaim}, // Deprecated: Use OIDCEmailClaim
+				EmailClaim:                   []string{providers.OIDCEmailClaim},
+				GroupsClaim:                  []string{providers.OIDCGroupsClaim},
 			},
 		},
 	}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -23,3 +23,30 @@ func GetCertPool(paths []string) (*x509.CertPool, error) {
 	}
 	return pool, nil
 }
+
+// GetFromNestedMap traverses through a potentially-nested map using the given slice of keys. If a value exists in that
+// nested field then the value is returned, otherwise nil is returned and the second return value is false. This method
+// is intended to mimic the interface for the standard [] operator on maps.
+func GetFromNestedMap(m map[string]interface{}, ks ...string) (interface{}, bool) {
+	if len(ks) == 0 {
+		return nil, false
+	}
+
+	v, ok := m[ks[0]]
+
+	if !ok {
+		return nil, false
+	}
+
+	if len(ks) == 1 {
+		return v, true
+	}
+
+	m, ok = v.(map[string]interface{})
+
+	if !ok {
+		return nil, false
+	}
+
+	return GetFromNestedMap(m, ks[1:]...)
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -34,12 +34,8 @@ func GetFromNestedMap(m map[string]interface{}, ks ...string) (interface{}, bool
 
 	v, ok := m[ks[0]]
 
-	if !ok {
-		return nil, false
-	}
-
-	if len(ks) == 1 {
-		return v, true
+	if !ok || len(ks) == 1 {
+		return v, ok
 	}
 
 	m, ok = v.(map[string]interface{})

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -95,3 +95,46 @@ func TestGetCertPool(t *testing.T) {
 	expectedSubjects := []string{testCA1Subj, testCA2Subj}
 	assert.Equal(t, expectedSubjects, got)
 }
+
+func TestGetFromNestedMap(t *testing.T) {
+	testCases := map[string]struct {
+		Map        map[string]interface{}
+		Keys       []string
+		Expected   interface{}
+		ExpectedOk bool
+	}{
+		"Empty Keys": {
+			Map:        map[string]interface{}{},
+			Keys:       []string{},
+			Expected:   nil,
+			ExpectedOk: false,
+		},
+		"Missing Field": {
+			Map:        map[string]interface{}{"field": "value"},
+			Keys:       []string{"nonexistent"},
+			Expected:   nil,
+			ExpectedOk: false,
+		},
+		"Top-level Field": {
+			Map:        map[string]interface{}{"field": "value"},
+			Keys:       []string{"field"},
+			Expected:   "value",
+			ExpectedOk: true,
+		},
+		"Nested Field": {
+			Map:        map[string]interface{}{"field1": map[string]interface{}{"field2": "value"}},
+			Keys:       []string{"field1", "field2"},
+			Expected:   "value",
+			ExpectedOk: true,
+		},
+	}
+
+	for testName, tc := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			out, ok := GetFromNestedMap(tc.Map, tc.Keys...)
+
+			assert.Equal(t, tc.Expected, out)
+			assert.Equal(t, tc.ExpectedOk, ok)
+		})
+	}
+}

--- a/pkg/validation/options.go
+++ b/pkg/validation/options.go
@@ -142,8 +142,8 @@ func Validate(o *options.Options) error {
 				o.Providers[0].Scope += " groups"
 			}
 		}
-		if o.Providers[0].OIDCConfig.UserIDClaim == "" {
-			o.Providers[0].OIDCConfig.UserIDClaim = "email"
+		if len(o.Providers[0].OIDCConfig.UserIDClaim) == 0 || o.Providers[0].OIDCConfig.UserIDClaim[0] == "" {
+			o.Providers[0].OIDCConfig.UserIDClaim = []string{"email"}
 		}
 	}
 
@@ -219,8 +219,8 @@ func parseProviderInfo(o *options.Options, msgs []string) []string {
 
 	// TODO (@NickMeves) - Remove This
 	// Backwards Compatibility for Deprecated UserIDClaim option
-	if o.Providers[0].OIDCConfig.EmailClaim == providers.OIDCEmailClaim &&
-		o.Providers[0].OIDCConfig.UserIDClaim != providers.OIDCEmailClaim {
+	if len(o.Providers[0].OIDCConfig.EmailClaim) == 1 && o.Providers[0].OIDCConfig.EmailClaim[0] == providers.OIDCEmailClaim &&
+		!(len(o.Providers[0].OIDCConfig.UserIDClaim) == 1 && o.Providers[0].OIDCConfig.UserIDClaim[0] == providers.OIDCEmailClaim) {
 		p.EmailClaim = o.Providers[0].OIDCConfig.UserIDClaim
 	}
 

--- a/providers/adfs.go
+++ b/providers/adfs.go
@@ -84,7 +84,7 @@ func (p *ADFSProvider) EnrichSession(ctx context.Context, s *sessions.SessionSta
 		return err
 	}
 
-	p.EmailClaim = "upn"
+	p.EmailClaim = []string{"upn"}
 	c, err := p.getClaims(idToken)
 
 	if err != nil {

--- a/providers/adfs_test.go
+++ b/providers/adfs_test.go
@@ -129,7 +129,7 @@ var _ = Describe("ADFS Provider Tests", func() {
 
 	Context("with valid token", func() {
 		It("should not throw an error", func() {
-			p.EmailClaim = "email"
+			p.EmailClaim = []string{"email"}
 			rawIDToken, _ := newSignedTestIDToken(defaultIDToken)
 			idToken, err := p.Verifier.Verify(context.Background(), rawIDToken)
 			Expect(err).To(BeNil())

--- a/providers/azure_test.go
+++ b/providers/azure_test.go
@@ -47,7 +47,7 @@ func testAzureProvider(hostname string) *AzureProvider {
 			ValidateURL:       &url.URL{},
 			ProtectedResource: &url.URL{},
 			Scope:             "",
-			EmailClaim:        "email",
+			EmailClaim:        []string{"email"},
 			Verifier: oidc.NewVerifier(
 				"https://issuer.example.com",
 				fakeAzureKeySetStub{},

--- a/providers/keycloak_oidc_test.go
+++ b/providers/keycloak_oidc_test.go
@@ -70,8 +70,8 @@ func newKeycloakOIDCProvider(serverURL *url.URL) *KeycloakOIDCProvider {
 		SkipClientIDCheck: true,
 		SkipExpiryCheck:   true,
 	})
-	p.EmailClaim = "email"
-	p.GroupsClaim = "groups"
+	p.EmailClaim = []string{"email"}
+	p.GroupsClaim = []string{"groups"}
 	return p
 }
 

--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -102,7 +102,7 @@ func (p *OIDCProvider) enrichFromProfileURL(ctx context.Context, s *sessions.Ses
 		return err
 	}
 
-	email, err := respJSON.Get(p.EmailClaim).String()
+	email, err := respJSON.GetPath(p.EmailClaim...).String()
 	if err == nil && s.Email == "" {
 		s.Email = email
 	}

--- a/providers/oidc_test.go
+++ b/providers/oidc_test.go
@@ -47,8 +47,8 @@ func newOIDCProvider(serverURL *url.URL) *OIDCProvider {
 			Host:   serverURL.Host,
 			Path:   "/api"},
 		Scope:       "openid profile offline_access",
-		EmailClaim:  "email",
-		GroupsClaim: "groups",
+		EmailClaim:  []string{"email"},
+		GroupsClaim: []string{"groups"},
 		Verifier: oidc.NewVerifier(
 			oidcIssuer,
 			mockJWKS{},
@@ -129,7 +129,7 @@ func TestOIDCProviderRedeem_custom_userid(t *testing.T) {
 	})
 
 	server, provider := newTestOIDCSetup(body)
-	provider.EmailClaim = "phone_number"
+	provider.EmailClaim = []string{"phone_number"}
 	defer server.Close()
 
 	session, err := provider.Redeem(context.Background(), provider.RedeemURL.String(), "code1234")
@@ -140,8 +140,8 @@ func TestOIDCProviderRedeem_custom_userid(t *testing.T) {
 func TestOIDCProvider_EnrichSession(t *testing.T) {
 	testCases := map[string]struct {
 		ExistingSession *sessions.SessionState
-		EmailClaim      string
-		GroupsClaim     string
+		EmailClaim      []string
+		GroupsClaim     []string
 		ProfileJSON     map[string]interface{}
 		ExpectedError   error
 		ExpectedSession *sessions.SessionState
@@ -155,8 +155,8 @@ func TestOIDCProvider_EnrichSession(t *testing.T) {
 				AccessToken:  accessToken,
 				RefreshToken: refreshToken,
 			},
-			EmailClaim:  "email",
-			GroupsClaim: "groups",
+			EmailClaim:  []string{"email"},
+			GroupsClaim: []string{"groups"},
 			ProfileJSON: map[string]interface{}{
 				"email":  "new@thing.com",
 				"groups": []string{"new", "thing"},
@@ -179,8 +179,8 @@ func TestOIDCProvider_EnrichSession(t *testing.T) {
 				AccessToken:  accessToken,
 				RefreshToken: refreshToken,
 			},
-			EmailClaim:  "email",
-			GroupsClaim: "groups",
+			EmailClaim:  []string{"email"},
+			GroupsClaim: []string{"groups"},
 			ProfileJSON: map[string]interface{}{
 				"email":  "found@email.com",
 				"groups": []string{"new", "thing"},
@@ -203,8 +203,8 @@ func TestOIDCProvider_EnrichSession(t *testing.T) {
 				AccessToken:  accessToken,
 				RefreshToken: refreshToken,
 			},
-			EmailClaim:  "email",
-			GroupsClaim: "groups",
+			EmailClaim:  []string{"email"},
+			GroupsClaim: []string{"groups"},
 			ProfileJSON: map[string]interface{}{
 				"email": "found@email.com",
 			},
@@ -225,8 +225,8 @@ func TestOIDCProvider_EnrichSession(t *testing.T) {
 				AccessToken:  accessToken,
 				RefreshToken: refreshToken,
 			},
-			EmailClaim:  "weird",
-			GroupsClaim: "groups",
+			EmailClaim:  []string{"weird"},
+			GroupsClaim: []string{"groups"},
 			ProfileJSON: map[string]interface{}{
 				"weird":  "weird@claim.com",
 				"groups": []string{"new", "thing"},
@@ -249,8 +249,8 @@ func TestOIDCProvider_EnrichSession(t *testing.T) {
 				AccessToken:  accessToken,
 				RefreshToken: refreshToken,
 			},
-			EmailClaim:  "email",
-			GroupsClaim: "groups",
+			EmailClaim:  []string{"email"},
+			GroupsClaim: []string{"groups"},
 			ProfileJSON: map[string]interface{}{
 				"groups": []string{"new", "thing"},
 			},
@@ -272,8 +272,8 @@ func TestOIDCProvider_EnrichSession(t *testing.T) {
 				AccessToken:  accessToken,
 				RefreshToken: refreshToken,
 			},
-			EmailClaim:  "email",
-			GroupsClaim: "groups",
+			EmailClaim:  []string{"email"},
+			GroupsClaim: []string{"groups"},
 			ProfileJSON: map[string]interface{}{
 				"email":  "new@thing.com",
 				"groups": []string{"new", "thing"},
@@ -297,8 +297,8 @@ func TestOIDCProvider_EnrichSession(t *testing.T) {
 				AccessToken:  accessToken,
 				RefreshToken: refreshToken,
 			},
-			EmailClaim:  "email",
-			GroupsClaim: "groups",
+			EmailClaim:  []string{"email"},
+			GroupsClaim: []string{"groups"},
 			ProfileJSON: map[string]interface{}{
 				"email": "new@thing.com",
 				"groups": []map[string]interface{}{
@@ -327,8 +327,8 @@ func TestOIDCProvider_EnrichSession(t *testing.T) {
 				AccessToken:  accessToken,
 				RefreshToken: refreshToken,
 			},
-			EmailClaim:  "email",
-			GroupsClaim: "groups",
+			EmailClaim:  []string{"email"},
+			GroupsClaim: []string{"groups"},
 			ProfileJSON: map[string]interface{}{
 				"email": "new@thing.com",
 				"groups": map[string]interface{}{
@@ -355,8 +355,8 @@ func TestOIDCProvider_EnrichSession(t *testing.T) {
 				AccessToken:  accessToken,
 				RefreshToken: refreshToken,
 			},
-			EmailClaim:  "email",
-			GroupsClaim: "groups",
+			EmailClaim:  []string{"email"},
+			GroupsClaim: []string{"groups"},
 			ProfileJSON: map[string]interface{}{
 				"email":  "new@thing.com",
 				"groups": []string{"new", "thing"},
@@ -380,8 +380,8 @@ func TestOIDCProvider_EnrichSession(t *testing.T) {
 				AccessToken:  accessToken,
 				RefreshToken: refreshToken,
 			},
-			EmailClaim:  "email",
-			GroupsClaim: "roles",
+			EmailClaim:  []string{"email"},
+			GroupsClaim: []string{"roles"},
 			ProfileJSON: map[string]interface{}{
 				"email": "new@thing.com",
 				"roles": []string{"new", "thing", "roles"},
@@ -405,8 +405,8 @@ func TestOIDCProvider_EnrichSession(t *testing.T) {
 				AccessToken:  accessToken,
 				RefreshToken: refreshToken,
 			},
-			EmailClaim:  "email",
-			GroupsClaim: "groups",
+			EmailClaim:  []string{"email"},
+			GroupsClaim: []string{"groups"},
 			ProfileJSON: map[string]interface{}{
 				"email":  "new@thing.com",
 				"groups": "singleton",
@@ -429,8 +429,8 @@ func TestOIDCProvider_EnrichSession(t *testing.T) {
 				AccessToken:  accessToken,
 				RefreshToken: refreshToken,
 			},
-			EmailClaim:  "email",
-			GroupsClaim: "groups",
+			EmailClaim:  []string{"email"},
+			GroupsClaim: []string{"groups"},
 			ProfileJSON: map[string]interface{}{
 				"email": "new@thing.com",
 			},
@@ -533,38 +533,45 @@ func TestOIDCProviderRefreshSessionIfNeededWithIdToken(t *testing.T) {
 func TestOIDCProviderCreateSessionFromToken(t *testing.T) {
 	testCases := map[string]struct {
 		IDToken        idTokenClaims
-		GroupsClaim    string
+		GroupsClaim    []string
 		ExpectedUser   string
 		ExpectedEmail  string
 		ExpectedGroups []string
 	}{
 		"Default IDToken": {
 			IDToken:        defaultIDToken,
-			GroupsClaim:    "groups",
+			GroupsClaim:    []string{"groups"},
 			ExpectedUser:   "123456789",
 			ExpectedEmail:  "janed@me.com",
 			ExpectedGroups: []string{"test:a", "test:b"},
 		},
 		"Minimal IDToken with no email claim": {
 			IDToken:        minimalIDToken,
-			GroupsClaim:    "groups",
+			GroupsClaim:    []string{"groups"},
 			ExpectedUser:   "123456789",
 			ExpectedEmail:  "123456789",
 			ExpectedGroups: nil,
 		},
 		"Custom Groups Claim": {
 			IDToken:        defaultIDToken,
-			GroupsClaim:    "roles",
+			GroupsClaim:    []string{"roles"},
 			ExpectedUser:   "123456789",
 			ExpectedEmail:  "janed@me.com",
 			ExpectedGroups: []string{"test:c", "test:d"},
 		},
 		"Complex Groups Claim": {
 			IDToken:        complexGroupsIDToken,
-			GroupsClaim:    "groups",
+			GroupsClaim:    []string{"groups"},
 			ExpectedUser:   "123456789",
 			ExpectedEmail:  "complex@claims.com",
 			ExpectedGroups: []string{"{\"groupId\":\"Admin Group Id\",\"roles\":[\"Admin\"]}"},
+		},
+		"Nested Claim": {
+			IDToken:        nestedIDToken,
+			GroupsClaim:    []string{"nested", "groups"},
+			ExpectedUser:   "123456789",
+			ExpectedEmail:  "nested@claims.com",
+			ExpectedGroups: []string{"test:a", "test:b"},
 		},
 	}
 	for testName, tc := range testCases {

--- a/providers/util.go
+++ b/providers/util.go
@@ -86,13 +86,13 @@ func formatGroup(rawGroup interface{}) (string, error) {
 
 // coerceArray extracts a field from simplejson.Json that might be a
 // singleton or a list and coerces it into a list.
-func coerceArray(sj *simplejson.Json, key string) []interface{} {
-	array, err := sj.Get(key).Array()
+func coerceArray(sj *simplejson.Json, keys []string) []interface{} {
+	array, err := sj.GetPath(keys...).Array()
 	if err == nil {
 		return array
 	}
 
-	single := sj.Get(key).Interface()
+	single := sj.GetPath(keys...).Interface()
 	if single == nil {
 		return nil
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add support for configuring the email and group claims to come from nested fields.

## Motivation and Context

I'm currently working on a use case where the groups claim lives in a nested field within the claims object. For example, give the portion of the claims object below, we need to set the group claim to the list at `realm_access.roles`:

```json
"realm_access": {
  "roles": [
    "Developers",
    "Approvers"
  ]
}
```

For our use case, we really just need this support for groups, but to keep things consistent I made the same changes on the email claim as well.

In this initial implementation, I went with changing the argument type to a `StringSlice` rather than leaving it as just a `String` and expecting delimiters like `.` since I was worried that there may be use cases where a claim name has a `.` in it.

I think the only portion of this change that is a breaking change is how it affects the alpha config schema. Since that is being deserialized from yaml, the `groupsClaim`, `emailClaim`, and `userIDClaim` fields are all now expected to be lists of strings rather than just strings.

## How Has This Been Tested?

Mainly by ensuring that the existing tests continue to pass. I also added new test cases specifically demonstrating the nested claims support.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
