### PR TITLE
Flag skip expiry check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ## Changes since v7.2.1
 
+- [#1590](https://github.com/oauth2-proxy/oauth2-proxy/pull/1590) Add --skip-expiry-check flag to skip the token expiration check (@jeremyvanhove)
 - [#1583](https://github.com/oauth2-proxy/oauth2-proxy/pull/1583) Add groups to session too when creating session from bearer token (@adriananeci)
 - [#1418](https://github.com/oauth2-proxy/oauth2-proxy/pull/1418) Support for passing arbitrary query parameters through from `/oauth2/start` to the identity provider's login URL. Configuration settings control which parameters are passed by default and precisely which values can be overridden per-request (@ianroberts)
 - [#1559](https://github.com/oauth2-proxy/oauth2-proxy/pull/1559) Introduce ProviderVerifier to clean up OIDC discovery code (@JoelSpeed)

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -85,6 +85,7 @@ type OAuthProxy struct {
 	SkipProviderButton  bool
 	skipAuthPreflight   bool
 	skipJwtBearerTokens bool
+	skipExpiryCheck     bool
 	forceJSONErrors     bool
 	realClientIPParser  ipapi.RealClientIPParser
 	trustedIPs          *ip.NetSet
@@ -153,6 +154,10 @@ func NewOAuthProxy(opts *options.Options, validator func(string) bool) (*OAuthPr
 		redirectURL.Path = fmt.Sprintf("%s/callback", opts.ProxyPrefix)
 	}
 
+	if opts.SkipExpiryCheck {
+		logger.Printf("Skipping JWT token expiration check")
+	}
+
 	logger.Printf("OAuthProxy configured for %s Client ID: %s", provider.Data().ProviderName, opts.Providers[0].ClientID)
 	refresh := "disabled"
 	if opts.Cookie.Refresh != time.Duration(0) {
@@ -205,6 +210,7 @@ func NewOAuthProxy(opts *options.Options, validator func(string) bool) (*OAuthPr
 		whitelistDomains:    opts.WhitelistDomains,
 		skipAuthPreflight:   opts.SkipAuthPreflight,
 		skipJwtBearerTokens: opts.SkipJwtBearerTokens,
+		skipExpiryCheck:     opts.SkipExpiryCheck,
 		realClientIPParser:  opts.GetRealClientIPParser(),
 		SkipProviderButton:  opts.SkipProviderButton,
 		forceJSONErrors:     opts.ForceJSONErrors,

--- a/pkg/apis/options/legacy_options.go
+++ b/pkg/apis/options/legacy_options.go
@@ -498,6 +498,7 @@ type LegacyProvider struct {
 	InsecureOIDCSkipIssuerVerification bool     `flag:"insecure-oidc-skip-issuer-verification" cfg:"insecure_oidc_skip_issuer_verification"`
 	InsecureOIDCSkipNonce              bool     `flag:"insecure-oidc-skip-nonce" cfg:"insecure_oidc_skip_nonce"`
 	SkipOIDCDiscovery                  bool     `flag:"skip-oidc-discovery" cfg:"skip_oidc_discovery"`
+	SkipExpiryCheck                    bool     `flag:"skip-expiry-check" cfg:"skip-expiry-check"`
 	OIDCJwksURL                        string   `flag:"oidc-jwks-url" cfg:"oidc_jwks_url"`
 	OIDCEmailClaim                     string   `flag:"oidc-email-claim" cfg:"oidc_email_claim"`
 	OIDCGroupsClaim                    string   `flag:"oidc-groups-claim" cfg:"oidc_groups_claim"`
@@ -652,6 +653,7 @@ func (l *LegacyProvider) convert() (Providers, error) {
 		GroupsClaim:                    l.OIDCGroupsClaim,
 		AudienceClaims:                 l.OIDCAudienceClaims,
 		ExtraAudiences:                 l.OIDCExtraAudiences,
+		SkipExpiryCheck:                l.SkipExpiryCheck,
 	}
 
 	// This part is out of the switch section because azure has a default tenant

--- a/pkg/apis/options/options.go
+++ b/pkg/apis/options/options.go
@@ -53,6 +53,7 @@ type Options struct {
 	SkipAuthRegex         []string `flag:"skip-auth-regex" cfg:"skip_auth_regex"`
 	SkipAuthRoutes        []string `flag:"skip-auth-route" cfg:"skip_auth_routes"`
 	SkipJwtBearerTokens   bool     `flag:"skip-jwt-bearer-tokens" cfg:"skip_jwt_bearer_tokens"`
+	SkipExpiryCheck       bool     `flag:"skip-expiry-check" cfg:"skip_expiry_check"`
 	ExtraJwtIssuers       []string `flag:"extra-jwt-issuers" cfg:"extra_jwt_issuers"`
 	SkipProviderButton    bool     `flag:"skip-provider-button" cfg:"skip_provider_button"`
 	SSLInsecureSkipVerify bool     `flag:"ssl-insecure-skip-verify" cfg:"ssl_insecure_skip_verify"`
@@ -120,6 +121,7 @@ func NewFlagSet() *pflag.FlagSet {
 	flagSet.Bool("skip-auth-preflight", false, "will skip authentication for OPTIONS requests")
 	flagSet.Bool("ssl-insecure-skip-verify", false, "skip validation of certificates presented when using HTTPS providers")
 	flagSet.Bool("skip-jwt-bearer-tokens", false, "will skip requests that have verified JWT bearer tokens (default false)")
+	flagSet.Bool("skip-expiry-check", false, "will skip the token expiration check (default false)")
 	flagSet.Bool("force-json-errors", false, "will force JSON errors instead of HTTP error pages or redirects")
 	flagSet.StringSlice("extra-jwt-issuers", []string{}, "if skip-jwt-bearer-tokens is set, a list of extra JWT issuer=audience pairs (where the issuer URL has a .well-known/openid-configuration or a .well-known/jwks.json)")
 

--- a/pkg/apis/options/providers.go
+++ b/pkg/apis/options/providers.go
@@ -225,6 +225,8 @@ type OIDCOptions struct {
 	// ExtraAudiences is a list of additional audiences that are allowed
 	// to pass verification in addition to the client id.
 	ExtraAudiences []string `json:"extraAudiences,omitempty"`
+	// SkipExpiryCheck allows to skip token expiry
+	SkipExpiryCheck bool `json:"skipExpiryCheck,omitempty"`
 }
 
 type LoginGovOptions struct {

--- a/pkg/providers/oidc/provider_verifier.go
+++ b/pkg/providers/oidc/provider_verifier.go
@@ -43,6 +43,10 @@ type ProviderVerifierOptions struct {
 	// SkipIssuerVerification skips verification of ID token issuers.
 	// When false, ID Token Issuers must match the OIDC discovery URL.
 	SkipIssuerVerification bool
+
+	// SkipExpiryCheck skips verification of token expiration.
+	// When false, the expiry token is verified.
+	SkipExpiryCheck bool
 }
 
 // validate checks that the required options are present before attempting to create
@@ -67,9 +71,10 @@ func (p ProviderVerifierOptions) validate() error {
 // toVerificationOptions returns an IDTokenVerificationOptions based on the configured options.
 func (p ProviderVerifierOptions) toVerificationOptions() IDTokenVerificationOptions {
 	return IDTokenVerificationOptions{
-		AudienceClaims: p.AudienceClaims,
-		ClientID:       p.ClientID,
-		ExtraAudiences: p.ExtraAudiences,
+		AudienceClaims:  p.AudienceClaims,
+		ClientID:        p.ClientID,
+		ExtraAudiences:  p.ExtraAudiences,
+		SkipExpiryCheck: p.SkipExpiryCheck,
 	}
 }
 
@@ -79,6 +84,7 @@ func (p ProviderVerifierOptions) toOIDCConfig() *oidc.Config {
 		ClientID:          p.ClientID,
 		SkipIssuerCheck:   p.SkipIssuerVerification,
 		SkipClientIDCheck: true,
+		SkipExpiryCheck:   p.SkipExpiryCheck,
 	}
 }
 

--- a/pkg/providers/oidc/verifier.go
+++ b/pkg/providers/oidc/verifier.go
@@ -22,9 +22,10 @@ type idTokenVerifier struct {
 
 // IDTokenVerificationOptions options for the oidc.idTokenVerifier that are required to verify an ID Token
 type IDTokenVerificationOptions struct {
-	AudienceClaims []string
-	ClientID       string
-	ExtraAudiences []string
+	AudienceClaims  []string
+	ClientID        string
+	ExtraAudiences  []string
+	SkipExpiryCheck bool
 }
 
 // NewVerifier constructs a new idTokenVerifier

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -92,6 +92,7 @@ func newProviderDataFromConfig(providerConfig options.Provider) (*ProviderData, 
 			JWKsURL:                providerConfig.OIDCConfig.JwksURL,
 			SkipDiscovery:          providerConfig.OIDCConfig.SkipDiscovery,
 			SkipIssuerVerification: providerConfig.OIDCConfig.InsecureSkipIssuerVerification,
+			SkipExpiryCheck:        providerConfig.OIDCConfig.SkipExpiryCheck,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("error building OIDC ProviderVerifier: %v", err)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Possibility to add `--skip-expiry-check` flag to skip the token expiration check.

<!--- Describe your changes in detail -->

## Motivation and Context

Generate a token from keycloak interface sets the "exp" field (expiration) of the token to 0 (corresponding to: 1970-01-01 01:00:00 +0100 CET)).
Use the flag --skip-expiry-check to skip the token expiration check.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.