### PR TITLE
1482 Replace deprecated bitbucket urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 ## Changes since v7.2.1
 
 - [#1477](https://github.com/oauth2-proxy/oauth2-proxy/pull/1477) Remove provider documentation for `Microsoft Azure AD` (@omBratteng)
+- [#1490](https://github.com/oauth2-proxy/oauth2-proxy/pull/1490) Replace deprecated bitbucket urls `Bitbucket` (@raresociopath)
+
 
 # V7.2.1
 

--- a/docs/docs/configuration/auth.md
+++ b/docs/docs/configuration/auth.md
@@ -506,7 +506,7 @@ To use the provider, pass the following options:
     * In "Callback URL" use `https://<oauth2-proxy>/oauth2/callback`, substituting `<oauth2-proxy>` with the actual hostname that oauth2-proxy is running on.
     * In Permissions section select:
         * Account -> Email
-        * Team membership -> Read
+        * Workspace membership -> Read
         * Repositories -> Read
 2. Note the Client ID and Client Secret.
 
@@ -518,7 +518,7 @@ To use the provider, pass the following options:
    --client-secret=<Client Secret>
 ```
 
-The default configuration allows everyone with Bitbucket account to authenticate. To restrict the access to the team members use additional configuration option: `--bitbucket-team=<Team name>`. To restrict the access to only these users who has access to one selected repository use `--bitbucket-repository=<Repository name>`.
+The default configuration allows everyone with Bitbucket account to authenticate. To restrict the access to the workspace members use additional configuration option: `--bitbucket-workspace=<Workspace name>`. To restrict the access to only these users who has access to one selected repository use `--bitbucket-repository=<Repository name>`.
 
 
 ### Gitea Auth Provider

--- a/pkg/apis/options/legacy_options.go
+++ b/pkg/apis/options/legacy_options.go
@@ -472,7 +472,7 @@ type LegacyProvider struct {
 
 	KeycloakGroups           []string `flag:"keycloak-group" cfg:"keycloak_groups"`
 	AzureTenant              string   `flag:"azure-tenant" cfg:"azure_tenant"`
-	BitbucketTeam            string   `flag:"bitbucket-team" cfg:"bitbucket_team"`
+	BitbucketWorkspace       string   `flag:"bitbucket-workspace" cfg:"bitbucket_workspace"`
 	BitbucketRepository      string   `flag:"bitbucket-repository" cfg:"bitbucket_repository"`
 	GitHubOrg                string   `flag:"github-org" cfg:"github_org"`
 	GitHubTeam               string   `flag:"github-team" cfg:"github_team"`
@@ -521,7 +521,7 @@ func legacyProviderFlagSet() *pflag.FlagSet {
 
 	flagSet.StringSlice("keycloak-group", []string{}, "restrict logins to members of these groups (may be given multiple times)")
 	flagSet.String("azure-tenant", "common", "go to a tenant-specific or common (tenant-independent) endpoint.")
-	flagSet.String("bitbucket-team", "", "restrict logins to members of this team")
+	flagSet.String("bitbucket-workspace", "", "restrict logins to members of this workspace")
 	flagSet.String("bitbucket-repository", "", "restrict logins to user with access to this repository")
 	flagSet.String("github-org", "", "restrict logins to members of this organisation")
 	flagSet.String("github-team", "", "restrict logins to members of this team")
@@ -680,7 +680,7 @@ func (l *LegacyProvider) convert() (Providers, error) {
 		}
 	case "bitbucket":
 		provider.BitbucketConfig = BitbucketOptions{
-			Team:       l.BitbucketTeam,
+			Workspace:  l.BitbucketWorkspace,
 			Repository: l.BitbucketRepository,
 		}
 	case "google":

--- a/pkg/apis/options/providers.go
+++ b/pkg/apis/options/providers.go
@@ -96,8 +96,8 @@ type ADFSOptions struct {
 }
 
 type BitbucketOptions struct {
-	// Team sets restrict logins to members of this team
-	Team string `json:"team,omitempty"`
+	// Workspace sets restrict logins to members of this workspace
+	Workspace string `json:"workspace,omitempty"`
 	// Repository sets restrict logins to user with access to this repository
 	Repository string `json:"repository,omitempty"`
 }

--- a/pkg/validation/options.go
+++ b/pkg/validation/options.go
@@ -268,7 +268,7 @@ func parseProviderInfo(o *options.Options, msgs []string) []string {
 			}
 		}
 	case *providers.BitbucketProvider:
-		p.SetTeam(o.Providers[0].BitbucketConfig.Team)
+		p.SetWorkspace(o.Providers[0].BitbucketConfig.Workspace)
 		p.SetRepository(o.Providers[0].BitbucketConfig.Repository)
 	case *providers.OIDCProvider:
 		p.SkipNonce = o.Providers[0].OIDCConfig.InsecureSkipNonce

--- a/providers/bitbucket_test.go
+++ b/providers/bitbucket_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func testBitbucketProvider(hostname, team string, repository string) *BitbucketProvider {
+func testBitbucketProvider(hostname, workspace string, repository string) *BitbucketProvider {
 	p := NewBitbucketProvider(
 		&ProviderData{
 			ProviderName: "",
@@ -23,8 +23,8 @@ func testBitbucketProvider(hostname, team string, repository string) *BitbucketP
 			ValidateURL:  &url.URL{},
 			Scope:        ""})
 
-	if team != "" {
-		p.SetTeam(team)
+	if workspace != "" {
+		p.SetWorkspace(workspace)
 	}
 
 	if repository != "" {
@@ -43,7 +43,7 @@ func testBitbucketProvider(hostname, team string, repository string) *BitbucketP
 func testBitbucketBackend(payload string) *httptest.Server {
 	paths := map[string]bool{
 		"/2.0/user/emails": true,
-		"/2.0/teams":       true,
+		"/2.0/workspaces":  true,
 	}
 
 	return httptest.NewServer(http.HandlerFunc(
@@ -74,10 +74,10 @@ func TestNewBitbucketProvider(t *testing.T) {
 	g.Expect(providerData.Scope).To(Equal("email"))
 }
 
-func TestBitbucketProviderScopeAdjustForTeam(t *testing.T) {
-	p := testBitbucketProvider("", "test-team", "")
+func TestBitbucketProviderScopeAdjustForWorkspace(t *testing.T) {
+	p := testBitbucketProvider("", "test-workspace", "")
 	assert.NotEqual(t, nil, p)
-	assert.Equal(t, "email team", p.Data().Scope)
+	assert.Equal(t, "email workspace", p.Data().Scope)
 }
 
 func TestBitbucketProviderScopeAdjustForRepository(t *testing.T) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

After the deprecation of /teams and some /users bitbucket endpoints oauth2-proxy stopped working completely.
This PR replaces the concept of teams with workspaces. 

## Motivation and Context

The issue this PR fixes: #1482 

## How Has This Been Tested?

Was tested on a live environment.

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
