### PR TITLE
Improve TLS handling for Redis to support non-standalone mode with TLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 - [#997](https://github.com/oauth2-proxy/oauth2-proxy/pull/997) Allow passing the raw url path when proxying upstream requests - e.g. /%2F/ (@FStelzer)
 - [#1147](https://github.com/oauth2-proxy/oauth2-proxy/pull/1147) Multiarch support for docker image (@goshlanguage)
 - [#1296](https://github.com/oauth2-proxy/oauth2-proxy/pull/1296) Fixed `panic` when connecting to Redis with TLS (@mstrzele)
+- [#1403](https://github.com/oauth2-proxy/oauth2-proxy/pull/1403) Improve TLS handling for Redis to support non-standalone mode with TLS (@wadahiro)
 
 # V7.1.3
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Improve TLS handling for Redis to support non-standalone mode with TLS.

## Description

oauth2-proxy can't connect with TLS for Redis non-standalone mode.  For example, it can't connect to Amazon ElastiCache (cluster mode) with TLS now.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It allows to connect securely to Redis with TLS.
Also, this PR fixes panic issue which is described in #1296.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

* Tested with Amazon ElastiCache (cluster mode) with TLS manually
* Automated test by `make test`

Note: I added test cases for standalone mode and cluster mode. Currently I don't add tests for sentinel mode because it seems that [github.com/Bose/minisentinel](https://github.com/Bose/minisentinel) doesn't support TLS.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
