### PR TITLE
Atlassian Cloud provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Changes since v7.2.0
 
+- [#1465](https://github.com/oauth2-proxy/oauth2-proxy/pull/1465) Add Atlassian Cloud provider (@Alex-Sizov)
 - [#1447](https://github.com/oauth2-proxy/oauth2-proxy/pull/1447) Fix docker build/push issues found during last release (@JoelSpeed)
 - [#1433](https://github.com/oauth2-proxy/oauth2-proxy/pull/1433) Let authentication fail when session validation fails (@stippi2)
 - [#1445](https://github.com/oauth2-proxy/oauth2-proxy/pull/1445) Fix docker container multi arch build issue by passing GOARCH details to make build (@jkandasa)

--- a/docs/docs/configuration/auth.md
+++ b/docs/docs/configuration/auth.md
@@ -22,6 +22,7 @@ Valid providers are :
 - [DigitalOcean](#digitalocean-auth-provider)
 - [Bitbucket](#bitbucket-auth-provider)
 - [Gitea](#gitea-auth-provider)
+- [Atlassian Cloud](#atlassian-cloud-auth-provider)
 
 The provider can be selected using the `provider` configuration value.
 
@@ -538,6 +539,25 @@ The default configuration allows everyone with Bitbucket account to authenticate
     --redeem-url="https://< your gitea host >/login/oauth/access_token"
     --validate-url="https://< your gitea host >/api/v1"
 ```
+
+
+### Atlassian Cloud Auth Provider
+
+1. Create a new OAuth2.0 integration app in the Atlassian Developer console as described [here](https://developer.atlassian.com/cloud/jira/platform/oauth-2-3lo-apps/#enabling-oauth-2-0--3lo-)
+2. Under Permissions add access to the User REST API and User identity API
+3. Under Authorization configure your callback url to match the proxy url, like `https://<proxy_host>/oauth2/callback`
+4. Get Authentication details under Setting
+5. Run proxy with the following options:
+```
+  --provider atlassian 
+  --provider-display-name "Atlassian" 
+  --client-id <client ID from step 4> 
+  --client-secret <secret from step 4> 
+  --redirect-url http://<proxy_host>/oauth2/callback 
+  --cookie-secret <cookie secret>
+```
+
+Note: By default the app is limited to the user who created it. To start sharing the app with your team you must first Enable sharing under the Distribution settings in the Developer console.
 
 
 ## Email Authentication

--- a/providers/atlassian-cloud.go
+++ b/providers/atlassian-cloud.go
@@ -1,0 +1,94 @@
+package providers
+
+import (
+	"context"
+	"net/url"
+	"errors"
+
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/sessions"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/requests"
+)
+
+// AtlassianProvider represents an Atlassian based Identity Provider
+type AtlassianProvider struct {
+	*ProviderData
+}
+
+var _ Provider = (*AtlassianProvider)(nil)
+
+const (
+	atlassianProviderName = "Atlassian"
+	atlassianDefaultScope = "read:me"
+	atlassianPrompt = "consent"
+	atlassianAudience = "api.atlassian.com"
+)
+
+var (
+	// Default Login URL for Atlassian.
+	// Pre-parsed URL of https://atlassian.org/site/oauth2/authorize.
+	atlassianDefaultLoginURL = &url.URL{
+		Scheme: "https",
+		Host:   "auth.atlassian.com",
+		Path:   "/authorize",
+	}
+
+	// Default Redeem URL for Atlassian.
+	// Pre-parsed URL of https://atlassian.org/site/oauth2/access_token.
+	atlassianDefaultRedeemURL = &url.URL{
+		Scheme: "https",
+		Host:   "auth.atlassian.com",
+		Path:   "/oauth/token",
+	}
+
+	// Default Validation URL for Atlassian.
+	// This simply returns the email of the authenticated user.
+	// Atlassian does not have a Profile URL to use.
+	// Pre-parsed URL of https://api.atlassian.org/2.0/user/emails.
+	atlassianDefaultValidateURL = &url.URL{
+		Scheme: "https",
+		Host:   "api.atlassian.com",
+		Path:   "/me",
+	}
+)
+
+// NewAtlassianProvider initiates a new AtlassianProvider
+func NewAtlassianProvider(p *ProviderData) *AtlassianProvider {
+	p.setProviderDefaults(providerDefaults{
+		name:        atlassianProviderName,
+		loginURL:    atlassianDefaultLoginURL,
+		redeemURL:   atlassianDefaultRedeemURL,
+		profileURL:  nil,
+		validateURL: atlassianDefaultValidateURL,
+		scope:       atlassianDefaultScope,
+	})
+	p.Prompt = atlassianPrompt
+	return &AtlassianProvider{ProviderData: p}
+}
+func (p *AtlassianProvider) GetLoginURL(redirectURI, state, _ string) string {
+	extraParams := url.Values{}
+	extraParams.Add("audience", atlassianAudience)
+	loginURL := makeLoginURL(p.ProviderData, redirectURI, state, extraParams)
+	return loginURL.String()
+}
+func (p *AtlassianProvider) ValidateSession(ctx context.Context, s *sessions.SessionState) bool {
+	return validateToken(ctx, p, s.AccessToken, makeOIDCHeader(s.AccessToken))
+}
+func (p *AtlassianProvider) GetEmailAddress(ctx context.Context, s *sessions.SessionState) (string, error) {
+	type me_email struct {
+		Email string `json:"email"`
+	}
+	var email me_email
+	err := requests.New(atlassianDefaultValidateURL.String()).
+		WithContext(ctx).
+		WithHeaders(makeOIDCHeader(s.AccessToken)).
+		Do().
+		UnmarshalInto(&email)
+	
+	if err != nil {
+		return "", err
+	}
+	if email.Email == "" {
+		return "", errors.New("No email in respose")
+	}
+	return email.Email, nil
+}

--- a/providers/atlassian-cloud.go
+++ b/providers/atlassian-cloud.go
@@ -2,8 +2,8 @@ package providers
 
 import (
 	"context"
-	"net/url"
 	"errors"
+	"net/url"
 
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/sessions"
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/requests"
@@ -19,8 +19,8 @@ var _ Provider = (*AtlassianProvider)(nil)
 const (
 	atlassianProviderName = "Atlassian"
 	atlassianDefaultScope = "read:me"
-	atlassianPrompt = "consent"
-	atlassianAudience = "api.atlassian.com"
+	atlassianPrompt       = "consent"
+	atlassianAudience     = "api.atlassian.com"
 )
 
 var (
@@ -74,21 +74,21 @@ func (p *AtlassianProvider) ValidateSession(ctx context.Context, s *sessions.Ses
 	return validateToken(ctx, p, s.AccessToken, makeOIDCHeader(s.AccessToken))
 }
 func (p *AtlassianProvider) GetEmailAddress(ctx context.Context, s *sessions.SessionState) (string, error) {
-	type me_email struct {
+	type meEmail struct {
 		Email string `json:"email"`
 	}
-	var email me_email
+	var email meEmail
 	err := requests.New(atlassianDefaultValidateURL.String()).
 		WithContext(ctx).
 		WithHeaders(makeOIDCHeader(s.AccessToken)).
 		Do().
 		UnmarshalInto(&email)
-	
+
 	if err != nil {
 		return "", err
 	}
 	if email.Email == "" {
-		return "", errors.New("No email in respose")
+		return "", errors.New("no email in respose")
 	}
 	return email.Email, nil
 }

--- a/providers/atlassian-cloud_test.go
+++ b/providers/atlassian-cloud_test.go
@@ -1,0 +1,20 @@
+package providers
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestNewAtlassianProvider(t *testing.T) {
+	g := NewWithT(t)
+
+	// Test that defaults are set when calling for a new provider with nothing set
+	providerData := NewAtlassianProvider(&ProviderData{}).Data()
+	g.Expect(providerData.ProviderName).To(Equal("Atlassian"))
+	g.Expect(providerData.LoginURL.String()).To(Equal("https://auth.atlassian.com/authorize"))
+	g.Expect(providerData.RedeemURL.String()).To(Equal("https://auth.atlassian.com/oauth/token"))
+	g.Expect(providerData.ProfileURL.String()).To(Equal(""))
+	g.Expect(providerData.ValidateURL.String()).To(Equal("https://api.atlassian.com/me"))
+	g.Expect(providerData.Scope).To(Equal("read:me"))
+}

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -51,6 +51,8 @@ func New(provider string, p *ProviderData) Provider {
 		return NewDigitalOceanProvider(p)
 	case "google":
 		return NewGoogleProvider(p)
+	case "atlassian":
+		return NewAtlassianProvider(p)
 	default:
 		return nil
 	}


### PR DESCRIPTION
## Description

This adds support for Atlassian cloud's 3LO apps. More details [here](https://developer.atlassian.com/cloud/jira/platform/oauth-2-3lo-apps/) 

## Motivation and Context

We're using Atlassian Cloud products, like Jira or Confluence in our company. So every employee (as well as some customers) has an access to Atlassian Cloud.
Also we use oauth2-proxy to secure some internal services. Sometimes we want non-technical persons to be able to connect to them.

## How Has This Been Tested?

I've created Atlassian App in the Developer Console, using the [instruction](https://developer.atlassian.com/cloud/jira/platform/oauth-2-3lo-apps/#enabling-oauth-2-0--3lo-).
After that I've conducted the following tests:
- Made local tests e.g. ran proxy on localhost and checked auth flow
- Built docker image, pushed to our registry, then using the [chart](https://github.com/oauth2-proxy/manifests/tree/main/helm/oauth2-proxy) installed it on kubernetes (EKS). Then redirected some of our applications to the proxy using auth-signin/auth-url options of nginx.

Right now we use this version over 2 weeks to authorize our employees. I have no issues reported. 

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
