### PR TITLE
Switch nextcloud provider to EnrichSession, add User and Groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [#1474](https://github.com/oauth2-proxy/oauth2-proxy/pull/1474) Support configuration of minimal acceptable TLS version (@polarctos)
 - [#1545](https://github.com/oauth2-proxy/oauth2-proxy/pull/1545) Fix issue with query string allowed group panic on skip methods (@andytson)
 - [#1286](https://github.com/oauth2-proxy/oauth2-proxy/pull/1286) Add the `allowed_email_domains` and the `allowed_groups` on the `auth_request` + support standard wildcard char for validation with sub-domain and email-domain. (@w3st3ry @armandpicard)
+- [#1454](https://github.com/oauth2-proxy/oauth2-proxy/pull/1454) Provide User and Groups in Nextcloud Provider (@max-te)
 
 # V7.2.1
 

--- a/providers/nextcloud.go
+++ b/providers/nextcloud.go
@@ -42,24 +42,30 @@ func (p *NextcloudProvider) EnrichSession(ctx context.Context, s *sessions.Sessi
 		return fmt.Errorf("error making request: %v", err)
 	}
 
-	email, err := json.GetPath("ocs", "data", "email").String()
-	if err != nil {
-		return fmt.Errorf("error retrieving email address: %v", err)
-	}
-	if email != "" {
-		s.Email = email
-	}
-
-	username, err := json.GetPath("ocs", "data", "id").String()
-	if err == nil && username != "" {
-		s.User = username
+	if s.Email == "" {
+		email, err := json.GetPath("ocs", "data", "email").String()
+		if err != nil {
+			return fmt.Errorf("error retrieving email address: %v", err)
+		}
+		if email != "" {
+			s.Email = email
+		}
 	}
 
-	groups, err := json.GetPath("ocs", "data", "groups").StringArray()
-	if err == nil {
-		for _, group := range groups {
-			if group != "" {
-				s.Groups = append(s.Groups, group)
+	if s.User == "" {
+		username, err := json.GetPath("ocs", "data", "id").String()
+		if err == nil && username != "" {
+			s.User = username
+		}
+	}
+
+	if len(s.Groups) == 0 {
+		groups, err := json.GetPath("ocs", "data", "groups").StringArray()
+		if err == nil {
+			for _, group := range groups {
+				if group != "" {
+					s.Groups = append(s.Groups, group)
+				}
 			}
 		}
 	}

--- a/providers/nextcloud.go
+++ b/providers/nextcloud.go
@@ -1,6 +1,13 @@
 package providers
 
-import "github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
+import (
+	"context"
+	"fmt"
+
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/sessions"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/requests"
+)
 
 // NextcloudProvider represents an Nextcloud based Identity Provider
 type NextcloudProvider struct {
@@ -21,4 +28,41 @@ func NewNextcloudProvider(p *ProviderData) *NextcloudProvider {
 		p.EmailClaim = "ocs.data.email"
 	}
 	return &NextcloudProvider{ProviderData: p}
+}
+
+// EnrichSession is called after Redeem to allow providers to enrich session fields
+// such as User, Email, Groups with provider specific API calls.
+func (p *NextcloudProvider) EnrichSession(ctx context.Context, s *sessions.SessionState) error {
+	json, err := requests.New(p.ValidateURL.String()).
+		WithContext(ctx).
+		WithHeaders(makeOIDCHeader(s.AccessToken)).
+		Do().
+		UnmarshalJSON()
+	if err != nil {
+		return fmt.Errorf("error making request: %v", err)
+	}
+
+	email, err := json.GetPath("ocs", "data", "email").String()
+	if err != nil {
+		return fmt.Errorf("error retrieving email address: %v", err)
+	}
+	if email != "" {
+		s.Email = email
+	}
+
+	username, err := json.GetPath("ocs", "data", "id").String()
+	if err == nil && username != "" {
+		s.User = username
+	}
+
+	groups, err := json.GetPath("ocs", "data", "groups").StringArray()
+	if err == nil {
+		for _, group := range groups {
+			if group != "" {
+				s.Groups = append(s.Groups, group)
+			}
+		}
+	}
+
+	return nil
 }

--- a/providers/nextcloud_test.go
+++ b/providers/nextcloud_test.go
@@ -107,6 +107,7 @@ func TestNextcloudProviderEnrichSessionFailedRequest(t *testing.T) {
 	assert.NotEqual(t, nil, err)
 	assert.Equal(t, "", session.Email)
 	assert.Equal(t, "", session.User)
+	assert.Equal(t, []string(nil), session.Groups)
 }
 
 func TestNextcloudProviderEnrichSessionEmailNotPresentInPayload(t *testing.T) {
@@ -123,4 +124,5 @@ func TestNextcloudProviderEnrichSessionEmailNotPresentInPayload(t *testing.T) {
 	assert.NotEqual(t, nil, err)
 	assert.Equal(t, "", session.Email)
 	assert.Equal(t, "", session.User)
+	assert.Equal(t, []string(nil), session.Groups)
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Replaces `GetEmailAddress` of the nextcloud with an `EnrichSession` function which also sets the session `User` and `Groups`.
<!--- Describe your changes in detail -->

## Motivation and Context
I wanted to use the username provided by nextcloud for authentication. This changes enables that, as well as exposing groups.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
I have been using the adjusted nextcloud provider in conjunction with traefik ForwardAuth to authenticate to an instance of miniflux for over a week now. In the same setup I have also proxied an instance of [whoami](https://github.com/traefik/whoami) to verify the `X-Auth-Request-{Email,Groups,User}` headers are as expected.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
