### PR TITLE
Add ValidateSession function to LoginGovProvder to include Auth Header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## Changes since v7.2.1
 
 - [#1477](https://github.com/oauth2-proxy/oauth2-proxy/pull/1477) Remove provider documentation for `Microsoft Azure AD` (@omBratteng)
+- [#1509](https://github.com/oauth2-proxy/oauth2-proxy/pull/1509) Update LoginGovProvider ValidateSession to pass access_token in Header (@pksheldon4)
 
 # V7.2.1
 

--- a/providers/logingov.go
+++ b/providers/logingov.go
@@ -84,7 +84,7 @@ func NewLoginGovProvider(p *ProviderData) *LoginGovProvider {
 		loginURL:    loginGovDefaultLoginURL,
 		redeemURL:   loginGovDefaultRedeemURL,
 		profileURL:  loginGovDefaultProfileURL,
-		validateURL: nil,
+		validateURL: loginGovDefaultProfileURL,
 		scope:       loginGovDefaultScope,
 	})
 	return &LoginGovProvider{
@@ -236,4 +236,9 @@ func (p *LoginGovProvider) GetLoginURL(redirectURI, state, _ string) string {
 	extraParams.Add("nonce", p.Nonce)
 	a := makeLoginURL(p.ProviderData, redirectURI, state, extraParams)
 	return a.String()
+}
+
+// ValidateSession validates the AccessToken
+func (p *LoginGovProvider) ValidateSession(ctx context.Context, s *sessions.SessionState) bool {
+	return validateToken(ctx, p, s.AccessToken, makeOIDCHeader(s.AccessToken))
 }

--- a/providers/logingov_test.go
+++ b/providers/logingov_test.go
@@ -75,7 +75,7 @@ func TestNewLoginGovProvider(t *testing.T) {
 	g.Expect(providerData.LoginURL.String()).To(Equal("https://secure.login.gov/openid_connect/authorize"))
 	g.Expect(providerData.RedeemURL.String()).To(Equal("https://secure.login.gov/api/openid_connect/token"))
 	g.Expect(providerData.ProfileURL.String()).To(Equal("https://secure.login.gov/api/openid_connect/userinfo"))
-	g.Expect(providerData.ValidateURL.String()).To(Equal(""))
+	g.Expect(providerData.ValidateURL.String()).To(Equal("https://secure.login.gov/api/openid_connect/userinfo"))
 	g.Expect(providerData.Scope).To(Equal("email openid"))
 }
 


### PR DESCRIPTION
## Description

Add ValidateSession function to LoginGovProvider to include Authorization header using access_token

## Motivation and Context
This recent bug fix is causing Login.gov oauth to fail "[#1433](https://github.com/oauth2-proxy/oauth2-proxy/pull/1433) Let authentication fail when session validation fails (@stippi2)"
We need to be able to update as this and future versions to resolve new CVE's.

## How Has This Been Tested?

I've tested this locally running the module and in our K8s test cluster to ensure it to work.

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x ] I have created a feature (non-master) branch for my PR.
