### PR TITLE
WIP: mutate config-elements setting default values

### DIFF
--- a/main.go
+++ b/main.go
@@ -114,6 +114,7 @@ func loadAlphaOptions(config, alphaConfig string, extraFlags *pflag.FlagSet, arg
 		return nil, fmt.Errorf("failed to load alpha options: %v", err)
 	}
 
+	alphaOpts.Default()
 	alphaOpts.MergeInto(opts)
 	return opts, nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -149,13 +149,13 @@ redirect_url="http://localhost:4180/oauth2/callback"
 				AzureConfig: options.AzureOptions{
 					Tenant: "common",
 				},
-				OIDCConfig: options.OIDCOptions{
+				OIDCConfig: &options.OIDCOptions{
 					GroupsClaim:       "groups",
 					EmailClaim:        "email",
 					UserIDClaim:       "email",
 					AudienceClaims:    []string{"aud"},
 					ExtraAudiences:    []string{},
-					InsecureSkipNonce: true,
+					InsecureSkipNonce: boolPtr(true),
 				},
 				LoginURLParameters: []options.LoginURLParameter{
 					{Name: "approval_prompt", Default: []string{"force"}},

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -1964,9 +1964,14 @@ func Test_noCacheHeaders(t *testing.T) {
 func baseTestOptions() *options.Options {
 	opts := options.NewOptions()
 	opts.Cookie.Secret = rawCookieSecret
+
+	opts.Providers = options.Providers{{Type: "google"}}
+
 	opts.Providers[0].ID = "providerID"
 	opts.Providers[0].ClientID = clientID
 	opts.Providers[0].ClientSecret = clientSecret
+	opts.Providers.Default()
+
 	opts.EmailDomains = []string{"*"}
 
 	// Default injected headers for legacy configuration

--- a/pkg/apis/options/alpha_options.go
+++ b/pkg/apis/options/alpha_options.go
@@ -45,6 +45,10 @@ type AlphaOptions struct {
 	Providers Providers `json:"providers,omitempty"`
 }
 
+func (a *AlphaOptions) Default() {
+	a.Providers.Default()
+}
+
 // MergeInto replaces alpha options in the Options struct with the values
 // from the AlphaOptions
 func (a *AlphaOptions) MergeInto(opts *Options) {

--- a/pkg/apis/options/legacy_options.go
+++ b/pkg/apis/options/legacy_options.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/logger"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/util"
 	"github.com/spf13/pflag"
 )
 
@@ -48,14 +49,14 @@ func NewLegacyOptions() *LegacyOptions {
 
 		LegacyProvider: LegacyProvider{
 			ProviderType:          "google",
-			AzureTenant:           "common",
+			AzureTenant:           "",
 			ApprovalPrompt:        "force",
 			UserIDClaim:           "email",
 			OIDCEmailClaim:        "email",
 			OIDCGroupsClaim:       "groups",
 			OIDCAudienceClaims:    []string{"aud"},
 			OIDCExtraAudiences:    []string{},
-			InsecureOIDCSkipNonce: true,
+			InsecureOIDCSkipNonce: util.BoolPtr(true),
 		},
 
 		Options: *NewOptions(),
@@ -496,7 +497,7 @@ type LegacyProvider struct {
 	OIDCIssuerURL                      string   `flag:"oidc-issuer-url" cfg:"oidc_issuer_url"`
 	InsecureOIDCAllowUnverifiedEmail   bool     `flag:"insecure-oidc-allow-unverified-email" cfg:"insecure_oidc_allow_unverified_email"`
 	InsecureOIDCSkipIssuerVerification bool     `flag:"insecure-oidc-skip-issuer-verification" cfg:"insecure_oidc_skip_issuer_verification"`
-	InsecureOIDCSkipNonce              bool     `flag:"insecure-oidc-skip-nonce" cfg:"insecure_oidc_skip_nonce"`
+	InsecureOIDCSkipNonce              *bool    `flag:"insecure-oidc-skip-nonce" cfg:"insecure_oidc_skip_nonce"`
 	SkipOIDCDiscovery                  bool     `flag:"skip-oidc-discovery" cfg:"skip_oidc_discovery"`
 	OIDCJwksURL                        string   `flag:"oidc-jwks-url" cfg:"oidc_jwks_url"`
 	OIDCEmailClaim                     string   `flag:"oidc-email-claim" cfg:"oidc_email_claim"`
@@ -640,7 +641,7 @@ func (l *LegacyProvider) convert() (Providers, error) {
 	}
 
 	// This part is out of the switch section for all providers that support OIDC
-	provider.OIDCConfig = OIDCOptions{
+	provider.OIDCConfig = &OIDCOptions{
 		IssuerURL:                      l.OIDCIssuerURL,
 		InsecureAllowUnverifiedEmail:   l.InsecureOIDCAllowUnverifiedEmail,
 		InsecureSkipIssuerVerification: l.InsecureOIDCSkipIssuerVerification,

--- a/pkg/apis/options/options.go
+++ b/pkg/apis/options/options.go
@@ -91,9 +91,12 @@ func (o *Options) SetRealClientIPParser(s ipapi.RealClientIPParser)       { o.re
 
 // NewOptions constructs a new Options with defaulted values
 func NewOptions() *Options {
+	providers := new(Providers)
+	providers.Default()
+
 	return &Options{
 		ProxyPrefix:        "/oauth2",
-		Providers:          providerDefaults(),
+		Providers:          *providers,
 		PingPath:           "/ping",
 		RealClientIPHeader: "X-Real-IP",
 		ForceHTTPS:         false,

--- a/pkg/util/pointers.go
+++ b/pkg/util/pointers.go
@@ -1,0 +1,10 @@
+package util
+
+// BoolPtr returns a pointer to a boolean value.
+// As long as bool defaults to false when populated from JSON with `omitempty`,
+// it is not possible to distinguish `omitempty`-default from intentional false.
+// Boolean pointers default to nil when `omitempty`, allowing to distinguish
+// default from false.
+func BoolPtr(b bool) *bool {
+	return &b
+}

--- a/providers/azure.go
+++ b/providers/azure.go
@@ -81,16 +81,12 @@ func NewAzureProvider(p *ProviderData, opts options.AzureOptions) *AzureProvider
 	}
 	p.getAuthorizationHeaderFunc = makeAzureHeader
 
-	tenant := "common"
-	if opts.Tenant != "" {
-		tenant = opts.Tenant
-		overrideTenantURL(p.LoginURL, azureDefaultLoginURL, tenant, "authorize")
-		overrideTenantURL(p.RedeemURL, azureDefaultRedeemURL, tenant, "token")
-	}
+	overrideTenantURL(p.LoginURL, azureDefaultLoginURL, opts.Tenant, "authorize")
+	overrideTenantURL(p.RedeemURL, azureDefaultRedeemURL, opts.Tenant, "token")
 
 	return &AzureProvider{
 		ProviderData: p,
-		Tenant:       tenant,
+		Tenant:       opts.Tenant,
 	}
 }
 

--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -27,7 +27,7 @@ func NewOIDCProvider(p *ProviderData, opts options.OIDCOptions) *OIDCProvider {
 
 	return &OIDCProvider{
 		ProviderData: p,
-		SkipNonce:    opts.InsecureSkipNonce,
+		SkipNonce:    *opts.InsecureSkipNonce,
 	}
 }
 

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -31,7 +31,11 @@ type Provider interface {
 	CreateSessionFromToken(ctx context.Context, token string) (*sessions.SessionState, error)
 }
 
+// NewProvider returns an upstream identity provider
 func NewProvider(providerConfig options.Provider) (Provider, error) {
+	if providerConfig.OIDCConfig == nil {
+		logger.Fatalf("failed to create %v provider without OIDC options", providerConfig.Type)
+	}
 	providerData, err := newProviderDataFromConfig(providerConfig)
 	if err != nil {
 		return nil, fmt.Errorf("could not create provider data: %v", err)
@@ -64,7 +68,7 @@ func NewProvider(providerConfig options.Provider) (Provider, error) {
 	case options.NextCloudProvider:
 		return NewNextcloudProvider(providerData), nil
 	case options.OIDCProvider:
-		return NewOIDCProvider(providerData, providerConfig.OIDCConfig), nil
+		return NewOIDCProvider(providerData, *providerConfig.OIDCConfig), nil
 	default:
 		return nil, fmt.Errorf("unknown provider type %q", providerConfig.Type)
 	}


### PR DESCRIPTION
More specifically,
- introduce a `DefaultUnsetFields` func for AlphaOpts, Provider,
  OIDCOptions and AzureOptions,
- replace boolean values with pointers, so that unset fields are nil, as
  a default-false is impossible to distinguish from an intentional,
  false

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
