### PR TITLE
Implement always-accept responses for unauthenticated /auth requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - [#1210](https://github.com/oauth2-proxy/oauth2-proxy/pull/1210) New Keycloak OIDC Provider (@pb82)
 - [#1244](https://github.com/oauth2-proxy/oauth2-proxy/pull/1244) Update Alpine image version to 3.14 (@ahovgaard)
 - [#1317](https://github.com/oauth2-proxy/oauth2-proxy/pull/1317) Fix incorrect `</form>` tag on the sing_in page when *not* using a custom template (@jord1e)
+- [#1332](https://github.com/oauth2-proxy/oauth2-proxy/pull/1332) Add an option to make the `/auth` endpoint always respond with `202 Accepted` (@jord1e)
 
 # V7.1.3
 

--- a/docs/docs/configuration/overview.md
+++ b/docs/docs/configuration/overview.md
@@ -420,19 +420,7 @@ It is recommended to use `--session-store-type=redis` when expecting large sessi
 
 You have to substitute *name* with the actual cookie name you configured via --cookie-name parameter. If you don't set a custom cookie name the variable  should be "$upstream_cookie__oauth2_proxy_1" instead of "$upstream_cookie_name_1" and the new cookie-name should be "_oauth2_proxy_1=" instead of "name_1=".
 
-You can use the `--auth-endpoint-accept-unauthenticated=true` option to allow requests to propagate without logging in, whilst still passing the Authorization header when applicable:
-```yaml
-nginx.ingress.kubernetes.io/auth-response-headers: Authorization
-nginx.ingress.kubernetes.io/auth-url: https://$host/oauth2/auth
-nginx.ingress.kubernetes.io/configuration-snippet: |
-  auth_request_set $name_upstream_1 $upstream_cookie_name_1;
-
-  access_by_lua_block {
-    if ngx.var.name_upstream_1 ~= "" then
-      ngx.header["Set-Cookie"] = "name_1=" .. ngx.var.name_upstream_1 .. ngx.var.auth_cookie:match("(; .*)")
-    end
-  }
-```
+You can use the `--auth-endpoint-accept-unauthenticated=true` option to allow requests to propagate without logging in, whilst still passing the Authorization header when applicable. This can be achieved by leaving the `nginx.ingress.kubernetes.io/auth-signin` annotation out.
 
 ## Configuring for use with the Traefik (v2) `ForwardAuth` middleware
 

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -957,6 +957,20 @@ func TestAuthOnlyEndpointUnauthorizedOnNoCookieSetError(t *testing.T) {
 	assert.Equal(t, "Unauthorized\n", string(bodyBytes))
 }
 
+func TestAuthOnlyEndpointAlwaysAcceptOptionOnNoCookie(t *testing.T) {
+	test, err := NewAuthOnlyEndpointTest("", func(opts *options.Options) {
+		opts.AuthEndpointAcceptUnauthenticated = true
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	test.proxy.ServeHTTP(test.rw, test.req)
+	assert.Equal(t, http.StatusAccepted, test.rw.Code)
+	bodyBytes, _ := ioutil.ReadAll(test.rw.Body)
+	assert.Equal(t, "", string(bodyBytes))
+}
+
 func TestAuthOnlyEndpointUnauthorizedOnExpiration(t *testing.T) {
 	test, err := NewAuthOnlyEndpointTest("", func(opts *options.Options) {
 		opts.Cookie.Expire = time.Duration(24) * time.Hour

--- a/pkg/apis/options/options.go
+++ b/pkg/apis/options/options.go
@@ -59,6 +59,8 @@ type Options struct {
 	SSLInsecureSkipVerify bool     `flag:"ssl-insecure-skip-verify" cfg:"ssl_insecure_skip_verify"`
 	SkipAuthPreflight     bool     `flag:"skip-auth-preflight" cfg:"skip_auth_preflight"`
 
+	AuthEndpointAcceptUnauthenticated bool `flag:"auth-endpoint-accept-unauthenticated" cfg:"auth_endpoint_accept_unauthenticated"`
+
 	SignatureKey    string `flag:"signature-key" cfg:"signature_key"`
 	GCPHealthChecks bool   `flag:"gcp-healthchecks" cfg:"gcp_healthchecks"`
 
@@ -122,6 +124,7 @@ func NewFlagSet() *pflag.FlagSet {
 	flagSet.Bool("ssl-insecure-skip-verify", false, "skip validation of certificates presented when using HTTPS providers")
 	flagSet.Bool("skip-jwt-bearer-tokens", false, "will skip requests that have verified JWT bearer tokens (default false)")
 	flagSet.StringSlice("extra-jwt-issuers", []string{}, "if skip-jwt-bearer-tokens is set, a list of extra JWT issuer=audience pairs (where the issuer URL has a .well-known/openid-configuration or a .well-known/jwks.json)")
+	flagSet.Bool("auth-endpoint-accept-unauthenticated", false, "Make the /auth endpoint respond with a 202 Accepted status code when the user is unauthenticated (this does not affect group based authorization)")
 
 	flagSet.StringSlice("email-domain", []string{}, "authenticate emails with the specified domain (may be given multiple times). Use * to authenticate any email")
 	flagSet.StringSlice("whitelist-domain", []string{}, "allowed domains for redirection after authentication. Prefix domain with a . to allow subdomains (eg .example.com)")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Allow for unauthenticated users to use the website/API, but pass the Authorization header when authenticated via `/sign_in`. This is done by making the `/auth` endpoint respond with `202 Accepted` when the session (cookie) is missing.

It's an explicit opt-in via the `--auth-endpoint-accept-unauthenticated` flag or `auth_endpoint_accept_unauthenticated` configuration property.

Authorization using the `--allowed-group` flag is not affected. The consequence is that unauthenticated user will be allowed to use the site whilst authenticated users with invalid groups will be unable to do so. This edge case has been documented.

This change was specifically made with ingress-nginx in mind.

## Motivation and Context

See description, this is the simplest way to implement this and the performance impact is negligible.

A more detailed solution is described in oauth2-proxy/oauth2-proxy#1319. But I opted for a simpler solution in the end.

## How Has This Been Tested?

I build a docker image and deployed it via the helm chart using a modified `image:` block. I then tested it by created a ingress using the following annotations (note that the `nginx.ingress.kubernetes.io/auth-signin` annotation is missing):
```yaml
nginx.ingress.kubernetes.io/auth-url: http://oauth2-proxy-test.default.svc.cluster.local:80/oauth2/auth
nginx.ingress.kubernetes.io/auth-response-headers: Authorization
```

When authenticated (cookie set) the Authorization header is passed to the proxied service, when unauthenticated the header isn't passed.

The NGINX controller logs __do not show any errors__.

It would be great if the changes can make it into 7.2.0.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
