### PR TITLE
docs/configuration: Fix entropy for bash secret

### DIFF
--- a/docs/docs/configuration/overview.md
+++ b/docs/docs/configuration/overview.md
@@ -31,7 +31,7 @@ import TabItem from '@theme/TabItem';
   <TabItem value="bash">
 
   ```shell
-  cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1 | base64
+  dd if=/dev/urandom bs=32 count=1 2>/dev/null | base64 | tr -d -- '\n' | tr -- '+/' '-_'; echo
   ```
 
   </TabItem>

--- a/docs/versioned_docs/version-6.1.x/configuration/overview.md
+++ b/docs/versioned_docs/version-6.1.x/configuration/overview.md
@@ -31,7 +31,7 @@ import TabItem from '@theme/TabItem';
   <TabItem value="bash">
 
   ```shell
-  cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1 | base64
+  dd if=/dev/urandom bs=32 count=1 2>/dev/null | base64 | tr -d -- '\n' | tr -- '+/' '-_'; echo
   ```
 
   </TabItem>

--- a/docs/versioned_docs/version-7.0.x/configuration/overview.md
+++ b/docs/versioned_docs/version-7.0.x/configuration/overview.md
@@ -31,7 +31,7 @@ import TabItem from '@theme/TabItem';
   <TabItem value="bash">
 
   ```shell
-  cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1 | base64
+  dd if=/dev/urandom bs=32 count=1 2>/dev/null | base64 | tr -d -- '\n' | tr -- '+/' '-_'; echo
   ```
 
   </TabItem>

--- a/docs/versioned_docs/version-7.1.x/configuration/overview.md
+++ b/docs/versioned_docs/version-7.1.x/configuration/overview.md
@@ -7,7 +7,7 @@ title: Overview
 
 ### Generating a Cookie Secret
 
-To generate a strong cookie secret use `python -c 'import os,base64; print(base64.urlsafe_b64encode(os.urandom(16)).decode())'`
+To generate a strong cookie secret use `python -c 'import os,base64; print(base64.urlsafe_b64encode(os.urandom(32)).decode())'`
 
 ### Config File
 

--- a/docs/versioned_docs/version-7.2.x/configuration/overview.md
+++ b/docs/versioned_docs/version-7.2.x/configuration/overview.md
@@ -31,7 +31,7 @@ import TabItem from '@theme/TabItem';
   <TabItem value="bash">
 
   ```shell
-  cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1 | base64
+  dd if=/dev/urandom bs=32 count=1 2>/dev/null | base64 | tr -d -- '\n' | tr -- '+/' '-_'; echo
   ```
 
   </TabItem>


### PR DESCRIPTION
Filtering `/dev/urandom` for alphanumeric characters resulted in loss of
input entropy to base64. Fixing this using a procedure with these steps:

  * Use `dd` to read 32 bytes from `/dev/urandom`
  * Concerting those to a single base64-encoded line
  * URL-Escaping the output
  * Appending a final newline

This output should be equivalent to output generated using Python and
OpenSSL variants mentioned in the changed document file.

Fixes: #1511

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
