### PR TITLE
Clarify that Keycloak OIDC also supports --cookie-refresh

### DIFF
--- a/docs/versioned_docs/version-7.2.x/configuration/overview.md
+++ b/docs/versioned_docs/version-7.2.x/configuration/overview.md
@@ -199,7 +199,7 @@ An example [oauth2-proxy.cfg](https://github.com/oauth2-proxy/oauth2-proxy/blob/
 | `--whitelist-domain` | string \| list | allowed domains for redirection after authentication. Prefix domain with a `.` to allow subdomains (e.g. `.example.com`)&nbsp;\[[2](#footnote2)\] | |
 | `--trusted-ip` | string \| list | list of IPs or CIDR ranges to allow to bypass authentication (may be given multiple times). When combined with `--reverse-proxy` and optionally `--real-client-ip-header` this will evaluate the trust of the IP stored in an HTTP header by a reverse proxy rather than the layer-3/4 remote address. WARNING: trusting IPs has inherent security flaws, especially when obtaining the IP address from an HTTP header (reverse-proxy mode). Use this option only if you understand the risks and how to manage them. | |
 
-\[<a name="footnote1">1</a>\]: Only these providers support `--cookie-refresh`: GitLab, Google and OIDC
+\[<a name="footnote1">1</a>\]: Only these providers support `--cookie-refresh`: GitLab, Google, OIDC, and Keycloak OIDC
 
 \[<a name="footnote2">2</a>\]: When using the `whitelist-domain` option, any domain prefixed with a `.` will allow any subdomain of the specified domain as a valid redirect URL. By default, only empty ports are allowed. This translates to allowing the default port of the URL's protocol (80 for HTTP, 443 for HTTPS, etc.) since browsers omit them. To allow only a specific port, add it to the whitelisted domain: `example.com:8080`. To allow any port, use `*`: `example.com:*`.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Doc change to reflect what I learned by trying it out.

## Motivation and Context

Under the hood, the keycloak-oidc provider uses the oidc provider. While this is obvious to maintainers of this component, it's not when "just using" it.

## How Has This Been Tested?

Tried out keycloak-oidc provider with --cookie-refresh=1m, log shows up: `Refreshing session - User: xyz; SessionAge: 1m4.913727464s`. Access token passed to upstream has been updated.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
