### PR TITLE
Ensure claim extractor does not attempt profile call when URL is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## Changes since v7.2.1
 
 - [#1561](https://github.com/oauth2-proxy/oauth2-proxy/pull/1561) Add ppc64le support (@mgiessing)
+- [#1563](https://github.com/oauth2-proxy/oauth2-proxy/pull/1563) Ensure claim extractor does not attempt profile call when URL is empty (@JoelSpeed)
 - [#1560](https://github.com/oauth2-proxy/oauth2-proxy/pull/1560) Fix provider data initialisation (@JoelSpeed)
 - [#1555](https://github.com/oauth2-proxy/oauth2-proxy/pull/1555) Refactor provider configuration into providers package (@JoelSpeed)
 - [#1394](https://github.com/oauth2-proxy/oauth2-proxy/pull/1394) Add generic claim extractor to get claims from ID Tokens (@JoelSpeed)

--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,6 @@ require (
 	github.com/prometheus/common v0.15.0 // indirect
 	github.com/prometheus/procfs v0.2.0 // indirect
 	github.com/spf13/afero v1.1.2 // indirect
-	github.com/spf13/cast v1.3.0 // indirect
 	github.com/spf13/jwalterweatherman v1.0.0 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
 	github.com/vmihailenco/tagparser v0.1.1 // indirect

--- a/pkg/providers/util/claim_extractor.go
+++ b/pkg/providers/util/claim_extractor.go
@@ -86,7 +86,7 @@ func (c *claimExtractor) GetClaim(claim string) (interface{}, bool, error) {
 // loadProfileClaims will fetch the profileURL using the provided headers as
 // authentication.
 func (c *claimExtractor) loadProfileClaims() (*simplejson.Json, error) {
-	if c.profileURL == nil || c.requestHeaders == nil {
+	if c.profileURL == nil || c.profileURL.String() == "" || c.requestHeaders == nil {
 		// When no profileURL is set, we return a non-empty map so that
 		// we don't attempt to populate the profile claims again.
 		// If there are no headers, the request would be unauthorized so we also skip

--- a/pkg/providers/util/claim_extractor_test.go
+++ b/pkg/providers/util/claim_extractor_test.go
@@ -259,6 +259,24 @@ var _ = Describe("Claim Extractor Suite", func() {
 		Expect(counter).To(BeEquivalentTo(1))
 	})
 
+	It("GetClaim should not return an error with a non-nil empty ProfileURL", func() {
+		claims, serverClose, err := newTestClaimExtractor(testClaimExtractorOpts{
+			idTokenPayload:        "{}",
+			profileRequestHeaders: newAuthorizedHeader(),
+		})
+		Expect(err).ToNot(HaveOccurred())
+		if serverClose != nil {
+			defer serverClose()
+		}
+		// Set the ProfileURL to be empty, but not nil
+		claims.(*claimExtractor).profileURL = &url.URL{}
+
+		value, exists, err := claims.GetClaim("user")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(exists).To(BeFalse())
+		Expect(value).To(BeNil())
+	})
+
 	type getClaimIntoTableInput struct {
 		testClaimExtractorOpts
 		into          interface{}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
This ensures that we don't attempt to make a profileURL call when the profileURL is empty.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Without this, the proxy logs an error when creating a session:
```
[2022/02/17 20:39:10] [oauthproxy.go:777] Error redeeming code during OAuth2 callback: could not get claim "groups": failed to fetch claims from profile URL: error making request to profile URL: error performing request: Get "": unsupported protocol scheme ""
```

CC @braunsonm as I know you found this while working on your PKCE PR

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Using the local testing environment, I could reproduce the issue until this fix was applied.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.