### PR TITLE
Add phabricator provider

### DIFF
--- a/pkg/apis/options/legacy_options.go
+++ b/pkg/apis/options/legacy_options.go
@@ -485,6 +485,9 @@ type LegacyProvider struct {
 	GoogleAdminEmail         string   `flag:"google-admin-email" cfg:"google_admin_email"`
 	GoogleServiceAccountJSON string   `flag:"google-service-account-json" cfg:"google_service_account_json"`
 
+	PhabricatorToken       string `flag:"phabricator-token" cfg:"phabricator_token"`
+	PhabricatorGroupFilter string `flag:"phabricator-group-filter" cfg:"phabricator_group_filter"`
+
 	// These options allow for other providers besides Google, with
 	// potential overrides.
 	ProviderType                       string   `flag:"provider" cfg:"provider"`
@@ -536,6 +539,9 @@ func legacyProviderFlagSet() *pflag.FlagSet {
 	flagSet.String("client-id", "", "the OAuth Client ID: ie: \"123456.apps.googleusercontent.com\"")
 	flagSet.String("client-secret", "", "the OAuth Client Secret")
 	flagSet.String("client-secret-file", "", "the file with OAuth Client Secret")
+
+	flagSet.String("phabricator-token", "", "the token to use when obtaining group information")
+	flagSet.String("phabricator-group-filter", "", "regex to filter phabricator groups")
 
 	flagSet.String("provider", "google", "OAuth provider")
 	flagSet.String("provider-display-name", "", "Provider display name")
@@ -688,6 +694,11 @@ func (l *LegacyProvider) convert() (Providers, error) {
 			Groups:             l.GoogleGroups,
 			AdminEmail:         l.GoogleAdminEmail,
 			ServiceAccountJSON: l.GoogleServiceAccountJSON,
+		}
+	case "phabricator":
+		provider.PhabricatorConfig = PhabricatorOptions{
+			Token:       l.PhabricatorToken,
+			GroupFilter: l.PhabricatorGroupFilter,
 		}
 	}
 

--- a/pkg/apis/options/providers.go
+++ b/pkg/apis/options/providers.go
@@ -37,6 +37,9 @@ type Provider struct {
 	// LoginGovConfig holds all configurations for LoginGov provider.
 	LoginGovConfig LoginGovOptions `json:"loginGovConfig,omitempty"`
 
+	// PhabricatorConfig holds all configurations for Phabricator provider.
+	PhabricatorConfig PhabricatorOptions `json:"phabricatorConfig,omitempty"`
+
 	// ID should be a unique identifier for the provider.
 	// This value is required for all providers.
 	ID string `json:"id,omitempty"`
@@ -173,6 +176,13 @@ type LoginGovOptions struct {
 	JWTKeyFile string `json:"jwtKeyFile,omitempty"`
 	// PubJWKURL is the JWK pubkey access endpoint
 	PubJWKURL string `json:"pubjwkURL,omitempty"`
+}
+
+type PhabricatorOptions struct {
+	// Token is the conduit token to use when listing user groups
+	Token string `json:"token,omitempty"`
+	// GroupFilter is a regular expression to filter user groups
+	GroupFilter string `json:"groupFilter,omitempty"`
 }
 
 func providerDefaults() Providers {

--- a/pkg/validation/options.go
+++ b/pkg/validation/options.go
@@ -328,6 +328,19 @@ func parseProviderInfo(o *options.Options, msgs []string) []string {
 				p.JWTKey = signKey
 			}
 		}
+	case *providers.PhabricatorProvider:
+		if o.Providers[0].PhabricatorConfig.Token == "" {
+			msgs = append(msgs, "phabricator provider requires a conduit token")
+		}
+		p.Token = o.Providers[0].PhabricatorConfig.Token
+
+		if o.Providers[0].PhabricatorConfig.GroupFilter != "" {
+			err := p.AddGroupFilter(o.Providers[0].PhabricatorConfig.GroupFilter)
+			if err != nil {
+				msgs = append(msgs, fmt.Sprintf("group_filter (%s) not valid regular expression: %v", o.Providers[0].PhabricatorConfig.GroupFilter, err))
+			}
+		}
+
 	}
 	return msgs
 }

