### PR TITLE
Fetch all Google groups the user is a member of in their domain

### DIFF
--- a/pkg/validation/providers.go
+++ b/pkg/validation/providers.go
@@ -69,9 +69,6 @@ func validateGoogleConfig(provider options.Provider) []string {
 	if len(provider.GoogleConfig.Groups) > 0 ||
 		provider.GoogleConfig.AdminEmail != "" ||
 		provider.GoogleConfig.ServiceAccountJSON != "" {
-		if len(provider.GoogleConfig.Groups) < 1 {
-			msgs = append(msgs, "missing setting: google-group")
-		}
 		if provider.GoogleConfig.AdminEmail == "" {
 			msgs = append(msgs, "missing setting: google-admin-email")
 		}


### PR DESCRIPTION
## Description

Rather than just matching the groups referenced by the --google-group flag.

I'd love to get feedback on this, and find out if it even makes sense, before adding tests. Two additional things I've considered doing, if needed, are:
* Putting this behind a flag, maybe --google-fetch-all-groups, so no one is surprised by the additional groups showing (it also might be good to avoid nuking the check for --google-group being set if the service account is passed)
* Adding a prefix or regex filter for groups returned. It would reduce the amount of data returned, since in my case I only want groups starting with a particular namespace

## Motivation and Context

I have software like Airflow and JupyterHub behind an oauth2-proxy instance. Ideally, I would configure authz roles in those services based upon the Google Groups the user is in (as passed by oauth2-proxy.) However, because this proxy doesn't pull the user's groups, I can't use the passed headers to do so. What I instead have to do is either
* give up on oauth2-proxy entirely and do OAuth2 separately in both applications, hoping their OAuth2 plugins handle group lookups well
* or add a plugin inside both applications to take the user from the header and do this fetch manually

It would be nice to have oauth2-proxy do the fetch in one central place, and then let downstream applications perform their checks as necessary based on the provided group list.

## How Has This Been Tested?

I've run this locally on my Macbook and tested logging in with my user to inspect the response headers (as well as /oauth2/userinfo.) I varied MaxResults to ensure that fetching multiple pages of groups works.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
