### PR TITLE
Remove the information about `Microsoft Azure AD` in the provider documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [#1445](https://github.com/oauth2-proxy/oauth2-proxy/pull/1445) Fix docker container multi arch build issue by passing GOARCH details to make build (@jkandasa)
 - [#1444](https://github.com/oauth2-proxy/oauth2-proxy/pull/1444) Update LinkedIn provider validate URL (@jkandasa)
 - [#1471](https://github.com/oauth2-proxy/oauth2-proxy/pull/1471) Update alpine to 3.15 (@AlexanderBabel)
+- [#1477](https://github.com/oauth2-proxy/oauth2-proxy/pull/1477) Remove provider documentation for `Microsoft Azure AD` (@omBratteng)
 
 # V7.2.0
 

--- a/docs/versioned_docs/version-7.2.x/configuration/auth.md
+++ b/docs/versioned_docs/version-7.2.x/configuration/auth.md
@@ -86,7 +86,7 @@ Note: The user is checked against the group members list on initial authenticati
    --oidc-issuer-url=https://sts.windows.net/{tenant-id}/
 ```
 
-Note: When using the Azure Auth provider with nginx and the cookie session store you may find the cookie is too large and doesn't get passed through correctly. Increasing the proxy_buffer_size in nginx or implementing the [redis session storage](sessions.md#redis-storage) should resolve this.
+Note: When using the Azure Auth provider with nginx and the cookie session store you may find the cookie is too large and doesn't get passed through correctly. Increasing the `proxy_buffer_size` in nginx or implementing the [redis session storage](sessions.md#redis-storage) should resolve this.
 
 ### ADFS Auth Provider
 

--- a/docs/versioned_docs/version-7.2.x/configuration/auth.md
+++ b/docs/versioned_docs/version-7.2.x/configuration/auth.md
@@ -15,7 +15,6 @@ Valid providers are :
 - [Keycloak](#keycloak-auth-provider)
 - [GitLab](#gitlab-auth-provider)
 - [LinkedIn](#linkedin-auth-provider)
-- [Microsoft Azure AD](#microsoft-azure-ad-provider)
 - [OpenID Connect](#openid-connect-provider)
 - [login.gov](#logingov-provider)
 - [Nextcloud](#nextcloud-provider)
@@ -233,12 +232,6 @@ For LinkedIn, the registration steps are:
     - In "OAuth 2.0 Redirect URLs", enter `https://internal.yourcompany.com/oauth2/callback`
 3.  Fill in the remaining required fields and Save.
 4.  Take note of the **Consumer Key / API Key** and **Consumer Secret / Secret Key**
-
-### Microsoft Azure AD Provider
-
-For adding an application to the Microsoft Azure AD follow [these steps to add an application](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app).
-
-Take note of your `TenantId` if applicable for your situation. The `TenantId` can be used to override the default `common` authorization server with a tenant specific server.
 
 ### OpenID Connect Provider
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

There is only one provider for Azure, and the section about `Microsoft Azure AD` does not specify anything about how to configure `oauth2-proxy`.

The documentation under `Azure Auth` contains more or less the same steps that the link found under `Microsoft Azure AD`.

## Motivation and Context

This closes https://github.com/oauth2-proxy/oauth2-proxy/issues/1073. And makes it less confusing to configure `oauth2-proxy` for Azure AD

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Not much tests, just changes to documentation

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My change requires a change to the documentation or CHANGELOG.
- [X] I have updated the documentation/CHANGELOG accordingly.
- [X] I have created a feature (non-master) branch for my PR.