--- a/providers/phabricator.go
+++ b/providers/phabricator.go
@@ -1,0 +1,176 @@
+package providers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/sessions"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/requests"
+)
+
+type PhabricatorProvider struct {
+	*ProviderData
+
+	Token       string
+	groupFilter *regexp.Regexp
+}
+
+var _ Provider = (*PhabricatorProvider)(nil)
+
+// types for the project search endpoint: https://secure.phabricator.com/conduit/method/project.search/
+type Constraints struct {
+	Members []string `json:"members"`
+}
+
+type Conduit struct {
+	Token string `json:"token"`
+}
+
+type Attachments struct {
+	Projects bool `json:"projects"`
+}
+
+type ProjectSearch struct {
+	Cons Constraints `json:"constraints"`
+	Cond Conduit     `json:"__conduit__"`
+	Atta Attachments `json:"attachments"`
+}
+
+const (
+	phabricatorProviderName = "Phabricator"
+)
+
+// NewphabricatorProvider creates a phabricatorProvider using the passed ProviderData
+func NewPhabricatorProvider(p *ProviderData) *PhabricatorProvider {
+	p.setProviderDefaults(providerDefaults{
+		name: phabricatorProviderName,
+		redeemURL: &url.URL{
+			Scheme: p.LoginURL.Scheme,
+			Host:   p.Data().LoginURL.Host,
+			Path:   "/oauthserver/token/",
+		},
+		profileURL: &url.URL{
+			Scheme: p.LoginURL.Scheme,
+			Host:   p.Data().LoginURL.Host,
+			Path:   "/api/user.whoami",
+		},
+		validateURL: &url.URL{
+			Scheme: p.LoginURL.Scheme,
+			Host:   p.Data().LoginURL.Host,
+			Path:   "/api/user.whoami",
+		},
+	})
+
+	return &PhabricatorProvider{ProviderData: p}
+}
+
+// AddGroupFilter adds a regex filter to group listing
+func (p *PhabricatorProvider) AddGroupFilter(filter string) error {
+	r, err := regexp.Compile(filter)
+	if err != nil {
+		return err
+	}
+	p.groupFilter = r
+	return nil
+}
+
+func (p *PhabricatorProvider) getUsernameAndEmailAddress(ctx context.Context, s *sessions.SessionState) (string, string, error) {
+	requestURL := p.ProfileURL.String() + "?access_token=" + s.AccessToken
+
+	json, err := requests.New(requestURL).
+		WithContext(ctx).
+		Do().
+		UnmarshalJSON()
+	if err != nil {
+		return "", "", err
+	}
+
+	result := json.Get("result")
+
+	email, err := result.Get("primaryEmail").String()
+	if err != nil {
+		return "", "", err
+	}
+
+	user, err := result.Get("userName").String()
+	if err != nil {
+		return "", "", err
+	}
+
+	return user, email, nil
+}
+
+func (p *PhabricatorProvider) getGroups(ctx context.Context, s *sessions.SessionState) ([]string, error) {
+	searchBody := ProjectSearch{
+		Constraints{
+			Members: []string{s.User},
+		},
+		Conduit{
+			Token: p.Token,
+		},
+		Attachments{
+			Projects: true,
+		},
+	}
+
+	requestURL := &url.URL{
+		Scheme: p.LoginURL.Scheme,
+		Host:   p.LoginURL.Host,
+		Path:   "/api/project.search",
+	}
+
+	jsonBody, _ := json.Marshal(searchBody)
+	form := url.Values{}
+	form.Add("params", string(jsonBody))
+
+	json, err := requests.New(requestURL.String()).
+		WithContext(ctx).
+		WithMethod("POST").
+		WithBody(strings.NewReader(form.Encode())).
+		Do().
+		UnmarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+
+	code, _ := json.Get("error_code").String()
+	if code != "" {
+		info, _ := json.Get("error_info").String()
+		return nil, fmt.Errorf("unable to look up phabricator groups: %s", info)
+	}
+
+	var groups []string
+	data, _ := json.Get("result").Get("data").Array()
+	for i := range data {
+		slug, _ := json.Get("result").Get("data").GetIndex(i).Get("fields").Get("slug").String()
+		if p.groupFilter == nil || p.groupFilter.MatchString(slug) {
+			groups = append(groups, slug)
+		}
+	}
+
+	return groups, nil
+}
+
+// EnrichSession uses the phabricator api to populate the session's email and
+// groups.
+func (p *PhabricatorProvider) EnrichSession(ctx context.Context, s *sessions.SessionState) error {
+	user, email, err := p.getUsernameAndEmailAddress(ctx, s)
+	if err != nil {
+		return err
+	}
+	s.Email = email
+	s.User = user
+
+	groups, err := p.getGroups(ctx, s)
+	if err != nil {
+		return err
+	}
+
+	s.Groups = groups
+
+	return nil
+}

