### PR TITLE
Update LinkedIn provider validate URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [#1433](https://github.com/oauth2-proxy/oauth2-proxy/pull/1433) Let authentication fail when session validation fails (@stippi2)
 - [#1445](https://github.com/oauth2-proxy/oauth2-proxy/pull/1445) Fix docker container multi arch build issue by passing GOARCH details to make build (@jkandasa)
+- [#1444](https://github.com/oauth2-proxy/oauth2-proxy/pull/1444) Update LinkedIn provider validate URL (@jkandasa)
 
 # V7.2.0
 

--- a/providers/linkedin.go
+++ b/providers/linkedin.go
@@ -46,6 +46,13 @@ var (
 		Host:   "api.linkedin.com",
 		Path:   "/v2/emailAddress",
 	}
+
+	// Default Validate URL for LinkedIn.
+	linkedinDefaultValidateURL = &url.URL{
+		Scheme: "https",
+		Host:   "api.linkedin.com",
+		Path:   "/v2/me",
+	}
 )
 
 // NewLinkedInProvider initiates a new LinkedInProvider
@@ -55,7 +62,7 @@ func NewLinkedInProvider(p *ProviderData) *LinkedInProvider {
 		loginURL:    linkedinDefaultLoginURL,
 		redeemURL:   linkedinDefaultRedeemURL,
 		profileURL:  linkedinDefaultProfileURL,
-		validateURL: linkedinDefaultProfileURL,
+		validateURL: linkedinDefaultValidateURL,
 		scope:       linkedinDefaultScope,
 	})
 	return &LinkedInProvider{ProviderData: p}

--- a/providers/linkedin_test.go
+++ b/providers/linkedin_test.go
@@ -54,7 +54,7 @@ func TestNewLinkedInProvider(t *testing.T) {
 	g.Expect(providerData.LoginURL.String()).To(Equal("https://www.linkedin.com/oauth/v2/authorization"))
 	g.Expect(providerData.RedeemURL.String()).To(Equal("https://www.linkedin.com/uas/oauth2/accessToken"))
 	g.Expect(providerData.ProfileURL.String()).To(Equal("https://api.linkedin.com/v2/emailAddress"))
-	g.Expect(providerData.ValidateURL.String()).To(Equal("https://api.linkedin.com/v2/emailAddress"))
+	g.Expect(providerData.ValidateURL.String()).To(Equal("https://api.linkedin.com/v2/me"))
 	g.Expect(providerData.Scope).To(Equal("r_emailaddress r_liteprofile"))
 }
 


### PR DESCRIPTION
Signed-off-by: Jeeva Kandasamy <jkandasa@gmail.com>

Resolves: #1443

## How Has This Been Tested?
Yes, tested it in my local system

```bash
./oauth2-proxy \
    --provider="linkedin" \
    --cookie-secure=false \
    --upstream="http://192.168.0.21:8080" \
    --http-address="0.0.0.0:4180" \
    --redirect-url="https://private-domain/oauth2/callback" \
    --cookie-secret="12345678" \
    --client-id="abcd" \
    --client-secret="abcd" \
    --email-domain="gmail.com"
```

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
