### PR TITLE
Fix formatting of Keycloak provider documentation

### DIFF
--- a/docs/docs/configuration/auth.md
+++ b/docs/docs/configuration/auth.md
@@ -146,11 +146,13 @@ If you are using GitHub enterprise, make sure you set the following to the appro
 
 ### Keycloak Auth Provider
 
+:::note 
+This is the legacy provider for Keycloak, use [Keycloak OIDC Auth Provider](#keycloak-oidc-auth-provider) if possible.
+:::
+
 1.  Create new client in your Keycloak realm with **Access Type** 'confidental' and **Valid Redirect URIs** 'https://internal.yourcompany.com/oauth2/callback'
 2.  Take note of the Secret in the credential tab of the client
 3.  Create a mapper with **Mapper Type** 'Group Membership' and **Token Claim Name** 'groups'.
-
-:::note this is the legacy Keycloak Auth Prodiver, use `keycloak-oidc` if possible. :::
 
 Make sure you set the following to the appropriate url:
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In https://github.com/oauth2-proxy/oauth2-proxy/pull/1210, documentation was added for a new Keycloak OIDC provider, but the `note` that was added is not formatted correctly. 

https://oauth2-proxy.github.io/oauth2-proxy/docs/next/configuration/oauth_provider#keycloak-auth-provider

![keycloak provider documentation](https://user-images.githubusercontent.com/61714293/134967051-59c50e80-c69e-4a72-95d6-1823d1b2a817.png)

## Motivation and Context

The documentation is difficult to read and the in page menu on the right is broken.

This PR fixes the formatting, corrects `prodiver` typo and adds a link to the recommended provider.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