--- a/providers/phabricator_test.go
+++ b/providers/phabricator_test.go
@@ -1,0 +1,173 @@
+package providers
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/sessions"
+	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
+)
+
+func testPhabricatorProvider(hostname string) *PhabricatorProvider {
+	p := NewPhabricatorProvider(
+		&ProviderData{
+			LoginURL: &url.URL{Host: hostname, Scheme: "http", Path: "/oauthserver/auth/"},
+		})
+	return p
+}
+
+func testPhabricatorBackend(whoamiPayload, projectsearchPayload string) *httptest.Server {
+	paths := map[string]string{
+		"/api/user.whoami":    whoamiPayload,
+		"/api/project.search": projectsearchPayload,
+	}
+
+	return httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			url := r.URL
+			log.Printf("%s %s\n", url.Path, url.RawQuery)
+			if paths[url.Path] == "" {
+				log.Printf("%s not in %+v\n", url.Path, paths)
+				w.WriteHeader(404)
+			} else if !IsAuthorizedInURL(r.URL) && r.URL.Path != "/api/project.search" {
+				w.WriteHeader(403)
+			} else {
+				w.WriteHeader(200)
+				w.Write([]byte(paths[url.Path]))
+			}
+		}))
+}
+
+func TestNewPhabricatorProvider(t *testing.T) {
+	g := NewWithT(t)
+
+	// Test that defaults are set when calling for a new provider with only LoginURL set
+	providerData := NewPhabricatorProvider(
+		&ProviderData{LoginURL: &url.URL{Host: "localhost", Scheme: "http", Path: "/oauthserver/auth/"}},
+	).Data()
+
+	g.Expect(providerData.ProviderName).To(Equal("Phabricator"))
+	g.Expect(providerData.LoginURL.String()).To(Equal("http://localhost/oauthserver/auth/"))
+	g.Expect(providerData.RedeemURL.String()).To(Equal("http://localhost/oauthserver/token/"))
+	g.Expect(providerData.ProfileURL.String()).To(Equal("http://localhost/api/user.whoami"))
+	g.Expect(providerData.ValidateURL.String()).To(Equal("http://localhost/api/user.whoami"))
+	g.Expect(providerData.Scope).To(Equal(""))
+}
+
+func TestPhabricatorProviderOverrides(t *testing.T) {
+	p := NewPhabricatorProvider(
+		&ProviderData{
+			LoginURL: &url.URL{
+				Scheme: "https",
+				Host:   "example.com",
+				Path:   "/oauthserver/auth/"},
+			RedeemURL: &url.URL{
+				Scheme: "https",
+				Host:   "example.com",
+				Path:   "/oauthserver/token/"},
+			ValidateURL: &url.URL{
+				Scheme: "https",
+				Host:   "example.com",
+				Path:   "/api/user.whoami"},
+		})
+	assert.NotEqual(t, nil, p)
+	assert.Equal(t, "Phabricator", p.Data().ProviderName)
+	assert.Equal(t, "https://example.com/oauthserver/auth/",
+		p.Data().LoginURL.String())
+	assert.Equal(t, "https://example.com/oauthserver/token/",
+		p.Data().RedeemURL.String())
+	assert.Equal(t, "https://example.com/api/user.whoami",
+		p.Data().ValidateURL.String())
+}
+
+func TestPhabricatorProviderEnrichSession(t *testing.T) {
+	b := testPhabricatorBackend(
+		`{"result": {"primaryEmail": "user@example.com", "userName": "user"}}`,
+		`{"result": {"data": [{"fields": {"slug": "general_access"}}]}}`,
+	)
+	defer b.Close()
+
+	bURL, _ := url.Parse(b.URL)
+	p := testPhabricatorProvider(bURL.Host)
+
+	session := CreateAuthorizedSession()
+	err := p.EnrichSession(context.Background(), session)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "user@example.com", session.Email)
+	assert.Equal(t, "user", session.User)
+	assert.Equal(t, []string{"general_access"}, session.Groups)
+}
+
+func TestPhabricatorProviderEnrichSessionFailedRequest(t *testing.T) {
+	b := testPhabricatorBackend(
+		`{"result": {"primaryEmail": "user@example.com", "userName": "user"}}`,
+		`{"result": {"data": [{"fields": {"slug": "general_access"}}]}}`,
+	)
+	defer b.Close()
+
+	bURL, _ := url.Parse(b.URL)
+	p := testPhabricatorProvider(bURL.Host)
+
+	session := &sessions.SessionState{AccessToken: "unexpected_access_token"}
+	err := p.EnrichSession(context.Background(), session)
+	assert.NotEqual(t, nil, err)
+	assert.Equal(t, "", session.Email)
+	assert.Equal(t, "", session.User)
+	assert.Empty(t, session.Groups)
+}
+
+func TestPhabricatorProviderFilterGroups(t *testing.T) {
+	b := testPhabricatorBackend(
+		`{"result": {"primaryEmail": "user@example.com", "userName": "user"}}`,
+		`{"result": {"data": [
+			{"fields": {"slug": "should_be_ignored"}},
+			{"fields": {"slug": "something_team"}},
+			{"fields": {"slug": "an_ignored_team_project"}},
+			{"fields": {"slug": "general_access"}}
+		]}}`,
+	)
+	defer b.Close()
+
+	tests := []struct {
+		regex          string
+		expectedGroups []string
+	}{
+		{
+			regex:          ``,
+			expectedGroups: []string{"should_be_ignored", "something_team", "an_ignored_team_project", "general_access"},
+		},
+		{
+			regex:          `.*`,
+			expectedGroups: []string{"should_be_ignored", "something_team", "an_ignored_team_project", "general_access"},
+		},
+		{
+			regex:          `.+_access$`,
+			expectedGroups: []string{"general_access"},
+		},
+		{
+			regex:          `.+_(access|team)$`,
+			expectedGroups: []string{"something_team", "general_access"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.regex, func(t *testing.T) {
+			bURL, _ := url.Parse(b.URL)
+			p := testPhabricatorProvider(bURL.Host)
+			err := p.AddGroupFilter(test.regex)
+			assert.Equal(t, nil, err)
+
+			session := CreateAuthorizedSession()
+			err = p.EnrichSession(context.Background(), session)
+			assert.Equal(t, nil, err)
+			assert.Equal(t, "user@example.com", session.Email)
+			assert.Equal(t, "user", session.User)
+			assert.Equal(t, test.expectedGroups, session.Groups)
+		})
+	}
+}

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -51,6 +51,8 @@ func New(provider string, p *ProviderData) Provider {
 		return NewDigitalOceanProvider(p)
 	case "google":
 		return NewGoogleProvider(p)
+	case "phabricator":
+		return NewPhabricatorProvider(p)
 	default:
 		return nil
 	}


### PR DESCRIPTION
This adds support for using phabricator as an auth provider.

This is based on a provider we've been running internally for a few years.

It'd be nice to be able to run unmodified upstream code, but since there's a freeze on new smaller providers I'll leave the PR as a draft in case others want to use it. I'll likely keep this branch updated to keep up to date with the tip of master.