### PR TITLE
RFC: SQL session store

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/go-redis/redis/v8 v8.2.3
 	github.com/google/uuid v1.2.0
 	github.com/justinas/alice v1.2.0
+	github.com/lib/pq v1.10.2
 	github.com/mbland/hmacauth v0.0.0-20170912233209-44256dfd4bfa
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/oauth2-proxy/tools/reference-gen v0.0.0-20210118095127-56ffd7384404

--- a/go.sum
+++ b/go.sum
@@ -242,6 +242,10 @@ github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/lib/pq v1.8.0 h1:9xohqzkUwzR4Ga4ivdTcawVS89YSDVxXMa3xJX3cGzg=
+github.com/lib/pq v1.8.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/lib/pq v1.10.2 h1:AqzbZs4ZoCBp+GtejcpCpcxM3zlSMx29dXbUSeVtJb8=
+github.com/lib/pq v1.10.2/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
 github.com/lyft/protoc-gen-validate v0.0.13/go.mod h1:XbGvPuh87YZc5TdIa2/I4pLk0QoUACkjt2znoq26NVQ=

--- a/pkg/apis/options/options.go
+++ b/pkg/apis/options/options.go
@@ -143,6 +143,9 @@ func NewFlagSet() *pflag.FlagSet {
 	flagSet.StringSlice("redis-sentinel-connection-urls", []string{}, "List of Redis sentinel connection URLs (eg redis://HOST[:PORT]). Used in conjunction with --redis-use-sentinel")
 	flagSet.Bool("redis-use-cluster", false, "Connect to redis cluster. Must set --redis-cluster-connection-urls to use this feature")
 	flagSet.StringSlice("redis-cluster-connection-urls", []string{}, "List of Redis cluster connection URLs (eg redis://HOST[:PORT]). Used in conjunction with --redis-use-cluster")
+	flagSet.String("sql-driver", "", "go SQL driver")
+	flagSet.String("sql-dsn", "", "SQL server DSN")
+	flagSet.String("sql-prefix", "oauth2", "SQL table name prefix")
 
 	flagSet.String("signature-key", "", "GAP-Signature request signature key (algorithm:secretkey)")
 	flagSet.Bool("gcp-healthchecks", false, "Enable GCP/GKE healthcheck endpoints")

--- a/pkg/apis/options/sessions.go
+++ b/pkg/apis/options/sessions.go
@@ -5,6 +5,7 @@ type SessionOptions struct {
 	Type   string             `flag:"session-store-type" cfg:"session_store_type"`
 	Cookie CookieStoreOptions `cfg:",squash"`
 	Redis  RedisStoreOptions  `cfg:",squash"`
+	SQL    SQLStoreOptions    `cfg:",squash"`
 }
 
 // CookieSessionStoreType is used to indicate the CookieSessionStore should be
@@ -14,6 +15,10 @@ var CookieSessionStoreType = "cookie"
 // RedisSessionStoreType is used to indicate the RedisSessionStore should be
 // used for storing sessions.
 var RedisSessionStoreType = "redis"
+
+// SQLSessionStoreType is used to indicate the SqlSessionStore should be
+// used for storing sessions.
+var SQLSessionStoreType = "sql"
 
 // CookieStoreOptions contains configuration options for the CookieSessionStore.
 type CookieStoreOptions struct {
@@ -34,11 +39,20 @@ type RedisStoreOptions struct {
 	InsecureSkipTLSVerify  bool     `flag:"redis-insecure-skip-tls-verify" cfg:"redis_insecure_skip_tls_verify"`
 }
 
+type SQLStoreOptions struct {
+	Driver      string `flag:"sql-driver" cfg:"sql_driver"`
+	DSN         string `flag:"sql-dsn" cfg:"sql_dsn"`
+	TablePrefix string `flag:"sql-prefix" cfg:"sql_prefix"`
+}
+
 func sessionOptionsDefaults() SessionOptions {
 	return SessionOptions{
 		Type: CookieSessionStoreType,
 		Cookie: CookieStoreOptions{
 			Minimal: false,
+		},
+		SQL: SQLStoreOptions{
+			TablePrefix: "oauth2",
 		},
 	}
 }

--- a/pkg/sessions/session_store.go
+++ b/pkg/sessions/session_store.go
@@ -7,6 +7,7 @@ import (
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/sessions"
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/sessions/cookie"
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/sessions/redis"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/sessions/sql"
 )
 
 // NewSessionStore creates a SessionStore from the provided configuration
@@ -16,6 +17,8 @@ func NewSessionStore(opts *options.SessionOptions, cookieOpts *options.Cookie) (
 		return cookie.NewCookieSessionStore(opts, cookieOpts)
 	case options.RedisSessionStoreType:
 		return redis.NewRedisSessionStore(opts, cookieOpts)
+	case options.SQLSessionStoreType:
+		return sql.NewSQLSessionStore(opts, cookieOpts)
 	default:
 		return nil, fmt.Errorf("unknown session store type '%s'", opts.Type)
 	}

--- a/pkg/sessions/sql/sql_store.go
+++ b/pkg/sessions/sql/sql_store.go
@@ -1,0 +1,92 @@
+package sql
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	// load the driver
+	_ "github.com/lib/pq"
+
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/sessions"
+
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/sessions/persistence"
+)
+
+// SessionStore is an implementation of the persistence.Store
+// interface that stores sessions in a SQL database
+type SessionStore struct {
+	pool  *sql.DB
+	table string
+}
+
+// NewSQLSessionStore initialises a new instance of the SessionStore and wraps
+// it in a persistence.Manager
+func NewSQLSessionStore(opts *options.SessionOptions, cookieOpts *options.Cookie) (sessions.SessionStore, error) {
+	table := opts.SQL.TablePrefix + "_sessions"
+	pool, err := sql.Open(opts.SQL.Driver, opts.SQL.DSN)
+	if err != nil {
+		return nil, fmt.Errorf("error constructing SQL client: %w", err)
+	}
+	_, err = pool.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
+            key text primary key,
+            value bytea,
+            expires timestamp)`, table))
+	if err != nil {
+		return nil, fmt.Errorf("error creating table: %w", err)
+	}
+	_, err = pool.Exec(fmt.Sprintf(`BEGIN;
+        CREATE INDEX IF NOT EXISTS exp_idx ON %s (expires);
+        CREATE OR REPLACE FUNCTION f_delete_expired () RETURNS trigger
+            AS 'BEGIN DELETE FROM TG_TABLE_NAME WHERE expires < current_timestamp; RETURN NULL; END' LANGUAGE PLPGSQL;
+        DROP TRIGGER IF EXISTS t_delete_expired ON %s;
+        CREATE TRIGGER t_delete_expired BEFORE INSERT ON %s
+            EXECUTE PROCEDURE f_delete_expired();
+        COMMIT;`, table, table, table))
+	if err != nil {
+		return nil, fmt.Errorf("error creating trigger: %w", err)
+	}
+	ss := &SessionStore{
+		pool:  pool,
+		table: table,
+	}
+	return persistence.NewManager(ss, cookieOpts), nil
+}
+
+// Save takes a sessions.SessionState and stores the information from it
+// to postgres, and adds a new persistence cookie on the HTTP response writer
+func (store *SessionStore) Save(ctx context.Context, key string, value []byte, exp time.Duration) error {
+	_, err := store.pool.ExecContext(ctx, fmt.Sprintf(
+		`INSERT INTO %s VALUES ($1, $2, current_timestamp + $3)
+                ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, expires = EXCLUDED.expires`,
+		store.table),
+		key, value, exp.Seconds())
+	if err != nil {
+		return fmt.Errorf("error saving SQL session: %w", err)
+	}
+	return nil
+}
+
+// Load reads sessions.SessionState information from a persistence
+// cookie within the HTTP request object
+func (store *SessionStore) Load(ctx context.Context, key string) ([]byte, error) {
+	var value []byte
+	err := store.pool.QueryRowContext(ctx,
+		fmt.Sprintf(`SELECT value FROM %s WHERE key = $1 AND expires > current_timestamp`, store.table), key).Scan(&value)
+	if err != nil {
+		return nil, fmt.Errorf("error loading SQL session: %w", err)
+	}
+	return value, nil
+}
+
+// Clear clears any saved session information for a given persistence cookie
+// from postgres, and then clears the session
+func (store *SessionStore) Clear(ctx context.Context, key string) error {
+	_, err := store.pool.ExecContext(ctx, fmt.Sprintf(`DELETE FROM %s WHERE key = $1`, store.table), key)
+	if err != nil {
+		return fmt.Errorf("error clearing the session from SQL: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This implements a session store in a SQL database. I'm submitting this as RFC as I'm not sure which approach on these two points you'd prefer:
- ORM vs bare SQL - I think this schema (basically a key-value + expiration) is too simple to warrant the overhead and additional dependencies
- triggers for expiration - it's either that, or running the expiration query 'manually' at every `Save`. No real difference IMO, I made an arbitrary choice.

## Motivation and Context

Currently redis is the only supported session store database, and one might not want to use cookie for whatever reason. This is a bit inconvenient if you're not already running redis. When deploying on existing infrastructure, a SQL server is something you're likely to already have. Likewise in cloud environments - there's RDS or Google's cloud SQL, while eg. Google's Memorystore has very limited authentication options, so you'd potentially need to run multiple instances.
No fundamental reason why this general approach couldn't work on mysql as well.

## How Has This Been Tested?

I haven't found a way to properly mock a SQL database in go, so there's no unit tests for that module. I did manually test all functionality against both a local postgres 11 and Google cloud SQL.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
