### PR TITLE
Let authentication fail when session validation fails (fixes #1396)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Changes since v7.2.0
 
+- [#1433](https://github.com/oauth2-proxy/oauth2-proxy/pull/1433) Let authentication fail when session validation fails ((@stippi2)
+
 # V7.2.0
 
 ## Release Highlights

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -755,7 +755,11 @@ func (p *OAuthProxy) OAuthCallback(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	csrf.SetSessionNonce(session)
-	p.provider.ValidateSession(req.Context(), session)
+	if !p.provider.ValidateSession(req.Context(), session) {
+		logger.PrintAuthf(session.Email, req, logger.AuthFailure, "Session validation failed: %s", session)
+		p.ErrorPage(rw, req, http.StatusForbidden, "Session validation failed")
+		return
+	}
 
 	if !p.redirectValidator.IsValidRedirect(appRedirect) {
 		appRedirect = "/"

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/validation"
 	"github.com/oauth2-proxy/oauth2-proxy/v7/providers"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -562,16 +563,12 @@ func TestSessionValidationFailure(t *testing.T) {
 	patTest, err := NewPassAccessTokenTest(PassAccessTokenTestOptions{
 		ValidToken: false,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	t.Cleanup(patTest.Close)
 
 	// An unsuccessful validation will return 403 and not set the auth cookie.
 	code, cookie := patTest.getCallbackEndpoint()
-	if code != http.StatusForbidden {
-		t.Fatalf("expected 403; got %d", code)
-	}
+	assert.Equal(t, http.StatusForbidden, code)
 	assert.Equal(t, "", cookie)
 }
 

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -322,6 +322,7 @@ type PassAccessTokenTest struct {
 
 type PassAccessTokenTestOptions struct {
 	PassAccessToken bool
+	ValidToken      bool
 	ProxyUpstream   options.Upstream
 }
 
@@ -385,7 +386,9 @@ func NewPassAccessTokenTest(opts PassAccessTokenTestOptions) (*PassAccessTokenTe
 	providerURL, _ := url.Parse(patt.providerServer.URL)
 	const emailAddress = "michael.bland@gsa.gov"
 
-	patt.opts.SetProvider(NewTestProvider(providerURL, emailAddress))
+	testProvider := NewTestProvider(providerURL, emailAddress)
+	testProvider.ValidToken = opts.ValidToken
+	patt.opts.SetProvider(testProvider)
 	patt.proxy, err = NewOAuthProxy(patt.opts, func(email string) bool {
 		return email == emailAddress
 	})
@@ -470,6 +473,7 @@ func (patTest *PassAccessTokenTest) getEndpointWithCookie(cookie string, endpoin
 func TestForwardAccessTokenUpstream(t *testing.T) {
 	patTest, err := NewPassAccessTokenTest(PassAccessTokenTestOptions{
 		PassAccessToken: true,
+		ValidToken:      true,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -496,6 +500,7 @@ func TestForwardAccessTokenUpstream(t *testing.T) {
 func TestStaticProxyUpstream(t *testing.T) {
 	patTest, err := NewPassAccessTokenTest(PassAccessTokenTestOptions{
 		PassAccessToken: true,
+		ValidToken:      true,
 		ProxyUpstream: options.Upstream{
 			ID:     "static-proxy",
 			Path:   "/static-proxy",
@@ -526,6 +531,7 @@ func TestStaticProxyUpstream(t *testing.T) {
 func TestDoNotForwardAccessTokenUpstream(t *testing.T) {
 	patTest, err := NewPassAccessTokenTest(PassAccessTokenTestOptions{
 		PassAccessToken: false,
+		ValidToken:      true,
 	})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Description

Use the result of `provider.ValidateSession()` to display an error page and return a 403 if necessary.
Fix the existing test cases for OAuth2Proxy and add another test case asserting a failing validation results in a 403.

## Motivation and Context

See [original issue](https://github.com/oauth2-proxy/oauth2-proxy/issues/1396) for context and more details.

## How Has This Been Tested?

Test coverage is provided as well as changes for tests that relied on the previous behavior and while using the default value of `TestProvider.ValidToken`. These tests now set this value to `true` before running.

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
