### PR TITLE
Unbreak oauth2-proxy for keycloak provider after 2c668a

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ If you are using an architecture specific tag (ex: v7.2.1-arm64) you should move
 - [#1638](https://github.com/oauth2-proxy/oauth2-proxy/pull/1638) Implement configurable upstream timeout (@jacksgt)
 - [#1650](https://github.com/oauth2-proxy/oauth2-proxy/pull/1650) Fixed 500 when checking if user has repo (@adamsong)
 - [#1635](https://github.com/oauth2-proxy/oauth2-proxy/pull/1635) Added description and unit tests for ipv6 address (@t-katsumura)
+- [#1502](https://github.com/oauth2-proxy/oauth2-proxy/pull/1502) Unbreak oauth2-proxy for keycloak provider after 2c668a (@ckwalsh)
 
 # V7.2.1
 

--- a/providers/keycloak.go
+++ b/providers/keycloak.go
@@ -100,3 +100,8 @@ func (p *KeycloakProvider) EnrichSession(ctx context.Context, s *sessions.Sessio
 
 	return nil
 }
+
+// ValidateSession validates the AccessToken
+func (p *KeycloakProvider) ValidateSession(ctx context.Context, s *sessions.SessionState) bool {
+	return validateToken(ctx, p, s.AccessToken, makeOIDCHeader(s.AccessToken))
+}


### PR DESCRIPTION
With 2c668a, oauth2-proxy fails a request if the token validation fails.
Token validation always fails with the keycloak provider, due to the
valudation request passing the token via the URL, and keycloak not
parsing the url for tokens.

This is fixed by forcing the validation request to pass the token via a
header.

This code taken from the DigitalOcean provider, which presumably forcing
the token to be passed via header for the same reason.

Test plan: I was unable to build a docker image to test the fix, but I
believe it is relatively simple, and it passes the "looks good to me"
test plan.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
