### PR TITLE
allow using X-Original-Forwarded-For header

### DIFF
--- a/pkg/ip/realclientip.go
+++ b/pkg/ip/realclientip.go
@@ -13,7 +13,7 @@ func GetRealClientIPParser(headerKey string) (ipapi.RealClientIPParser, error) {
 	headerKey = http.CanonicalHeaderKey(headerKey)
 
 	switch headerKey {
-	case http.CanonicalHeaderKey("X-Forwarded-For"), http.CanonicalHeaderKey("X-Real-IP"), http.CanonicalHeaderKey("X-ProxyUser-IP"):
+	case http.CanonicalHeaderKey("X-Forwarded-For"), http.CanonicalHeaderKey("X-Original-Forwarded-For"), http.CanonicalHeaderKey("X-Real-IP"), http.CanonicalHeaderKey("X-ProxyUser-IP"):
 		return &xForwardedForClientIPParser{header: headerKey}, nil
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Allow using IP address from `X-Original-Forwarded-For`

## Motivation and Context

Fixes https://github.com/oauth2-proxy/oauth2-proxy/issues/1675

## How Has This Been Tested?

I have verified this setup with AWS NLB + ingress-nginx 1.2.0

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
