### PR TITLE
Split session save function to detect redis duplicate/not found session key error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - [#1147](https://github.com/oauth2-proxy/oauth2-proxy/pull/1147) Multiarch support for docker image (@goshlanguage)
 - [#1296](https://github.com/oauth2-proxy/oauth2-proxy/pull/1296) Fixed `panic` when connecting to Redis with TLS (@mstrzele)
 - [#1403](https://github.com/oauth2-proxy/oauth2-proxy/pull/1403) Improve TLS handling for Redis to support non-standalone mode with TLS (@wadahiro)
+- [#1416](https://github.com/oauth2-proxy/oauth2-proxy/pull/1416) Split session save function to detect redis duplicate/not found session key error (@wadahiro)
 
 # V7.1.3
 

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -473,9 +473,9 @@ func (p *OAuthProxy) LoadCookiedSession(req *http.Request) (*sessionsapi.Session
 	return p.sessionStore.Load(req)
 }
 
-// SaveSession creates a new session cookie value and sets this on the response
-func (p *OAuthProxy) SaveSession(rw http.ResponseWriter, req *http.Request, s *sessionsapi.SessionState) error {
-	return p.sessionStore.Save(rw, req, s)
+// CreateSession creates a new session cookie value and sets this on the response
+func (p *OAuthProxy) CreateSession(rw http.ResponseWriter, req *http.Request, s *sessionsapi.SessionState) error {
+	return p.sessionStore.Create(rw, req, s)
 }
 
 func (p *OAuthProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
@@ -594,7 +594,7 @@ func (p *OAuthProxy) SignIn(rw http.ResponseWriter, req *http.Request) {
 	user, ok := p.ManualSignIn(req)
 	if ok {
 		session := &sessionsapi.SessionState{User: user, Groups: p.basicAuthGroups}
-		err = p.SaveSession(rw, req, session)
+		err = p.CreateSession(rw, req, session)
 		if err != nil {
 			logger.Printf("Error saving session: %v", err)
 			p.ErrorPage(rw, req, http.StatusInternalServerError, err.Error())
@@ -768,7 +768,7 @@ func (p *OAuthProxy) OAuthCallback(rw http.ResponseWriter, req *http.Request) {
 	}
 	if p.Validator(session.Email) && authorized {
 		logger.PrintAuthf(session.Email, req, logger.AuthSuccess, "Authenticated via OAuth2: %s", session)
-		err := p.SaveSession(rw, req, session)
+		err := p.CreateSession(rw, req, session)
 		if err != nil {
 			logger.Errorf("Error saving session state for %s: %v", remoteAddr, err)
 			p.ErrorPage(rw, req, http.StatusInternalServerError, err.Error())

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -241,7 +241,7 @@ func TestBasicAuthPassword(t *testing.T) {
 	// Save the required session
 	rw := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/", nil)
-	err = proxy.sessionStore.Save(rw, req, &sessions.SessionState{
+	err = proxy.sessionStore.Create(rw, req, &sessions.SessionState{
 		Email: emailAddress,
 	})
 	assert.NoError(t, err)
@@ -300,7 +300,7 @@ func TestPassGroupsHeadersWithGroups(t *testing.T) {
 	// Save the required session
 	rw := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/", nil)
-	err = proxy.sessionStore.Save(rw, req, session)
+	err = proxy.sessionStore.Create(rw, req, session)
 	assert.NoError(t, err)
 
 	// Extract the cookie value to inject into the test request
@@ -772,7 +772,7 @@ func NewProcessCookieTestWithOptionsModifiers(modifiers ...OptionsModifier) (*Pr
 }
 
 func (p *ProcessCookieTest) SaveSession(s *sessions.SessionState) error {
-	err := p.proxy.SaveSession(p.rw, p.req, s)
+	err := p.proxy.CreateSession(p.rw, p.req, s)
 	if err != nil {
 		return err
 	}
@@ -1471,7 +1471,7 @@ func (st *SignatureTest) MakeRequestWithExpectedKey(method, body, key string) er
 
 	state := &sessions.SessionState{
 		Email: "mbland@acm.org", AccessToken: "my_access_token"}
-	err = proxy.SaveSession(st.rw, req, state)
+	err = proxy.CreateSession(st.rw, req, state)
 	if err != nil {
 		return err
 	}

--- a/pkg/apis/sessions/interfaces.go
+++ b/pkg/apis/sessions/interfaces.go
@@ -7,9 +7,13 @@ import (
 	"time"
 )
 
+var ErrDuplicateSessionKey = errors.New("duplicate session key")
+var ErrNotFoundSessionKey = errors.New("not found session key")
+
 // SessionStore is an interface to storing user sessions in the proxy
 type SessionStore interface {
-	Save(rw http.ResponseWriter, req *http.Request, s *SessionState) error
+	Create(rw http.ResponseWriter, req *http.Request, s *SessionState) error
+	Update(rw http.ResponseWriter, req *http.Request, s *SessionState) error
 	Load(req *http.Request) (*SessionState, error)
 	Clear(rw http.ResponseWriter, req *http.Request) error
 }

--- a/pkg/sessions/cookie/session_store.go
+++ b/pkg/sessions/cookie/session_store.go
@@ -32,17 +32,16 @@ type SessionStore struct {
 	Minimal      bool
 }
 
+// Create takes a sessions.SessionState and stores the information from it
+// within Cookies set on the HTTP response writer
+func (s *SessionStore) Create(rw http.ResponseWriter, req *http.Request, ss *sessions.SessionState) error {
+	return s.save(rw, req, ss)
+}
+
 // Save takes a sessions.SessionState and stores the information from it
 // within Cookies set on the HTTP response writer
-func (s *SessionStore) Save(rw http.ResponseWriter, req *http.Request, ss *sessions.SessionState) error {
-	if ss.CreatedAt == nil || ss.CreatedAt.IsZero() {
-		ss.CreatedAtNow()
-	}
-	value, err := s.cookieForSession(ss)
-	if err != nil {
-		return err
-	}
-	return s.setSessionCookie(rw, req, value, *ss.CreatedAt)
+func (s *SessionStore) Update(rw http.ResponseWriter, req *http.Request, ss *sessions.SessionState) error {
+	return s.save(rw, req, ss)
 }
 
 // Load reads sessions.SessionState information from Cookies within the
@@ -80,6 +79,17 @@ func (s *SessionStore) Clear(rw http.ResponseWriter, req *http.Request) error {
 	}
 
 	return nil
+}
+
+func (s *SessionStore) save(rw http.ResponseWriter, req *http.Request, ss *sessions.SessionState) error {
+	if ss.CreatedAt == nil || ss.CreatedAt.IsZero() {
+		ss.CreatedAtNow()
+	}
+	value, err := s.cookieForSession(ss)
+	if err != nil {
+		return err
+	}
+	return s.setSessionCookie(rw, req, value, *ss.CreatedAt)
 }
 
 // cookieForSession serializes a session state for storage in a cookie

--- a/pkg/sessions/persistence/interfaces.go
+++ b/pkg/sessions/persistence/interfaces.go
@@ -11,7 +11,9 @@ import (
 // Implementing this interface allows it to easily use the persistence.Manager
 // for session ticket + encryption details.
 type Store interface {
-	Save(context.Context, string, []byte, time.Duration) error
+	Create(context.Context, string, []byte, time.Duration) error
+	Update(context.Context, string, []byte, time.Duration) error
+	CreateOrUpdate(context.Context, string, []byte, time.Duration) error
 	Load(context.Context, string) ([]byte, error)
 	Clear(context.Context, string) error
 	Lock(key string) sessions.Lock

--- a/pkg/sessions/persistence/manager_test.go
+++ b/pkg/sessions/persistence/manager_test.go
@@ -1,12 +1,16 @@
 package persistence
 
 import (
+	"context"
+	"crypto/rand"
+	"net/http/httptest"
 	"time"
 
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
 	sessionsapi "github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/sessions"
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/sessions/tests"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Persistence Manager Tests", func() {
@@ -22,4 +26,118 @@ var _ = Describe("Persistence Manager Tests", func() {
 			ms.FastForward(d)
 			return nil
 		})
+
+	Context("creating duplicate session key", func() {
+		var m *Manager
+		BeforeEach(func() {
+			cookieSecret := make([]byte, 32)
+			_, err := rand.Read(cookieSecret)
+			Expect(err).ToNot(HaveOccurred())
+
+			cookieOpts := &options.Cookie{
+				Name:     "_oauth2_proxy",
+				Path:     "/",
+				Expire:   time.Duration(168) * time.Hour,
+				Refresh:  time.Duration(1) * time.Hour,
+				Secure:   true,
+				HTTPOnly: true,
+				SameSite: "",
+				Secret:   string(cookieSecret),
+			}
+
+			m = NewManager(ms, cookieOpts)
+		})
+
+		It("returns an error", func() {
+			// Setup mock func to return error
+			ms.BeforeCreateFunc(func(c context.Context, key string, value []byte, exp time.Duration) error {
+				return sessionsapi.ErrDuplicateSessionKey
+			})
+
+			expires := time.Now().Add(1 * time.Hour)
+			session := &sessionsapi.SessionState{
+				AccessToken: "AccessToken",
+				IDToken:     "IDToken",
+				ExpiresOn:   &expires,
+			}
+
+			req := httptest.NewRequest("GET", "http://example.com/", nil)
+			saveResp := httptest.NewRecorder()
+			err := m.Create(saveResp, req, session)
+			Expect(err).To(MatchError(sessionsapi.ErrDuplicateSessionKey))
+		})
+
+		It("does not return an error by succeeding on retry", func() {
+			// Setup mock func to return success on retry
+			i := 0
+			ms.BeforeCreateFunc(func(c context.Context, key string, value []byte, exp time.Duration) error {
+				if i < 1 {
+					i++
+					return sessionsapi.ErrDuplicateSessionKey
+				}
+				return nil
+			})
+
+			expires := time.Now().Add(1 * time.Hour)
+			session := &sessionsapi.SessionState{
+				AccessToken: "AccessToken",
+				IDToken:     "IDToken",
+				ExpiresOn:   &expires,
+			}
+
+			req := httptest.NewRequest("GET", "http://example.com/", nil)
+			saveResp := httptest.NewRecorder()
+			err := m.Create(saveResp, req, session)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("updating with no existing session key", func() {
+		var m *Manager
+		BeforeEach(func() {
+			cookieSecret := make([]byte, 32)
+			_, err := rand.Read(cookieSecret)
+			Expect(err).ToNot(HaveOccurred())
+
+			cookieOpts := &options.Cookie{
+				Name:     "_oauth2_proxy",
+				Path:     "/",
+				Expire:   time.Duration(168) * time.Hour,
+				Refresh:  time.Duration(1) * time.Hour,
+				Secure:   true,
+				HTTPOnly: true,
+				SameSite: "",
+				Secret:   string(cookieSecret),
+			}
+
+			m = NewManager(ms, cookieOpts)
+		})
+
+		It("returns an error", func() {
+			// Setup mock func to return error
+			ms.BeforeUpdateFunc(func(c context.Context, key string, value []byte, exp time.Duration) error {
+				return sessionsapi.ErrNotFoundSessionKey
+			})
+
+			expires := time.Now().Add(1 * time.Hour)
+			session := &sessionsapi.SessionState{
+				AccessToken: "AccessToken",
+				IDToken:     "IDToken",
+				ExpiresOn:   &expires,
+			}
+
+			req := httptest.NewRequest("GET", "http://example.com/", nil)
+			saveResp := httptest.NewRecorder()
+			err := m.Create(saveResp, req, session)
+			Expect(err).ToNot(HaveOccurred())
+
+			resultCookies := saveResp.Result().Cookies()
+			for _, c := range resultCookies {
+				req.AddCookie(c)
+			}
+
+			err = m.Update(saveResp, req, session)
+			Expect(err).To(MatchError(sessionsapi.ErrNotFoundSessionKey))
+		})
+	})
 })

--- a/pkg/sessions/redis/client.go
+++ b/pkg/sessions/redis/client.go
@@ -12,6 +12,8 @@ import (
 type Client interface {
 	Get(ctx context.Context, key string) ([]byte, error)
 	Lock(key string) sessions.Lock
+	SetNX(ctx context.Context, key string, value []byte, expiration time.Duration) (bool, error)
+	SetXX(ctx context.Context, key string, value []byte, expiration time.Duration) (bool, error)
 	Set(ctx context.Context, key string, value []byte, expiration time.Duration) error
 	Del(ctx context.Context, key string) error
 }
@@ -30,6 +32,14 @@ func newClient(c *redis.Client) Client {
 
 func (c *client) Get(ctx context.Context, key string) ([]byte, error) {
 	return c.Client.Get(ctx, key).Bytes()
+}
+
+func (c *client) SetNX(ctx context.Context, key string, value []byte, expiration time.Duration) (bool, error) {
+	return c.Client.SetNX(ctx, key, value, expiration).Result()
+}
+
+func (c *client) SetXX(ctx context.Context, key string, value []byte, expiration time.Duration) (bool, error) {
+	return c.Client.SetXX(ctx, key, value, expiration).Result()
 }
 
 func (c *client) Set(ctx context.Context, key string, value []byte, expiration time.Duration) error {
@@ -58,6 +68,14 @@ func newClusterClient(c *redis.ClusterClient) Client {
 
 func (c *clusterClient) Get(ctx context.Context, key string) ([]byte, error) {
 	return c.ClusterClient.Get(ctx, key).Bytes()
+}
+
+func (c *clusterClient) SetNX(ctx context.Context, key string, value []byte, expiration time.Duration) (bool, error) {
+	return c.ClusterClient.SetNX(ctx, key, value, expiration).Result()
+}
+
+func (c *clusterClient) SetXX(ctx context.Context, key string, value []byte, expiration time.Duration) (bool, error) {
+	return c.ClusterClient.SetXX(ctx, key, value, expiration).Result()
 }
 
 func (c *clusterClient) Set(ctx context.Context, key string, value []byte, expiration time.Duration) error {

--- a/pkg/sessions/tests/session_store_tests.go
+++ b/pkg/sessions/tests/session_store_tests.go
@@ -208,7 +208,7 @@ func PersistentSessionStoreInterfaceTests(in *testInput) {
 		BeforeEach(func() {
 			req := httptest.NewRequest("GET", "http://example.com/", nil)
 			saveResp := httptest.NewRecorder()
-			err := in.ss().Save(saveResp, req, in.session)
+			err := in.ss().Create(saveResp, req, in.session)
 			Expect(err).ToNot(HaveOccurred())
 
 			resultCookies = saveResp.Result().Cookies()
@@ -250,7 +250,7 @@ func PersistentSessionStoreInterfaceTests(in *testInput) {
 		BeforeEach(func() {
 			req := httptest.NewRequest("GET", "http://example.com/", nil)
 			resp := httptest.NewRecorder()
-			err := in.ss().Save(resp, req, in.session)
+			err := in.ss().Create(resp, req, in.session)
 			Expect(err).ToNot(HaveOccurred())
 
 			for _, cookie := range resp.Result().Cookies() {
@@ -291,7 +291,7 @@ func PersistentSessionStoreInterfaceTests(in *testInput) {
 		var loadedSession *sessionsapi.SessionState
 		BeforeEach(func() {
 			resp := httptest.NewRecorder()
-			err := in.ss().Save(resp, in.request, in.session)
+			err := in.ss().Create(resp, in.request, in.session)
 			Expect(err).ToNot(HaveOccurred())
 
 			for _, cookie := range resp.Result().Cookies() {
@@ -361,10 +361,10 @@ func PersistentSessionStoreInterfaceTests(in *testInput) {
 }
 
 func SessionStoreInterfaceTests(in *testInput) {
-	Context("when Save is called", func() {
+	Context("when Create is called", func() {
 		Context("with no existing session", func() {
 			BeforeEach(func() {
-				err := in.ss().Save(in.response, in.request, in.session)
+				err := in.ss().Create(in.response, in.request, in.session)
 				Expect(err).ToNot(HaveOccurred())
 			})
 
@@ -388,7 +388,7 @@ func SessionStoreInterfaceTests(in *testInput) {
 				cookie := cookiesapi.MakeCookieFromOptions(in.request, in.cookieOpts.Name, value, in.cookieOpts, in.cookieOpts.Expire, time.Now())
 				in.request.AddCookie(cookie)
 
-				err = in.ss().Save(in.response, in.request, in.session)
+				err = in.ss().Create(in.response, in.request, in.session)
 				Expect(err).ToNot(HaveOccurred())
 			})
 
@@ -403,13 +403,13 @@ func SessionStoreInterfaceTests(in *testInput) {
 			CheckCookieOptions(in)
 		})
 
-		Context("with an expired saved session", func() {
+		Context("with an expired created session", func() {
 			var err error
 			BeforeEach(func() {
-				By("saving a session")
+				By("creating a session")
 				req := httptest.NewRequest("GET", "http://example.com/", nil)
 				saveResp := httptest.NewRecorder()
-				err = in.ss().Save(saveResp, req, in.session)
+				err = in.ss().Create(saveResp, req, in.session)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("and clearing the session")
@@ -420,8 +420,8 @@ func SessionStoreInterfaceTests(in *testInput) {
 				err = in.ss().Clear(clearResp, in.request)
 				Expect(err).ToNot(HaveOccurred())
 
-				By("then saving a request with the cleared session")
-				err = in.ss().Save(in.response, in.request, in.session)
+				By("then creating a request with the cleared session")
+				err = in.ss().Create(in.response, in.request, in.session)
 			})
 
 			It("no error should occur", func() {
@@ -434,7 +434,7 @@ func SessionStoreInterfaceTests(in *testInput) {
 		BeforeEach(func() {
 			req := httptest.NewRequest("GET", "http://example.com/", nil)
 			saveResp := httptest.NewRecorder()
-			err := in.ss().Save(saveResp, req, in.session)
+			err := in.ss().Create(saveResp, req, in.session)
 			Expect(err).ToNot(HaveOccurred())
 
 			for _, c := range saveResp.Result().Cookies() {
@@ -456,7 +456,7 @@ func SessionStoreInterfaceTests(in *testInput) {
 			BeforeEach(func() {
 				req := httptest.NewRequest("GET", "http://example.com/", nil)
 				resp := httptest.NewRecorder()
-				err := in.ss().Save(resp, req, in.session)
+				err := in.ss().Create(resp, req, in.session)
 				Expect(err).ToNot(HaveOccurred())
 				for _, cookie := range resp.Result().Cookies() {
 					in.request.AddCookie(cookie)

--- a/pkg/validation/sessions.go
+++ b/pkg/validation/sessions.go
@@ -65,7 +65,7 @@ func sendRedisConnectionTest(client redis.Client, key string, val string) []stri
 	msgs := []string{}
 	ctx := context.Background()
 
-	err := client.Set(ctx, key, []byte(val), time.Duration(60)*time.Second)
+	_, err := client.SetNX(ctx, key, []byte(val), time.Duration(60)*time.Second)
 	if err != nil {
 		msgs = append(msgs, fmt.Sprintf("unable to set a redis initialization key: %v", err))
 	} else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Split session save function to detect redis duplicate/not found session key error.

## Description

<!--- Describe your changes in detail -->

Currently, redis store implementation uses [SET](https://redis.io/commands/set) command when creating or updating session. It can't detect the following cases:

- When creating a session with a key that already exists in Redis.
- When updating a session with a key that does not yet exist in Redis.

To detect them, I split current `Save` function into the following three functions:

- `Create` : If the same key exists, don't create it using `SET NX` command
- `Update`: If the key doesn't exists, don't create it using `SET XX` command
- `CreateOrUpdate` : Create or Update (Same as current implementation)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Current implementation causes the following problems:

- If the same session key is generated by oauth2-proxy extremely unlucky, the Redis session will be shared between users.
- Updating Redis session by refreshing may revive discarded session depending on timing.

Note: The session key issued by oauth2-proxy is random enough, but I believe it should be checked for duplicate, as described in the [OWASP Session Management Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#session-id-entropy) as follows:

> Additionally, a random session ID is not enough; it must also be unique to avoid duplicated IDs. A random session ID must not already exist in the current session ID space.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Automated test by `make test`

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
