### PR TITLE
Add option to masquerade the requestor's redirect URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ## Changes since v7.2.1
 
+- [#1598](https://github.com/oauth2-proxy/oauth2-proxy/pull/1598) Add option to masquerade the requestor's redirect URL (@zv0n)
 - [#1583](https://github.com/oauth2-proxy/oauth2-proxy/pull/1583) Add groups to session too when creating session from bearer token (@adriananeci)
 - [#1418](https://github.com/oauth2-proxy/oauth2-proxy/pull/1418) Support for passing arbitrary query parameters through from `/oauth2/start` to the identity provider's login URL. Configuration settings control which parameters are passed by default and precisely which values can be overridden per-request (@ianroberts)
 - [#1559](https://github.com/oauth2-proxy/oauth2-proxy/pull/1559) Introduce ProviderVerifier to clean up OIDC discovery code (@JoelSpeed)

--- a/docs/docs/configuration/overview.md
+++ b/docs/docs/configuration/overview.md
@@ -130,6 +130,7 @@ An example [oauth2-proxy.cfg](https://github.com/oauth2-proxy/oauth2-proxy/blob/
 | `--jwt-key` | string | private key in PEM format used to sign JWT, so that you can say something like `--jwt-key="${OAUTH2_PROXY_JWT_KEY}"`: required by login.gov | |
 | `--jwt-key-file` | string | path to the private key file in PEM format used to sign the JWT so that you can say something like `--jwt-key-file=/etc/ssl/private/jwt_signing_key.pem`: required by login.gov | |
 | `--login-url` | string | Authentication endpoint | |
+| `--masquerade-request-host` | bool | if the `redirect-url` is set to the proxy's URL, redirect to the original request's host after the callback is finished (useful when you want to use the proxy for authorization only) | false |
 | `--insecure-oidc-allow-unverified-email` | bool | don't fail if an email address in an id_token is not verified | false |
 | `--insecure-oidc-skip-issuer-verification` | bool | allow the OIDC issuer URL to differ from the expected (currently required for Azure multi-tenant compatibility) | false |
 | `--insecure-oidc-skip-nonce` | bool | skip verifying the OIDC ID Token's nonce claim | true |

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -814,6 +814,7 @@ func (p *OAuthProxy) OAuthCallback(rw http.ResponseWriter, req *http.Request) {
 		p.ErrorPage(rw, req, http.StatusInternalServerError, err.Error())
 		return
 	}
+	delete(p.requestRedirectURLs, nonce)
 
 	if !csrf.CheckOAuthState(nonce) {
 		logger.PrintAuthf(session.Email, req, logger.AuthFailure, "Invalid authentication via OAuth2: CSRF token mismatch, potential attack")

--- a/pkg/apis/options/options.go
+++ b/pkg/apis/options/options.go
@@ -18,14 +18,15 @@ type SignatureData struct {
 // Options holds Configuration Options that can be set by Command Line Flag,
 // or Config File
 type Options struct {
-	ProxyPrefix        string   `flag:"proxy-prefix" cfg:"proxy_prefix"`
-	PingPath           string   `flag:"ping-path" cfg:"ping_path"`
-	PingUserAgent      string   `flag:"ping-user-agent" cfg:"ping_user_agent"`
-	ReverseProxy       bool     `flag:"reverse-proxy" cfg:"reverse_proxy"`
-	RealClientIPHeader string   `flag:"real-client-ip-header" cfg:"real_client_ip_header"`
-	TrustedIPs         []string `flag:"trusted-ip" cfg:"trusted_ips"`
-	ForceHTTPS         bool     `flag:"force-https" cfg:"force_https"`
-	RawRedirectURL     string   `flag:"redirect-url" cfg:"redirect_url"`
+	ProxyPrefix           string   `flag:"proxy-prefix" cfg:"proxy_prefix"`
+	PingPath              string   `flag:"ping-path" cfg:"ping_path"`
+	PingUserAgent         string   `flag:"ping-user-agent" cfg:"ping_user_agent"`
+	ReverseProxy          bool     `flag:"reverse-proxy" cfg:"reverse_proxy"`
+	RealClientIPHeader    string   `flag:"real-client-ip-header" cfg:"real_client_ip_header"`
+	TrustedIPs            []string `flag:"trusted-ip" cfg:"trusted_ips"`
+	ForceHTTPS            bool     `flag:"force-https" cfg:"force_https"`
+	RawRedirectURL        string   `flag:"redirect-url" cfg:"redirect_url"`
+	MasqueradeRequestHost bool     `flag:"masquerade-request-host" cfg:"masquerade-request-host"`
 
 	AuthenticatedEmailsFile string   `flag:"authenticated-emails-file" cfg:"authenticated_emails_file"`
 	EmailDomains            []string `flag:"email-domain" cfg:"email_domains"`
@@ -114,6 +115,7 @@ func NewFlagSet() *pflag.FlagSet {
 	flagSet.StringSlice("trusted-ip", []string{}, "list of IPs or CIDR ranges to allow to bypass authentication. WARNING: trusting by IP has inherent security flaws, read the configuration documentation for more information.")
 	flagSet.Bool("force-https", false, "force HTTPS redirect for HTTP requests")
 	flagSet.String("redirect-url", "", "the OAuth Redirect URL. ie: \"https://internalapp.yourcompany.com/oauth2/callback\"")
+	flagSet.Bool("masquerade-request-host", false, "if the redirect-url is set to this proxy, redirect to the original request's host after the callback is finished (useful when you want to use the proxy for authorization only)")
 	flagSet.StringSlice("skip-auth-regex", []string{}, "(DEPRECATED for --skip-auth-route) bypass authentication for requests path's that match (may be given multiple times)")
 	flagSet.StringSlice("skip-auth-route", []string{}, "bypass authentication for requests that match the method & path. Format: method=path_regex OR path_regex alone for all methods")
 	flagSet.Bool("skip-provider-button", false, "will skip sign-in-page to directly reach the next step: oauth/start")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

I have added an option to masquerade website's request URL with the proxy's URL. When this option is specified, the proxy remembers the requestor's URL (e.g. `site01.com`) in a hash map, the URLs are indexed using `HashOAuthState()` from the CSRF cookie. For the masquerading to work `--redirect-url` must be set to a URL registered with the identity provider. With the masquerade option enabled, the callback function disregards the request's host and instead extracts the `nonce` from the `state` in the URL query, the `nonce` is used to look up the original requestor's URL in the hash map and the callback is redirected to the original request's host where the callback function runs as usual.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

At our company users can create websites, we would like to give them an option to require user authorization via our identity provider. However since any user can create one or multiple websites at any time, it would be impractical to register every website with the identity provider.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I have run the oauth2-proxy binary with options `--redirect-url "http://localhost:4180/oauth2/callback" --masquerade-request-host=true`, then created a website which uses proxy-pass to redirect `/oauth2` requests to the proxy. When user wanted to authenticate, they were redirected to identity provider with redirect-uri `localhost:4180/oauth2/callback` but once the callback has finished the user has been redirected to the original site.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
