### PR TITLE
Allow specifying URL as input for custom sign in logo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - [#1210](https://github.com/oauth2-proxy/oauth2-proxy/pull/1210) New Keycloak OIDC Provider (@pb82)
 - [#1244](https://github.com/oauth2-proxy/oauth2-proxy/pull/1244) Update Alpine image version to 3.14 (@ahovgaard)
 - [#1317](https://github.com/oauth2-proxy/oauth2-proxy/pull/1317) Fix incorrect `</form>` tag on the sing_in page when *not* using a custom template (@jord1e)
+- [#1330](https://github.com/oauth2-proxy/oauth2-proxy/pull/1330) Allow specifying URL as input for custom sign in logo (@MaikuMori)
 
 # V7.1.3
 

--- a/docs/docs/configuration/overview.md
+++ b/docs/docs/configuration/overview.md
@@ -95,7 +95,7 @@ An example [oauth2-proxy.cfg](https://github.com/oauth2-proxy/oauth2-proxy/blob/
 | `--cookie-secure` | bool | set [secure (HTTPS only) cookie flag](https://owasp.org/www-community/controls/SecureFlag) | true |
 | `--cookie-samesite` | string | set SameSite cookie attribute (`"lax"`, `"strict"`, `"none"`, or `""`). | `""` |
 | `--custom-templates-dir` | string | path to custom html templates | |
-| `--custom-sign-in-logo` | string | path to an custom image for the sign_in page logo. Use \"-\" to disable default logo. |
+| `--custom-sign-in-logo` | string | path or a URL to an custom image for the sign_in page logo. Use \"-\" to disable default logo. |
 | `--display-htpasswd-form` | bool | display username / password login form if an htpasswd file is provided | true |
 | `--email-domain` | string \| list  | authenticate emails with the specified domain (may be given multiple times). Use `*` to authenticate any email | |
 | `--errors-to-info-log` | bool | redirects error-level logging to default log channel instead of stderr | |

--- a/pkg/apis/options/app.go
+++ b/pkg/apis/options/app.go
@@ -11,9 +11,10 @@ type Templates struct {
 	// If either file is missing, the default will be used instead.
 	Path string `flag:"custom-templates-dir" cfg:"custom_templates_dir"`
 
-	// CustomLogo is the path to a logo that should replace the default logo
+	// CustomLogo is the path or a URL to a logo that should replace the default logo
 	// on the sign_in page template.
 	// Supported formats are .svg, .png, .jpg and .jpeg.
+	// If URL is used the format support depends on the browser.
 	// To disable the default logo, set this value to "-".
 	CustomLogo string `flag:"custom-sign-in-logo" cfg:"custom_sign_in_logo"`
 
@@ -40,7 +41,7 @@ func templatesFlagSet() *pflag.FlagSet {
 	flagSet := pflag.NewFlagSet("templates", pflag.ExitOnError)
 
 	flagSet.String("custom-templates-dir", "", "path to custom html templates")
-	flagSet.String("custom-sign-in-logo", "", "path to an custom image for the sign_in page logo. Use \"-\" to disable default logo.")
+	flagSet.String("custom-sign-in-logo", "", "path or URL to an custom image for the sign_in page logo. Use \"-\" to disable default logo.")
 	flagSet.String("banner", "", "custom banner string. Use \"-\" to disable default banner.")
 	flagSet.String("footer", "", "custom footer string. Use \"-\" to disable default footer.")
 	flagSet.Bool("display-htpasswd-form", true, "display username / password login form if an htpasswd file is provided")

--- a/pkg/app/pagewriter/pagewriter.go
+++ b/pkg/app/pagewriter/pagewriter.go
@@ -54,7 +54,7 @@ type Opts struct {
 
 	// CustomLogo is the path or URL to a logo to be displayed on the sign in page.
 	// The logo can be either PNG, JPG/JPEG or SVG.
-	// If URL is used, image support depends on the browser.
+	// If a URL is used, image support depends on the browser.
 	CustomLogo string
 }
 

--- a/pkg/app/pagewriter/pagewriter.go
+++ b/pkg/app/pagewriter/pagewriter.go
@@ -52,8 +52,9 @@ type Opts struct {
 	// SignInMessage is the messge displayed above the login button.
 	SignInMessage string
 
-	// CustomLogo is the path to a logo to be displayed on the sign in page.
+	// CustomLogo is the path or URL to a logo to be displayed on the sign in page.
 	// The logo can be either PNG, JPG/JPEG or SVG.
+	// If URL is used, image support depends on the browser.
 	CustomLogo string
 }
 

--- a/pkg/app/pagewriter/sign_in_page.go
+++ b/pkg/app/pagewriter/sign_in_page.go
@@ -91,7 +91,8 @@ func (s *signInPageWriter) WriteSignInPage(rw http.ResponseWriter, req *http.Req
 }
 
 // loadCustomLogo loads the logo file from the path and encodes it to an HTML
-// entity. If no custom logo is provided, the OAuth2 Proxy Icon is used instead.
+// entity or if a URL is provided then it's used directly,
+// otherwise if no custom logo is provided, the OAuth2 Proxy Icon is used instead.
 func loadCustomLogo(logoPath string) (string, error) {
 	if logoPath == "" {
 		// The default logo is an SVG so this will be valid to just return.
@@ -102,6 +103,11 @@ func loadCustomLogo(logoPath string) (string, error) {
 		// Return no logo when the custom logo is set to `-`.
 		// This disables the logo rendering.
 		return "", nil
+	}
+
+	if strings.HasPrefix(logoPath, "https://") || strings.HasPrefix(logoPath, "http://") {
+		// Return img tag pointing to the URL.
+		return fmt.Sprintf("<img src=\"%s\" alt=\"Logo\" />", logoPath), nil
 	}
 
 	logoData, err := os.ReadFile(logoPath)

--- a/pkg/app/pagewriter/sign_in_page.go
+++ b/pkg/app/pagewriter/sign_in_page.go
@@ -105,7 +105,7 @@ func loadCustomLogo(logoPath string) (string, error) {
 		return "", nil
 	}
 
-	if strings.HasPrefix(logoPath, "https://") || strings.HasPrefix(logoPath, "http://") {
+	if strings.HasPrefix(logoPath, "https://") {
 		// Return img tag pointing to the URL.
 		return fmt.Sprintf("<img src=\"%s\" alt=\"Logo\" />", logoPath), nil
 	}

--- a/pkg/app/pagewriter/sign_in_page_test.go
+++ b/pkg/app/pagewriter/sign_in_page_test.go
@@ -127,11 +127,6 @@ var _ = Describe("SignIn Page", func() {
 				expectedErr:  nil,
 				expectedData: "",
 			}),
-			Entry("with HTTP URL", loadCustomLogoTableInput{
-				logoPath:     "http://raw.githubusercontent.com/oauth2-proxy/oauth2-proxy/master/docs/static/img/logos/OAuth2_Proxy_icon.png",
-				expectedErr:  nil,
-				expectedData: "<img src=\"http://raw.githubusercontent.com/oauth2-proxy/oauth2-proxy/master/docs/static/img/logos/OAuth2_Proxy_icon.png\" alt=\"Logo\" />",
-			}),
 			Entry("with HTTPS URL", loadCustomLogoTableInput{
 				logoPath:     "https://raw.githubusercontent.com/oauth2-proxy/oauth2-proxy/master/docs/static/img/logos/OAuth2_Proxy_icon.png",
 				expectedErr:  nil,

--- a/pkg/app/pagewriter/sign_in_page_test.go
+++ b/pkg/app/pagewriter/sign_in_page_test.go
@@ -127,6 +127,16 @@ var _ = Describe("SignIn Page", func() {
 				expectedErr:  nil,
 				expectedData: "",
 			}),
+			Entry("with HTTP URL", loadCustomLogoTableInput{
+				logoPath:     "http://raw.githubusercontent.com/oauth2-proxy/oauth2-proxy/master/docs/static/img/logos/OAuth2_Proxy_icon.png",
+				expectedErr:  nil,
+				expectedData: "<img src=\"http://raw.githubusercontent.com/oauth2-proxy/oauth2-proxy/master/docs/static/img/logos/OAuth2_Proxy_icon.png\" alt=\"Logo\" />",
+			}),
+			Entry("with HTTPS URL", loadCustomLogoTableInput{
+				logoPath:     "https://raw.githubusercontent.com/oauth2-proxy/oauth2-proxy/master/docs/static/img/logos/OAuth2_Proxy_icon.png",
+				expectedErr:  nil,
+				expectedData: "<img src=\"https://raw.githubusercontent.com/oauth2-proxy/oauth2-proxy/master/docs/static/img/logos/OAuth2_Proxy_icon.png\" alt=\"Logo\" />",
+			}),
 			Entry("with an svg custom logo", loadCustomLogoTableInput{
 				logoPath:     "customDir/logo.svg",
 				expectedErr:  nil,


### PR DESCRIPTION
## Description

I didn't use specific URL verification functions from standard lib because just testing for `https:// | http://` seems sufficient.

## Motivation and Context

Adding custom files in K8S to containers is tedious, I would rather link to logo stored on a CDN.

## How Has This Been Tested?

I've added tests. They seem to run :). I'm actually testing Codespaces for this PR, so bear with me.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My change requires a change to the documentation or CHANGELOG.
- [X] I have updated the documentation accordingly.
- [x] I have updated the CHANGELOG accordingly.
- [X] I have created a feature (non-master) branch for my PR.
