### PR TITLE
Moving to scratch image as the base image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 ## Breaking Changes
 
 ## Changes since v7.3.0
+- [#1683](https://github.com/oauth2-proxy/oauth2-proxy/pull/1683) Start publishing scratch images (@sorenmat)
+
 - [#1691](https://github.com/oauth2-proxy/oauth2-proxy/pull/1691) Fix Redis IdleTimeout when Redis timeout option is set to non-zero (@dimss)
 
 - [#1669](https://github.com/oauth2-proxy/oauth2-proxy/pull/1699) Fix method deprecated error in lint (@t-katsumura)

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ RUN case ${TARGETPLATFORM} in \
 
 # Copy binary to alpine
 FROM ${RUNTIME_IMAGE}
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY nsswitch.conf /etc/nsswitch.conf
 COPY --from=builder /go/src/github.com/oauth2-proxy/oauth2-proxy/oauth2-proxy /bin/oauth2-proxy
 COPY --from=builder /go/src/github.com/oauth2-proxy/oauth2-proxy/jwt_signing_key.pem /etc/ssl/private/jwt_signing_key.pem

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ DOCKER_BUILD_PLATFORM ?= linux/amd64,linux/arm64,linux/ppc64le,linux/arm/v6,linu
 DOCKER_BUILD_RUNTIME_IMAGE ?= alpine:3.15
 DOCKER_BUILDX_ARGS ?= --build-arg RUNTIME_IMAGE=${DOCKER_BUILD_RUNTIME_IMAGE}
 DOCKER_BUILDX := docker buildx build ${DOCKER_BUILDX_ARGS} --build-arg VERSION=${VERSION}
+DOCKER_BUILDX_SCRATCH := --build-arg RUNTIME_IMAGE=scratch
 DOCKER_BUILDX_X_PLATFORM := $(DOCKER_BUILDX) --platform ${DOCKER_BUILD_PLATFORM}
 DOCKER_BUILDX_PUSH := docker buildx build --push ${DOCKER_BUILDX_ARGS} --build-arg VERSION=${VERSION}
 DOCKER_BUILDX_PUSH_X_PLATFORM := $(DOCKER_BUILDX_PUSH) --platform ${DOCKER_BUILD_PLATFORM}
@@ -53,15 +54,10 @@ docker:
 
 .PHONY: docker-all
 docker-all: docker
-	$(DOCKER_BUILDX) --platform linux/amd64 -t $(REGISTRY)/oauth2-proxy:latest-amd64 .
 	$(DOCKER_BUILDX_X_PLATFORM) -f Dockerfile -t $(REGISTRY)/oauth2-proxy:${VERSION} .
-	$(DOCKER_BUILDX) --platform linux/amd64 -t $(REGISTRY)/oauth2-proxy:${VERSION}-amd64 .
-	$(DOCKER_BUILDX) --platform linux/arm64 -t $(REGISTRY)/oauth2-proxy:latest-arm64 .
-	$(DOCKER_BUILDX) --platform linux/arm64 -t $(REGISTRY)/oauth2-proxy:${VERSION}-arm64 .
-	$(DOCKER_BUILDX) --platform linux/ppc64le -t $(REGISTRY)/oauth2-proxy:latest-ppc64le .
-	$(DOCKER_BUILDX) --platform linux/ppc64le -t $(REGISTRY)/oauth2-proxy:${VERSION}-ppc64le .
-	$(DOCKER_BUILDX) --platform linux/arm/v6 -t $(REGISTRY)/oauth2-proxy:latest-armv6 .
-	$(DOCKER_BUILDX) --platform linux/arm/v6 -t $(REGISTRY)/oauth2-proxy:${VERSION}-armv6 .
+	$(DOCKER_BUILDX_X_PLATFORM) -f Dockerfile -t $(REGISTRY)/oauth2-proxy:latest .
+	$(DOCKER_BUILDX_X_PLATFORM) $(DOCKER_BUILDX_SCRATCH) -f Dockerfile -t $(REGISTRY)/oauth2-proxy:latest-scratch .
+	$(DOCKER_BUILDX_X_PLATFORM) $(DOCKER_BUILDX_SCRATCH) -f Dockerfile -t $(REGISTRY)/oauth2-proxy:${VERSION}-scratch .
 
 .PHONY: docker-push
 docker-push:
@@ -69,15 +65,10 @@ docker-push:
 
 .PHONY: docker-push-all
 docker-push-all: docker-push
-	$(DOCKER_BUILDX_PUSH) --platform linux/amd64 -t $(REGISTRY)/oauth2-proxy:latest-amd64 .
 	$(DOCKER_BUILDX_PUSH_X_PLATFORM) -t $(REGISTRY)/oauth2-proxy:${VERSION} .
-	$(DOCKER_BUILDX_PUSH) --platform linux/amd64 -t $(REGISTRY)/oauth2-proxy:${VERSION}-amd64 .
-	$(DOCKER_BUILDX_PUSH) --platform linux/arm64 -t $(REGISTRY)/oauth2-proxy:latest-arm64 .
-	$(DOCKER_BUILDX_PUSH) --platform linux/arm64 -t $(REGISTRY)/oauth2-proxy:${VERSION}-arm64 .
-	$(DOCKER_BUILDX_PUSH) --platform linux/ppc64le -t $(REGISTRY)/oauth2-proxy:latest-ppc64le .
-	$(DOCKER_BUILDX_PUSH) --platform linux/ppc64le -t $(REGISTRY)/oauth2-proxy:${VERSION}-ppc64le .
-	$(DOCKER_BUILDX_PUSH) --platform linux/arm/v6 -t $(REGISTRY)/oauth2-proxy:latest-armv6 .
-	$(DOCKER_BUILDX_PUSH) --platform linux/arm/v6 -t $(REGISTRY)/oauth2-proxy:${VERSION}-armv6 .
+
+	$(DOCKER_BUILDX_PUSH_X_PLATFORM) $(DOCKER_BUILDX_SCRATCH) -t $(REGISTRY)/oauth2-proxy:latest-scratch .
+	$(DOCKER_BUILDX_PUSH_X_PLATFORM) $(DOCKER_BUILDX_SCRATCH) -t $(REGISTRY)/oauth2-proxy:${VERSION}-scratch .
 
 .PHONY: generate
 generate:


### PR DESCRIPTION
## Description

We are seeing quite a bit of vulnerabilities in the base images
from time to time. And since this is a staticly linked Go binary
we have the possiblity to run it from a scratch image reducing the
attack surface.

We need to copy over the public root certificates in order for SSL calls
to be supported.

We are now building the following images:
   latest
   latest-scratch
   VERSION
   VERSION-scratch

All of these images are build for the supported platforms.

Please note, this remove the explicit tagging of images with the
platform architecture like latest-arm64.

If one needs an explicit image you can pull with --platform=arm64

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

This is been manually tested in our environments (dev and prod) 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.