### PR TITLE
Add response-type configuration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ## Changes since v7.2.1
 
+- [#1603](https://github.com/oauth2-proxy/oauth2-proxy/pull/1603) Add response-type configuration option
 - [#1583](https://github.com/oauth2-proxy/oauth2-proxy/pull/1583) Add groups to session too when creating session from bearer token (@adriananeci)
 - [#1418](https://github.com/oauth2-proxy/oauth2-proxy/pull/1418) Support for passing arbitrary query parameters through from `/oauth2/start` to the identity provider's login URL. Configuration settings control which parameters are passed by default and precisely which values can be overridden per-request (@ianroberts)
 - [#1559](https://github.com/oauth2-proxy/oauth2-proxy/pull/1559) Introduce ProviderVerifier to clean up OIDC discovery code (@JoelSpeed)

--- a/docs/docs/configuration/alpha_config.md
+++ b/docs/docs/configuration/alpha_config.md
@@ -103,6 +103,7 @@ longer available when using alpha configuration:
 - `resource`
 - `validate-url`/`validate_url`
 - `scope`
+- `response-type`/`response_type`
 - `prompt`
 - `approval-prompt`/`approval_prompt`
 - `acr-values`/`acr_values`
@@ -418,6 +419,7 @@ Provider holds all configuration for a single provider
 | `resource` | _string_ | ProtectedResource is the resource that is protected (Azure AD and ADFS only) |
 | `validateURL` | _string_ | ValidateURL is the access token validation endpoint |
 | `scope` | _string_ | Scope is the OAuth scope specification |
+| `responseType` | _string_ | ResponseType tells the authorization server which grant to execute |
 | `allowedGroups` | _[]string_ | AllowedGroups is a list of restrict logins to members of this group |
 | `force_code_challenge_method` | _string_ | The forced code challenge method |
 

--- a/docs/docs/configuration/alpha_config.md.tmpl
+++ b/docs/docs/configuration/alpha_config.md.tmpl
@@ -103,6 +103,7 @@ longer available when using alpha configuration:
 - `resource`
 - `validate-url`/`validate_url`
 - `scope`
+- `response-type`/`response_type`
 - `prompt`
 - `approval-prompt`/`approval_prompt`
 - `acr-values`/`acr_values`

--- a/docs/docs/configuration/overview.md
+++ b/docs/docs/configuration/overview.md
@@ -170,6 +170,7 @@ An example [oauth2-proxy.cfg](https://github.com/oauth2-proxy/oauth2-proxy/blob/
 | `--request-id-header` | string | Request header to use as the request ID in logging | X-Request-Id |
 | `--request-logging` | bool | Log requests | true |
 | `--request-logging-format` | string | Template for request log lines | see [Logging Configuration](#logging-configuration) |
+| `--response-type` | string | OAuth response_type parameter in authorization request | `"code"` |
 | `--resource` | string | The resource that is protected (Azure AD only) | |
 | `--reverse-proxy` | bool | are we running behind a reverse proxy, controls whether headers like X-Real-IP are accepted and allows X-Forwarded-{Proto,Host,Uri} headers to be used on redirect selection | false |
 | `--scope` | string | OAuth scope specification | |

--- a/main_test.go
+++ b/main_test.go
@@ -146,6 +146,7 @@ redirect_url="http://localhost:4180/oauth2/callback"
 				Type:         "google",
 				ClientSecret: "b2F1dGgyLXByb3h5LWNsaWVudC1zZWNyZXQK",
 				ClientID:     "oauth2-proxy",
+				ResponseType: "",
 				AzureConfig: options.AzureOptions{
 					Tenant: "common",
 				},

--- a/pkg/apis/options/legacy_options.go
+++ b/pkg/apis/options/legacy_options.go
@@ -509,6 +509,7 @@ type LegacyProvider struct {
 	ProtectedResource                  string   `flag:"resource" cfg:"resource"`
 	ValidateURL                        string   `flag:"validate-url" cfg:"validate_url"`
 	Scope                              string   `flag:"scope" cfg:"scope"`
+	ResponseType                       string   `flag:"response-type" cfg:"response_type"`
 	Prompt                             string   `flag:"prompt" cfg:"prompt"`
 	ApprovalPrompt                     string   `flag:"approval-prompt" cfg:"approval_prompt"` // Deprecated by OIDC 1.0
 	UserIDClaim                        string   `flag:"user-id-claim" cfg:"user_id_claim"`
@@ -563,6 +564,7 @@ func legacyProviderFlagSet() *pflag.FlagSet {
 	flagSet.String("resource", "", "The resource that is protected (Azure AD only)")
 	flagSet.String("validate-url", "", "Access token validation endpoint")
 	flagSet.String("scope", "", "OAuth scope specification")
+	flagSet.String("response-type", "", "OAuth response_type parameter in authorization request")
 	flagSet.String("prompt", "", "OIDC prompt")
 	flagSet.String("approval-prompt", "force", "OAuth approval_prompt")
 	flagSet.String("code-challenge-method", "", "use PKCE code challenges with the specified method. Either 'plain' or 'S256'")
@@ -637,6 +639,7 @@ func (l *LegacyProvider) convert() (Providers, error) {
 		Scope:               l.Scope,
 		AllowedGroups:       l.AllowedGroups,
 		CodeChallengeMethod: l.CodeChallengeMethod,
+		ResponseType:        l.ResponseType,
 	}
 
 	// This part is out of the switch section for all providers that support OIDC

--- a/pkg/apis/options/providers.go
+++ b/pkg/apis/options/providers.go
@@ -74,6 +74,8 @@ type Provider struct {
 	ValidateURL string `json:"validateURL,omitempty"`
 	// Scope is the OAuth scope specification
 	Scope string `json:"scope,omitempty"`
+	// ResponseType tells the authorization server which grant to execute
+	ResponseType string `json:"responseType,omitempty"`
 	// AllowedGroups is a list of restrict logins to members of this group
 	AllowedGroups []string `json:"allowedGroups,omitempty"`
 	// The forced code challenge method

--- a/providers/provider_data.go
+++ b/providers/provider_data.go
@@ -37,6 +37,7 @@ type ProviderData struct {
 	ClientSecret      string
 	ClientSecretFile  string
 	Scope             string
+	ResponseType      string
 	// The picked CodeChallenge Method or empty if none.
 	CodeChallengeMethod string
 	// Code challenge methods supported by the Provider
@@ -179,12 +180,13 @@ func (p *ProviderData) setAllowedGroups(groups []string) {
 }
 
 type providerDefaults struct {
-	name        string
-	loginURL    *url.URL
-	redeemURL   *url.URL
-	profileURL  *url.URL
-	validateURL *url.URL
-	scope       string
+	name         string
+	loginURL     *url.URL
+	redeemURL    *url.URL
+	profileURL   *url.URL
+	validateURL  *url.URL
+	scope        string
+	responseType string
 }
 
 func (p *ProviderData) setProviderDefaults(defaults providerDefaults) {
@@ -193,6 +195,10 @@ func (p *ProviderData) setProviderDefaults(defaults providerDefaults) {
 	p.RedeemURL = defaultURL(p.RedeemURL, defaults.redeemURL)
 	p.ProfileURL = defaultURL(p.ProfileURL, defaults.profileURL)
 	p.ValidateURL = defaultURL(p.ValidateURL, defaults.validateURL)
+
+	if p.ResponseType == "" {
+		p.ResponseType = defaults.responseType
+	}
 
 	if p.Scope == "" {
 		p.Scope = defaults.scope

--- a/providers/provider_default_test.go
+++ b/providers/provider_default_test.go
@@ -70,6 +70,66 @@ func TestProviderDataEnrichSession(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 }
 
+func TestResponseTypeDefaultConfigured(t *testing.T) {
+	p := &ProviderData{
+		LoginURL: &url.URL{
+			Scheme: "http",
+			Host:   "my.test.idp",
+			Path:   "/oauth/authorize",
+		},
+	}
+
+	result := p.GetLoginURL("https://my.test.app/oauth", "", "", url.Values{})
+	assert.Contains(t, result, "response_type=code")
+}
+
+func TestResponseTypeIsConfigured(t *testing.T) {
+	p := &ProviderData{
+		LoginURL: &url.URL{
+			Scheme: "http",
+			Host:   "my.test.idp",
+			Path:   "/oauth/authorize",
+		},
+		ResponseType: "mytype",
+	}
+
+	result := p.GetLoginURL("https://my.test.app/oauth", "", "", url.Values{})
+	assert.Contains(t, result, "response_type=mytype")
+}
+
+func TestResponseTypeDefaultAndDataIsConfigured(t *testing.T) {
+	p := &ProviderData{
+		LoginURL: &url.URL{
+			Scheme: "http",
+			Host:   "my.test.idp",
+			Path:   "/oauth/authorize",
+		},
+		ResponseType: "mytype",
+	}
+	p.setProviderDefaults(providerDefaults{
+		responseType: "othertype",
+	})
+
+	result := p.GetLoginURL("https://my.test.app/oauth", "", "", url.Values{})
+	assert.Contains(t, result, "response_type=mytype")
+}
+
+func TestResponseTypeDefaultIsConfigured(t *testing.T) {
+	p := &ProviderData{
+		LoginURL: &url.URL{
+			Scheme: "http",
+			Host:   "my.test.idp",
+			Path:   "/oauth/authorize",
+		},
+	}
+	p.setProviderDefaults(providerDefaults{
+		responseType: "othertype",
+	})
+
+	result := p.GetLoginURL("https://my.test.app/oauth", "", "", url.Values{})
+	assert.Contains(t, result, "response_type=othertype")
+}
+
 func TestProviderDataAuthorize(t *testing.T) {
 	testCases := []struct {
 		name          string

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -76,6 +76,7 @@ func newProviderDataFromConfig(providerConfig options.Provider) (*ProviderData, 
 		ClientID:         providerConfig.ClientID,
 		ClientSecret:     providerConfig.ClientSecret,
 		ClientSecretFile: providerConfig.ClientSecretFile,
+		ResponseType:     providerConfig.ResponseType,
 	}
 
 	needsVerifier, err := providerRequiresOIDCProviderVerifier(providerConfig.Type)
@@ -161,6 +162,9 @@ func newProviderDataFromConfig(providerConfig options.Provider) (*ProviderData, 
 	}
 	if providerConfig.OIDCConfig.UserIDClaim == "" {
 		providerConfig.OIDCConfig.UserIDClaim = "email"
+	}
+	if p.ResponseType == "" {
+		p.ResponseType = "code"
 	}
 
 	p.setAllowedGroups(providerConfig.AllowedGroups)

--- a/providers/providers_test.go
+++ b/providers/providers_test.go
@@ -172,6 +172,51 @@ func TestScope(t *testing.T) {
 	}
 }
 
+func TestResponseType(t *testing.T) {
+	g := NewWithT(t)
+
+	testCases := []struct {
+		name                   string
+		configuredResponseType string
+		expectedResponseType   string
+		allowedGroups          []string
+	}{
+		{
+			name:                   "with no ResponseType provided",
+			configuredResponseType: "",
+			expectedResponseType:   "code",
+		},
+		{
+			name:                   "with a configured ResponseType provided",
+			configuredResponseType: "code id_token",
+			expectedResponseType:   "code id_token",
+		},
+	}
+
+	for _, tc := range testCases {
+		providerConfig := options.Provider{
+			ID:               providerID,
+			Type:             "oidc",
+			ClientID:         clientID,
+			ClientSecretFile: clientSecret,
+			LoginURL:         msAuthURL,
+			RedeemURL:        msTokenURL,
+			ResponseType:     tc.configuredResponseType,
+			AllowedGroups:    tc.allowedGroups,
+			OIDCConfig: options.OIDCOptions{
+				IssuerURL:     msIssuerURL,
+				SkipDiscovery: true,
+				JwksURL:       msKeysURL,
+			},
+		}
+
+		pd, err := newProviderDataFromConfig(providerConfig)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		g.Expect(pd.ResponseType).To(Equal(tc.expectedResponseType))
+	}
+}
+
 func TestForcedMethodS256(t *testing.T) {
 	g := NewWithT(t)
 	options := options.NewOptions()

--- a/providers/util.go
+++ b/providers/util.go
@@ -40,7 +40,7 @@ func makeLoginURL(p *ProviderData, redirectURI, state string, extraParams url.Va
 	params.Set("redirect_uri", redirectURI)
 	params.Add("scope", p.Scope)
 	params.Set("client_id", p.ClientID)
-	params.Set("response_type", "code")
+	params.Set("response_type", getResponseType(p))
 	params.Add("state", state)
 	for n, p := range extraParams {
 		for _, v := range p {
@@ -73,4 +73,11 @@ func formatGroup(rawGroup interface{}) (string, error) {
 		return "", err
 	}
 	return string(jsonGroup), nil
+}
+
+func getResponseType(p *ProviderData) string {
+	if p.ResponseType != "" {
+		return p.ResponseType
+	}
+	return "code"
 }


### PR DESCRIPTION
In order to get an id-token from azure a specific response_type needs to be set.

This was previously reported and fixed (https://github.com/oauth2-proxy/oauth2-proxy/issues/218) for azure specifically, but is no possible in the latest version.

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
