### PR TITLE
Update KeyCloak Auth Provider oidc_issuer_url

### DIFF
--- a/docs/docs/configuration/auth.md
+++ b/docs/docs/configuration/auth.md
@@ -192,7 +192,7 @@ Make sure you set the following to the appropriate url:
     --client-id=<your client's id>
     --client-secret=<your client's secret>
     --redirect-url=https://myapp.com/oauth2/callback
-    --oidc-issuer-url=https://<keycloak host>/auth/<your realm>/basic
+    --oidc-issuer-url=https://<keycloak host>/realms/<your realm>
     --allowed-role=<realm role name> // Optional, required realm role
     --allowed-role=<client id>:<client role name> // Optional, required client role
 ```


### PR DESCRIPTION
The correct URL for the oidc-issuer-url in KeyCloak v18.0 is: https://<keycloak host>/realms/<your realm>. 
Using the old URL causes oauth2-proxy to crash on startup.

## Description
Updating the documentation to support newer versions of KeyCloak

## Motivation and Context
The current recommended setting for the oidc-issuer-url in the documentation will cause oauth2-proxy to fail.

old url:  --oidc-issuer-url=https://<keycloak host>/auth/realms/<your realm>
new url: --oidc-issuer-url=https://<keycloak host>/realms/<your realm>

## How Has This Been Tested?
This has been tested using KeyCloak v18.0 on OpenShift
Viewing - https://sso-keyauth.apps-crc.testing/realms/master/.well-known/openid-configuration
Show issuer URL as:
"issuer":"https://sso-keyauth.apps-crc.testing/realms/master"

## Checklist:
- [ x ] My change requires a change to the documentation or CHANGELOG.
- [ x ] I have updated the documentation/CHANGELOG accordingly.
- [ x ] I have created a feature (non-master) branch for my PR.
