### PR TITLE
Fix missing groups claim for jwt bearer tokens

### DIFF
--- a/pkg/apis/middleware/session.go
+++ b/pkg/apis/middleware/session.go
@@ -20,10 +20,11 @@ type VerifyFunc func(ctx context.Context, token string) (*oidc.IDToken, error)
 func CreateTokenToSessionFunc(verify VerifyFunc) TokenToSessionFunc {
 	return func(ctx context.Context, token string) (*sessionsapi.SessionState, error) {
 		var claims struct {
-			Subject           string `json:"sub"`
-			Email             string `json:"email"`
-			Verified          *bool  `json:"email_verified"`
-			PreferredUsername string `json:"preferred_username"`
+			Subject           string   `json:"sub"`
+			Email             string   `json:"email"`
+			Verified          *bool    `json:"email_verified"`
+			PreferredUsername string   `json:"preferred_username"`
+			Groups            []string `json:"groups"`
 		}
 
 		idToken, err := verify(ctx, token)
@@ -47,6 +48,7 @@ func CreateTokenToSessionFunc(verify VerifyFunc) TokenToSessionFunc {
 			Email:             claims.Email,
 			User:              claims.Subject,
 			PreferredUsername: claims.PreferredUsername,
+			Groups:            claims.Groups,
 			AccessToken:       token,
 			IDToken:           token,
 			RefreshToken:      "",


### PR DESCRIPTION
Bearer JWT tokens provided for use with the `--skip-jwt-bearer-tokens` and `--extra-jwt-issuers` did not have group claims extracted and therefore didn't forward the `X-Forwared-Groups` and `--required-group` features. 

## Description

This change extracts the `groups` claim from JWT bearer tokens and adds them to the created session.

## Motivation and Context

Applications that make use of the groups claim expect to be able to use the same group related features for clients that use oauth2-proxy for oauth2 flow as well as clients that do their own auth flow and provide ID tokens.

This fixes #1352

## How Has This Been Tested?

I created an ID token that included a "groups" claim and ran this through oauth2-proxy with `set_xauthrequest=true` and ensured the contents of the upstream request included `X-Forwarded-Groups`. Also, adding a `--required-group=xxxx` argument no correctly allows traffic through with that group in the ID token.

I checked the unit tests for the session middleware but it wasn't immediately obvious how to get this behavior under test.

The blast radius of this change seems minimal, but because this has the potential to allow more traffic through than was previously the case it should be reviewed carefully.

## Checklist:

(I didn't add a changelog entry because I don't know what the PR number will be until I create it)

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
