### PR TITLE
do not verify email in JWT Bearer token auth

### DIFF
--- a/pkg/apis/middleware/session.go
+++ b/pkg/apis/middleware/session.go
@@ -35,14 +35,6 @@ func CreateTokenToSessionFunc(verify VerifyFunc) TokenToSessionFunc {
 			return nil, fmt.Errorf("failed to parse bearer token claims: %v", err)
 		}
 
-		if claims.Email == "" {
-			claims.Email = claims.Subject
-		}
-
-		if claims.Verified != nil && !*claims.Verified {
-			return nil, fmt.Errorf("email in id_token (%s) isn't verified", claims.Email)
-		}
-
 		newSession := &sessionsapi.SessionState{
 			Email:             claims.Email,
 			User:              claims.Subject,

--- a/pkg/middleware/jwt_session_test.go
+++ b/pkg/middleware/jwt_session_test.go
@@ -463,7 +463,7 @@ Nnc3a3lGVWFCNUMxQnNJcnJMTWxka1dFaHluYmI4Ongtb2F1dGgtYmFzaWM=`
 				},
 				expectedErr:     nil,
 				expectedUser:    "123456789",
-				expectedEmail:   "123456789",
+				expectedEmail:   "",
 				expectedExpires: &expiresFuture,
 			}),
 			Entry("with a verified email", tokenToSessionTableInput{
@@ -485,7 +485,7 @@ Nnc3a3lGVWFCNUMxQnNJcnJMTWxka1dFaHluYmI4Ongtb2F1dGgtYmFzaWM=`
 				expectedEmail:   "foo@example.com",
 				expectedExpires: &expiresFuture,
 			}),
-			Entry("with a non-verified email", tokenToSessionTableInput{
+			Entry("do not fail with a non-verified email", tokenToSessionTableInput{
 				idToken: idTokenClaims{
 					StandardClaims: jwt.StandardClaims{
 						Audience:  "asdf1234",
@@ -499,7 +499,10 @@ Nnc3a3lGVWFCNUMxQnNJcnJMTWxka1dFaHluYmI4Ongtb2F1dGgtYmFzaWM=`
 					Email:    "foo@example.com",
 					Verified: &notVerified,
 				},
-				expectedErr: errors.New("email in id_token (foo@example.com) isn't verified"),
+				expectedErr:     nil,
+				expectedUser:    "123456789",
+				expectedEmail:   "foo@example.com",
+				expectedExpires: &expiresFuture,
 			}),
 		)
 	})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

PR for the issue #1152.

> When configuring JWT bearer token authentication with the --skip-jwt-bearer-tokens and turning off email-Validation with --insecure-oidc-allow-unverified-email, tokens with unverified emails cause an email in id_token <email> isn't verified error.

My changes include:
1. Do not throw error if id_token field 'email' is 'unverified'
2. Do not map id_token field 'subject' into id_token field 'email' if email is missing (may not be required to solve this issue but seemed logical to me)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I am trying to accomplish M2M authentication using an OAuth2.0 Client Credentials flow, but cannot get tokens with verified emails.

This PR fixes #1152.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Manual tests (keycloak-oidc provider and m2m tests with --skip-jwt-bearer-token and --extra-jwt-issuer set)
- Some unit test adjustments (see PR)



## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
