### PR TITLE
Fixing a typo, pointing to correct compose file

### DIFF
--- a/contrib/local-environment/Makefile
+++ b/contrib/local-environment/Makefile
@@ -12,7 +12,7 @@ alpha-config-up:
 
 .PHONY: alpha-config-%
 alpha-config-%:
-	docker-compose -f docker-compose.yaml -f docker-compose-nginx.yaml $*
+	docker-compose -f docker-compose.yaml -f docker-compose-alpha-config.yaml $*
 
 .PHONY: nginx-up
 nginx-up:


### PR DESCRIPTION
Fixing a typo for the docker-compose-alpha-config.yaml

The make file section for `make alpha-config-XXX` was pointing to the docker-compose-nginx.yml file instead of the correct `docker-compose-alpha-config.yaml` file.

## Description

Just fixed the typo.

## Motivation and Context

Will ensure that `make alhpa-config-down` works.

## How Has This Been Tested?

Just `make`

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
