### PR TITLE
Increase default sessionRefreshLockDuration to 10 seconds

### DIFF
--- a/pkg/middleware/stored_session.go
+++ b/pkg/middleware/stored_session.go
@@ -24,7 +24,7 @@ const (
 	// If the refresh request isn't finished within this time, the lock will be
 	// released.
 	// TODO: This should probably be configurable by the end user.
-	sessionRefreshLockDuration = 2 * time.Second
+	sessionRefreshLockDuration = 10 * time.Second
 
 	// How long to wait after failing to obtain the lock before trying again.
 	// TODO: This should probably be configurable by the end user.


### PR DESCRIPTION
## Description

If Redis is being used to coordinate session locking with a provider
that issues new refresh tokens per flow, it is critical that we
avoid allowing concurrent refresh attempts.  A failure in this path
will effectively cause the user to be logged out.

Refresh flows are also where providers may implement stricter
security checks, which may be slow especially if they involve making
network requests to other systems (i.e. account disablement detection).

Thus 10 seconds seems to be a safer default than 2 seconds.

Signed-off-by: Monis Khan <mok@vmware.com>

## Motivation and Context

Users are occasionally being logged out of oauth2-proxy when it attempts to make concurrent refresh flows even with redis as the session store.  The refresh flows are occasionally slow due to network conditions and/or load on the OIDC provider.

## How Has This Been Tested?

Ran unit tests.  Also confirmed that the occasional logouts went away with the longer `sessionRefreshLockDuration` value.  Note that before this change I could see the concurrent refresh attempts on the OIDC provider's logs so it is clear that that is the reason as to why the user was being logged out.

## Checklist:

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.

cc @JoelSpeed 