### PR TITLE
Fix initialization of provider data to set user claim from config

### DIFF
--- a/providers/providers.go
+++ b/providers/providers.go
@@ -148,6 +148,7 @@ func newProviderDataFromConfig(providerConfig options.Provider) (*ProviderData, 
 	if providerConfig.OIDCConfig.UserIDClaim == "" {
 		providerConfig.OIDCConfig.UserIDClaim = "email"
 	}
+	p.UserClaim = providerConfig.OIDCConfig.UserIDClaim
 
 	p.setAllowedGroups(providerConfig.AllowedGroups)
 

--- a/providers/providers_test.go
+++ b/providers/providers_test.go
@@ -171,3 +171,44 @@ func TestScope(t *testing.T) {
 		g.Expect(pd.Scope).To(Equal(tc.expectedScope))
 	}
 }
+
+func TestUserIDClaim(t *testing.T) {
+	g := NewWithT(t)
+
+	testCases := []struct {
+		name                  string
+		configuredUserIDClaim string
+		expectedUserIDClaim   string
+	}{
+		{
+			name:                  "with no user ID claim provided",
+			configuredUserIDClaim: "",
+			expectedUserIDClaim:   "email",
+		},
+		{
+			name:                  "with a configured user ID claim provided",
+			configuredUserIDClaim: "sub",
+			expectedUserIDClaim:   "sub",
+		},
+	}
+
+	for _, tc := range testCases {
+		providerConfig := options.Provider{
+			ID:               providerID,
+			Type:             "oidc",
+			ClientID:         clientID,
+			ClientSecretFile: clientSecret,
+			OIDCConfig: options.OIDCOptions{
+				IssuerURL:     msIssuerURL,
+				SkipDiscovery: true,
+				JwksURL:       msKeysURL,
+				UserIDClaim:   tc.configuredUserIDClaim,
+			},
+		}
+
+		pd, err := newProviderDataFromConfig(providerConfig)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		g.Expect(pd.UserClaim).To(Equal(tc.expectedUserIDClaim))
+	}
+}


### PR DESCRIPTION
## Description

Sets the user claim in the provider data based on the value from the OIDC config.

## Motivation and Context

I recently switched from using the legacy configuration to using the alpha configuration in order to take advantage of the the `LoginURLParameter` option. However, after making this change I noticed that the `X-Auth-Request-User` was no longer being set as expected. 

You can see here that the legacy configuration defaulted to using `sub` for the user claim:
https://github.com/oauth2-proxy/oauth2-proxy/blob/master/providers/provider_data.go#L201-L203

When using the alpha configuration, it uses `email` as the default, but it was not respecting when the `OIDCConfig.UserIDClaim` option is set.

## How Has This Been Tested?

I have added unit tests for when the `userIDClaim` is provided as well as when not provided that it defaults to `email` (previously implemented).

I also tested this manually using Auth0 as the OIDC provider with `sub` as the user ID claim.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
