### PR TITLE
Use the httputil.NewSingleHostReverseProxy instead of yhat/wsutil for …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ## Changes since v7.1.3
 
+- [#1348](https://github.com/oauth2-proxy/oauth2-proxy/pull/1348) Using the native httputil proxy code for websockets rather than yhat/wsutil to properly handle HTTP-level failures (@thetrime)
 - [#1337](https://github.com/oauth2-proxy/oauth2-proxy/pull/1337) Changing user field type to text when using htpasswd (@pburgisser)
 - [#1276](https://github.com/oauth2-proxy/oauth2-proxy/pull/1276) Update crypto and switched to new github.com/golang-jwt/jwt (@JVecsei)
 - [#1264](https://github.com/oauth2-proxy/oauth2-proxy/pull/1264) Update go-oidc to v3 (@NickMeves)

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,6 @@ require (
 	github.com/spf13/viper v1.6.3
 	github.com/stretchr/testify v1.6.1
 	github.com/vmihailenco/msgpack/v4 v4.3.11
-	github.com/yhat/wsutil v0.0.0-20170731153501-1d66fa95c997
 	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97
 	golang.org/x/net v0.0.0-20210226172049-e18ecbb05110
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d

--- a/go.sum
+++ b/go.sum
@@ -426,8 +426,6 @@ github.com/vmihailenco/tagparser v0.1.1 h1:quXMXlA39OCbd2wAdTsGDlK9RkOk6Wuw+x37w
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
-github.com/yhat/wsutil v0.0.0-20170731153501-1d66fa95c997 h1:1+FQ4Ns+UZtUiQ4lP0sTCyKSQ0EXoiwAdHZB0Pd5t9Q=
-github.com/yhat/wsutil v0.0.0-20170731153501-1d66fa95c997/go.mod h1:DIGbh/f5XMAessMV/uaIik81gkDVjUeQ9ApdaU7wRKE=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/gopher-lua v0.0.0-20190206043414-8bfc7677f583/go.mod h1:gqRgreBUhTSL0GeU64rtZ3Uq3wtjOa/TB2YfrtkCbVQ=
 github.com/yuin/gopher-lua v0.0.0-20191213034115-f46add6fdb5c/go.mod h1:gqRgreBUhTSL0GeU64rtZ3Uq3wtjOa/TB2YfrtkCbVQ=

--- a/pkg/upstream/http.go
+++ b/pkg/upstream/http.go
@@ -10,7 +10,6 @@ import (
 	"github.com/mbland/hmacauth"
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/middleware"
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
-	"github.com/yhat/wsutil"
 )
 
 const (
@@ -156,14 +155,12 @@ func setProxyDirector(proxy *httputil.ReverseProxy) {
 
 // newWebSocketReverseProxy creates a new reverse proxy for proxying websocket connections.
 func newWebSocketReverseProxy(u *url.URL, skipTLSVerify bool) http.Handler {
-	// This should create the correct scheme for insecure vs secure connections
-	wsScheme := "ws" + strings.TrimPrefix(u.Scheme, "http")
-	wsURL := &url.URL{Scheme: wsScheme, Host: u.Host}
-
-	wsProxy := wsutil.NewSingleHostReverseProxy(wsURL)
+	wsProxy := httputil.NewSingleHostReverseProxy(u)
 	/* #nosec G402 */
 	if skipTLSVerify {
-		wsProxy.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		wsProxy.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
 	}
 	return wsProxy
 }


### PR DESCRIPTION
…websocket proxying. This correctly handles 404 responses with keep-alive by terminating the tunnel rather than keeping it alive

## Description

httputil has handled websockets natively since go1.12. The upstream package yhat/wsutil hasn't been updated in years and fails to handle some edge cases

## Motivation and Context

This proposal fixes #1347 

## How Has This Been Tested?

The change is relatively localised. The way I tested it was as follows:
   1. I created a simple web server which echoed everything it received, and after receiving two newlines, wrote back this string: `HTTP/1.1 404 Not Found\nContent-Type: text/plain\nConnection: keep-alive\nContent-length: 7\n\nMissing`
   2. I tested the unpatched version of oauth2-proxy by opening a telnet session to it and pasting in a canned request twice. This request had the following features:
      * Upgrade: websocket
      * Connection: upgrade
      * Cookie: < a cookie corresponding to a valid oauth2-proxy session >
   3. The first request arrived at my test server with an Authorization: header. The second request did not.
   4. I then tested the patched version of oauth2-proxy in the same way
   5. The first request arrived at my test server with an Authorization: header. The second request did as well.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [X] I have created a feature (non-master) branch for my PR.

This should probably be mentioned in the changelog, but it shouldn't break anything that doesn't rely on what should be considered broken behaviour