### PR TITLE
Changing user field type to text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ## Changes since v7.1.3
 
+- [#1337](https://github.com/oauth2-proxy/oauth2-proxy/pull/1337) Changing user field type to text when using htpasswd (@pburgisser)
 - [#1276](https://github.com/oauth2-proxy/oauth2-proxy/pull/1276) Update crypto and switched to new github.com/golang-jwt/jwt (@JVecsei)
 - [#1264](https://github.com/oauth2-proxy/oauth2-proxy/pull/1264) Update go-oidc to v3 (@NickMeves)
 - [#1233](https://github.com/oauth2-proxy/oauth2-proxy/pull/1233) Extend email-domain validation with sub-domain capability (@morarucostel)

--- a/pkg/app/pagewriter/sign_in.html
+++ b/pkg/app/pagewriter/sign_in.html
@@ -49,7 +49,7 @@
         <div class="field">
           <label class="label" for="username">Username</label>
           <div class="control">
-            <input class="input" type="email" placeholder="e.g. userx@example.com"  name="username" id="username">
+            <input class="input" type="text" placeholder="e.g. userx@example.com"  name="username" id="username">
           </div>
         </div>
 


### PR DESCRIPTION
Fix #1336 

## Description

Change username field from email to text when htpasswd is enabled

## Motivation and Context

The username field is requesting an email as the username where a username may now contain an '@'

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
