### PR TITLE
Extract roles from token if the configured provider is keycloak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#1433](https://github.com/oauth2-proxy/oauth2-proxy/pull/1433) Let authentication fail when session validation fails (@stippi2)
 - [#1445](https://github.com/oauth2-proxy/oauth2-proxy/pull/1445) Fix docker container multi arch build issue by passing GOARCH details to make build (@jkandasa)
 - [#1444](https://github.com/oauth2-proxy/oauth2-proxy/pull/1444) Update LinkedIn provider validate URL (@jkandasa)
+- [#1446](https://github.com/oauth2-proxy/oauth2-proxy/pull/1446) Extract roles from keycloak generated tokens when using `--skip-jwt-bearer-tokens=true` (@jplana)
 
 # V7.2.0
 

--- a/providers/keycloak_oidc.go
+++ b/providers/keycloak_oidc.go
@@ -26,6 +26,18 @@ func NewKeycloakOIDCProvider(p *ProviderData) *KeycloakOIDCProvider {
 
 var _ Provider = (*KeycloakOIDCProvider)(nil)
 
+// CreateSessionFromToken converts Bearer IDTokens into sessions, extracting keycloak' roles
+func (p *KeycloakOIDCProvider) CreateSessionFromToken(ctx context.Context, token string) (*sessions.SessionState, error) {
+
+	ss, err := p.OIDCProvider.CreateSessionFromToken(ctx, token)
+	if err != nil {
+		return nil, err
+	}
+
+	return ss, p.extractRoles(ctx, ss)
+
+}
+
 // AddAllowedRoles sets Keycloak roles that are authorized.
 // Assumes `SetAllowedGroups` is already called on groups and appends to that
 // with `role:` prefixed roles.


### PR DESCRIPTION
## Description

Add a CreateSessionFromToken specific to the keycloak_oidc provider that extracts the general claims and data from the token, but also adds the roles from the `resource_access.app.roles.role` claim to `groups`. 

## Motivation and Context

When using the option `--skip-jwt-bearer-tokens=true` in combination with a keycloak provider configuration using roles:

```
server:
  BindAddress: 0.0.0.0:4080
  SecureBindAddress: "-"
providers:
  - id: keycloak
    provider: keycloak-oidc
    clientID: k8s-oauth2-ingress-test
    clientSecret: XXX-XXX-XXX-XXX-XXX
    profileURL: https://keycloak/auth/realms/realm/protocol/openid-connect/userinfo
    scope: email openid profile
    oidcConfig:
      issuerURL: https://keycloak/auth/realm/master
      emailClaim: email
      groupsClaim: groups
    keycloakConfig:
       roles:
         - k8s-oauth2-ingress-test:test-role
```

Then a (valid) JWT token like:

```
{
  "exp": 1636439529,
  "iat": 1636396329,
  "auth_time": 1636390654,
  "jti": "XXX-XXX-XXX-XXX-XXX",
  "iss": "https://keycloak/auth/realm/master",
  "aud": "k8s-oauth2-ingress-test",
  "sub": "XXX-XXX-XXX-XXX-XXX",
  "typ": "Bearer",
  "azp": "k8s-oauth2-ingress-test",
  "nonce": "XXX-XXX-XXX-XXX-XXX",
  "session_state": "XXX-XXX-XXX-XXX-XXX",
  "acr": "0",
  "resource_access": {
    "k8s-oauth2-ingress-test": {
      "roles": [
        "test-role"
      ]
    }
  },
  "scope": "openid profile email",
  "email_verified": true,
  "name": "User",
  "preferred_username": "user",
  "locale": "en",
  "given_name": "User Given",
  "family_name": "User Family",
  "email": "user@email.com"
}

```
 

passed in an Authorization header (like in `http http://httpbin.oauth2-proxy.localhost:8080/ "Authorization: Bearer [TOKEN]`)

should work and just pass the request to the backend, as the role is included within the token. This is however failing Authorization as the "enrich" functions of the provider are not called, and the keycloak role extraction is just invoked there. With this change, if the configured provider is keycloak, when extracting a new session from a bearer token, roles will be extracted and requests will be forwarded as expected.

## How Has This Been Tested?

I used a keycloak instance that adds roles to specific users. The following scenarios have been tested:

1. Service with the following configuration (` --skip-jwt-bearer-tokens=true`)

```
server:
  BindAddress: 0.0.0.0:4080
  SecureBindAddress: "-"
providers:
  - id: keycloak
    provider: keycloak-oidc
    clientID: k8s-oauth2-ingress-test
    clientSecret: XXX-XXX-XXX-XXX-XXX
    profileURL: https://keycloak/auth/realms/realm/protocol/openid-connect/userinfo
    scope: email openid profile
    oidcConfig:
      issuerURL: https://keycloak/auth/realm/master
      emailClaim: email
      groupsClaim: groups
```

Using an auth_token *with* the resource_access.k8s-oauth2-ingress-test.roles.test-role
Using an auth_token *without* the resource_access.k8s-oauth2-ingress-test.roles.test-role



2. Service with the following configuration (` --skip-jwt-bearer-tokens=true`)

```
server:
  BindAddress: 0.0.0.0:4080
  SecureBindAddress: "-"
providers:
  - id: keycloak
    provider: keycloak-oidc
    clientID: k8s-oauth2-ingress-test
    clientSecret: XXX-XXX-XXX-XXX-XXX
    profileURL: https://keycloak/auth/realms/realm/protocol/openid-connect/userinfo
    scope: email openid profile
    oidcConfig:
      issuerURL: https://keycloak/auth/realm/master
      emailClaim: email
      groupsClaim: groups
    keycloakConfig:
       roles:
         - k8s-oauth2-ingress-test:test-role
```

Using an auth_token *with* the resource_access.k8s-oauth2-ingress-test.roles.test-role
Using an auth_token *without* the resource_access.k8s-oauth2-ingress-test.roles.test-role

3. Service with the following configuration (` --skip-jwt-bearer-tokens=false`)

```
server:
  BindAddress: 0.0.0.0:4080
  SecureBindAddress: "-"
providers:
  - id: keycloak
    provider: keycloak-oidc
    clientID: k8s-oauth2-ingress-test
    clientSecret: XXX-XXX-XXX-XXX-XXX
    profileURL: https://keycloak/auth/realms/realm/protocol/openid-connect/userinfo
    scope: email openid profile
    oidcConfig:
      issuerURL: https://keycloak/auth/realm/master
      emailClaim: email
      groupsClaim: groups
```

Using an auth_token *with* the resource_access.k8s-oauth2-ingress-test.roles.test-role
Using an auth_token *without* the resource_access.k8s-oauth2-ingress-test.roles.test-role



4. Service with the following configuration (` --skip-jwt-bearer-tokens=false`)

```
server:
  BindAddress: 0.0.0.0:4080
  SecureBindAddress: "-"
providers:
  - id: keycloak
    provider: keycloak-oidc
    clientID: k8s-oauth2-ingress-test
    clientSecret: XXX-XXX-XXX-XXX-XXX
    profileURL: https://keycloak/auth/realms/realm/protocol/openid-connect/userinfo
    scope: email openid profile
    oidcConfig:
      issuerURL: https://keycloak/auth/realm/master
      emailClaim: email
      groupsClaim: groups
    keycloakConfig:
       roles:
         - k8s-oauth2-ingress-test:test-role
```

Using an auth_token *with* the resource_access.k8s-oauth2-ingress-test.roles.test-role
Using an auth_token *without* the resource_access.k8s-oauth2-ingress-test.roles.test-role


## Checklist:


- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
