### PR TITLE
Add ppc64le support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Changes since v7.2.1
 
+- [#1561](https://github.com/oauth2-proxy/oauth2-proxy/pull/1561) Add ppc64le support (@mgiessing)
 - [#1560](https://github.com/oauth2-proxy/oauth2-proxy/pull/1560) Fix provider data initialisation (@JoelSpeed)
 - [#1555](https://github.com/oauth2-proxy/oauth2-proxy/pull/1555) Refactor provider configuration into providers package (@JoelSpeed)
 - [#1394](https://github.com/oauth2-proxy/oauth2-proxy/pull/1394) Add generic claim extractor to get claims from ID Tokens (@JoelSpeed)

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ ARG BUILDPLATFORM
 RUN case ${TARGETPLATFORM} in \
          "linux/amd64")  GOARCH=amd64  ;; \
          "linux/arm64")  GOARCH=arm64  ;; \
+         "linux/ppc64le")  GOARCH=ppc64le  ;; \
          "linux/arm/v6") GOARCH=arm GOARM=6  ;; \
     esac && \
     printf "Building OAuth2 Proxy for arch ${GOARCH}\n" && \

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,8 @@ docker-all: docker
 	$(DOCKER_BUILDX) --platform linux/amd64 -t $(REGISTRY)/oauth2-proxy:${VERSION}-amd64 .
 	$(DOCKER_BUILDX) --platform linux/arm64 -t $(REGISTRY)/oauth2-proxy:latest-arm64 .
 	$(DOCKER_BUILDX) --platform linux/arm64 -t $(REGISTRY)/oauth2-proxy:${VERSION}-arm64 .
+	$(DOCKER_BUILDX) --platform linux/ppc64le -t $(REGISTRY)/oauth2-proxy:latest-ppc64le .
+	$(DOCKER_BUILDX) --platform linux/ppc64le -t $(REGISTRY)/oauth2-proxy:${VERSION}-ppc64le .
 	$(DOCKER_BUILDX) --platform linux/arm/v6 -t $(REGISTRY)/oauth2-proxy:latest-armv6 .
 	$(DOCKER_BUILDX) --platform linux/arm/v6 -t $(REGISTRY)/oauth2-proxy:${VERSION}-armv6 .
 
@@ -71,6 +73,8 @@ docker-push-all: docker-push
 	$(DOCKER_BUILDX_PUSH) --platform linux/amd64 -t $(REGISTRY)/oauth2-proxy:${VERSION}-amd64 .
 	$(DOCKER_BUILDX_PUSH) --platform linux/arm64 -t $(REGISTRY)/oauth2-proxy:latest-arm64 .
 	$(DOCKER_BUILDX_PUSH) --platform linux/arm64 -t $(REGISTRY)/oauth2-proxy:${VERSION}-arm64 .
+	$(DOCKER_BUILDX_PUSH) --platform linux/ppc64le -t $(REGISTRY)/oauth2-proxy:latest-ppc64le .
+	$(DOCKER_BUILDX_PUSH) --platform linux/ppc64le -t $(REGISTRY)/oauth2-proxy:${VERSION}-ppc64le .
 	$(DOCKER_BUILDX_PUSH) --platform linux/arm/v6 -t $(REGISTRY)/oauth2-proxy:latest-armv6 .
 	$(DOCKER_BUILDX_PUSH) --platform linux/arm/v6 -t $(REGISTRY)/oauth2-proxy:${VERSION}-armv6 .
 

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ build: validate-go-version clean $(BINARY)
 $(BINARY):
 	CGO_ENABLED=0 $(GO) build -a -installsuffix cgo -ldflags="-X main.VERSION=${VERSION}" -o $@ github.com/oauth2-proxy/oauth2-proxy/v7
 
-DOCKER_BUILD_PLATFORM ?= linux/amd64,linux/arm64,linux/arm/v6
+DOCKER_BUILD_PLATFORM ?= linux/amd64,linux/arm64,linux/ppc64le,linux/arm/v6
 DOCKER_BUILDX_ARGS ?=
 DOCKER_BUILDX := docker buildx build ${DOCKER_BUILDX_ARGS} --build-arg VERSION=${VERSION}
 DOCKER_BUILDX_X_PLATFORM := $(DOCKER_BUILDX) --platform ${DOCKER_BUILD_PLATFORM}

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Going forward, all images shall be available at `quay.io/oauth2-proxy/oauth2-pro
 
     b. Build with `$ go get github.com/oauth2-proxy/oauth2-proxy/v7` which will put the binary in `$GOROOT/bin`
 
-    c. Using the prebuilt docker image [quay.io/oauth2-proxy/oauth2-proxy](https://quay.io/oauth2-proxy/oauth2-proxy) (AMD64, ARMv6 and ARM64 tags available)
+    c. Using the prebuilt docker image [quay.io/oauth2-proxy/oauth2-proxy](https://quay.io/oauth2-proxy/oauth2-proxy) (AMD64, PPC64LE, ARMv6 and ARM64 tags available)
 
 Prebuilt binaries can be validated by extracting the file and verifying it against the `sha256sum.txt` checksum file provided for each release starting with version `v3.0.0`.
 

--- a/dist.sh
+++ b/dist.sh
@@ -7,7 +7,7 @@ if [[ -z ${BINARY} ]] || [[ -z ${VERSION} ]]; then
 	exit 1
 fi
 
-ARCHS=(darwin-amd64 linux-amd64 linux-arm64 linux-armv6 freebsd-amd64 windows-amd64)
+ARCHS=(darwin-amd64 linux-amd64 linux-arm64 linux-ppc64le linux-armv6 freebsd-amd64 windows-amd64)
 
 mkdir -p release
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This change will provide support for IBM Power (ppc64le) architecture.
<!--- Describe your changes in detail -->

## Motivation and Context
ppc64le is an architecture which is mainly used in server systems and thus not that widely recognized compared to x86 or arm. Nevertheless there is a strong focus on linux and open source and therefore this patch will help a people using these architecture.

## How Has This Been Tested?

Since this is not a content-wise change I tested github actions workflow in my repository. Furthermore Go provides multi-arch builds therefore I didn't test any of the functionality, because that shouldn't be affected by this PR.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] My change requires a change to the documentation or CHANGELOG.
- [x ] I have updated the documentation/CHANGELOG accordingly.
- [x ] I have created a feature (non-master) branch for my PR.
