### PR TITLE
Add flags to define CSRF cookie expiration time and to allow CSRF cookies per request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,13 @@
 ## Release Highlights
 
 ## Important Notes
+- [#1504](https://github.com/oauth2-proxy/oauth2-proxy/pull/1583) Rename CSRF cookie to allow parallel callbacks (@YoavOst)
+  - Since the CSRF cookie name is now longer it could potentially break long cookie names (around 1000 characters).
 
 ## Breaking Changes
 
 ## Changes since v7.3.0
+- [#1504](https://github.com/oauth2-proxy/oauth2-proxy/pull/1583) Rename CSRF cookie to allow parallel callbacks (@YoavOst)
 
 # V7.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 ## Important Notes
 - [#1708](https://github.com/oauth2-proxy/oauth2-proxy/pull/1708) Enable different CSRF cookies per request (@miguelborges99)
   - Since the CSRF cookie name is now longer it could potentially break long cookie names (around 1000 characters).
-  - The CSRF cookie expiration time now depends on the time defined in flag "--cookie-csrf-expire".
+  - Having unique CSRF cookies per request can lead to quite a number of cookies, in case an application performs a high number of parallel authentication requests in the background. Each call will redirect to /oauth2/start, if the user is not authenticated, and a new cookie will be set. The requests successfully authenticated will have its CSRF cookies immediatly expired, however the failed ones will mantain its CSRF tokens and they expire by default in 15 minutes. 
+  - The user may redefine the CSRF cookie expiration time using flag "--cookie-csrf-expire" (e.g. --cookie-csrf-expire=5m).
     By default, it is 15 minutes.
 
 ## Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## Important Notes
 - [#1708](https://github.com/oauth2-proxy/oauth2-proxy/pull/1708) Enable different CSRF cookies per request (@miguelborges99)
   - Since the CSRF cookie name is now longer it could potentially break long cookie names (around 1000 characters).
-  - Having unique CSRF cookies per request can lead to quite a number of cookies, in case an application performs a high number of parallel authentication requests in the background. Each call will redirect to /oauth2/start, if the user is not authenticated, and a new cookie will be set. The requests successfully authenticated will have its CSRF cookies immediatly expired, however the failed ones will mantain its CSRF tokens and they expire by default in 15 minutes. 
+  - Having a unique CSRF cookie per request can lead to quite a number of cookies, in case an application performs a high number of parallel authentication requests. Each call will redirect to /oauth2/start, if the user is not authenticated, and a new cookie will be set. The successfully authenticated requests will have its CSRF cookies immediatly expired, however the failed ones will mantain its CSRF cookies until they expire (by default in 15 minutes). 
   - The user may redefine the CSRF cookie expiration time using flag "--cookie-csrf-expire" (e.g. --cookie-csrf-expire=5m). By default, it is 15 minutes, but you can fine tune to your environment.
 
 ## Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,7 @@
 - [#1708](https://github.com/oauth2-proxy/oauth2-proxy/pull/1708) Enable different CSRF cookies per request (@miguelborges99)
   - Since the CSRF cookie name is now longer it could potentially break long cookie names (around 1000 characters).
   - Having unique CSRF cookies per request can lead to quite a number of cookies, in case an application performs a high number of parallel authentication requests in the background. Each call will redirect to /oauth2/start, if the user is not authenticated, and a new cookie will be set. The requests successfully authenticated will have its CSRF cookies immediatly expired, however the failed ones will mantain its CSRF tokens and they expire by default in 15 minutes. 
-  - The user may redefine the CSRF cookie expiration time using flag "--cookie-csrf-expire" (e.g. --cookie-csrf-expire=5m).
-    By default, it is 15 minutes.
+  - The user may redefine the CSRF cookie expiration time using flag "--cookie-csrf-expire" (e.g. --cookie-csrf-expire=5m). By default, it is 15 minutes, but you can fine tune to your environment.
 
 ## Breaking Changes
 - [#1708](https://github.com/oauth2-proxy/oauth2-proxy/pull/1708) Enable different CSRF cookies per request (@miguelborges99)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,13 @@
 ## Release Highlights
 
 ## Important Notes
-- [#1504](https://github.com/oauth2-proxy/oauth2-proxy/pull/1583) Rename CSRF cookie to allow parallel callbacks (@YoavOst)
+- [#1708](https://github.com/oauth2-proxy/oauth2-proxy/pull/1708) Rename CSRF cookie to allow parallel callbacks (@YoavOst)
   - Since the CSRF cookie name is now longer it could potentially break long cookie names (around 1000 characters).
 
 ## Breaking Changes
 
 ## Changes since v7.3.0
-- [#1504](https://github.com/oauth2-proxy/oauth2-proxy/pull/1583) Rename CSRF cookie to allow parallel callbacks (@YoavOst)
+- [#1708](https://github.com/oauth2-proxy/oauth2-proxy/pull/1708) Rename CSRF cookie to allow parallel callbacks (@YoavOst)
 
 # V7.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,21 @@
 ## Release Highlights
 
 ## Important Notes
-- [#1708](https://github.com/oauth2-proxy/oauth2-proxy/pull/1708) Rename CSRF cookie to allow parallel callbacks (@YoavOst)
+- [#1708](https://github.com/oauth2-proxy/oauth2-proxy/pull/1708) Enable different CSRF cookies per request (@miguelborges99)
   - Since the CSRF cookie name is now longer it could potentially break long cookie names (around 1000 characters).
+  - The CSRF cookie expiration time now depends on the time defined in flag "--cookie-csrf-expire".
+    By default, it is 15 minutes.
 
 ## Breaking Changes
+- [#1708](https://github.com/oauth2-proxy/oauth2-proxy/pull/1708) Enable different CSRF cookies per request (@miguelborges99)
+  - The CSRF cookie expiration time now depends on the time defined in flag "--cookie-csrf-expire". 
+    By default, it is 15 minutes.
 
 ## Changes since v7.3.0
-- [#1708](https://github.com/oauth2-proxy/oauth2-proxy/pull/1708) Rename CSRF cookie to allow parallel callbacks (@YoavOst)
+- [#1708](https://github.com/oauth2-proxy/oauth2-proxy/pull/1708) Enable different CSRF cookies per request (@miguelborges99) 
+  - Add flag "--cookie-csrf-per-request" which activates an algorithm to name CSRF cookies differently per request. 
+    This feature allows parallel callbacks and by default it is disabled. 
+  - Add flag "--cookie-csrf-expire" to define a different expiration time for the CSRF cookie. By default, it is 15 minutes.
 
 # V7.3.0
 

--- a/docs/docs/configuration/overview.md
+++ b/docs/docs/configuration/overview.md
@@ -95,8 +95,8 @@ An example [oauth2-proxy.cfg](https://github.com/oauth2-proxy/oauth2-proxy/blob/
 | `--cookie-secret` | string | the seed string for secure cookies (optionally base64 encoded) | |
 | `--cookie-secure` | bool | set [secure (HTTPS only) cookie flag](https://owasp.org/www-community/controls/SecureFlag) | true |
 | `--cookie-samesite` | string | set SameSite cookie attribute (`"lax"`, `"strict"`, `"none"`, or `""`). | `""` |
-| `--cookie-csrf-per-request` | bool | use unique CSRF cookies per request, making it possible to have parallel callback requests. | false |
-| `--cookie-csrf-expire` | duration | define the CSRF cookie time-to-live duration | 15m |
+| `--cookie-csrf-per-request` | bool | Enable having different CSRF cookies per request, making it possible to have parallel requests. | false |
+| `--cookie-csrf-expire` | duration | expire timeframe for CSRF cookie | 15m |
 | `--custom-templates-dir` | string | path to custom html templates | |
 | `--custom-sign-in-logo` | string | path or a URL to an custom image for the sign_in page logo. Use \"-\" to disable default logo. |
 | `--display-htpasswd-form` | bool | display username / password login form if an htpasswd file is provided | true |

--- a/docs/docs/configuration/overview.md
+++ b/docs/docs/configuration/overview.md
@@ -95,6 +95,8 @@ An example [oauth2-proxy.cfg](https://github.com/oauth2-proxy/oauth2-proxy/blob/
 | `--cookie-secret` | string | the seed string for secure cookies (optionally base64 encoded) | |
 | `--cookie-secure` | bool | set [secure (HTTPS only) cookie flag](https://owasp.org/www-community/controls/SecureFlag) | true |
 | `--cookie-samesite` | string | set SameSite cookie attribute (`"lax"`, `"strict"`, `"none"`, or `""`). | `""` |
+| `--cookie-csrf-per-request` | bool | use unique CSRF cookies per request, making it possible to have parallel callback requests. | false |
+| `--cookie-csrf-expire` | duration | define the CSRF cookie time-to-live duration | 15m |
 | `--custom-templates-dir` | string | path to custom html templates | |
 | `--custom-sign-in-logo` | string | path or a URL to an custom image for the sign_in page logo. Use \"-\" to disable default logo. |
 | `--display-htpasswd-form` | bool | display username / password login form if an htpasswd file is provided | true |

--- a/pkg/apis/options/cookie.go
+++ b/pkg/apis/options/cookie.go
@@ -8,15 +8,17 @@ import (
 
 // Cookie contains configuration options relating to Cookie configuration
 type Cookie struct {
-	Name     string        `flag:"cookie-name" cfg:"cookie_name"`
-	Secret   string        `flag:"cookie-secret" cfg:"cookie_secret"`
-	Domains  []string      `flag:"cookie-domain" cfg:"cookie_domains"`
-	Path     string        `flag:"cookie-path" cfg:"cookie_path"`
-	Expire   time.Duration `flag:"cookie-expire" cfg:"cookie_expire"`
-	Refresh  time.Duration `flag:"cookie-refresh" cfg:"cookie_refresh"`
-	Secure   bool          `flag:"cookie-secure" cfg:"cookie_secure"`
-	HTTPOnly bool          `flag:"cookie-httponly" cfg:"cookie_httponly"`
-	SameSite string        `flag:"cookie-samesite" cfg:"cookie_samesite"`
+	Name           string        `flag:"cookie-name" cfg:"cookie_name"`
+	Secret         string        `flag:"cookie-secret" cfg:"cookie_secret"`
+	Domains        []string      `flag:"cookie-domain" cfg:"cookie_domains"`
+	Path           string        `flag:"cookie-path" cfg:"cookie_path"`
+	Expire         time.Duration `flag:"cookie-expire" cfg:"cookie_expire"`
+	Refresh        time.Duration `flag:"cookie-refresh" cfg:"cookie_refresh"`
+	Secure         bool          `flag:"cookie-secure" cfg:"cookie_secure"`
+	HTTPOnly       bool          `flag:"cookie-httponly" cfg:"cookie_httponly"`
+	SameSite       string        `flag:"cookie-samesite" cfg:"cookie_samesite"`
+	CSRFPerRequest bool          `flag:"cookie-csrf-per-request" cfg:"cookie_csrf_per_request"`
+	CSRFExpire     time.Duration `flag:"cookie-csrf-expire" cfg:"cookie_csrf_expire"`
 }
 
 func cookieFlagSet() *pflag.FlagSet {
@@ -31,21 +33,24 @@ func cookieFlagSet() *pflag.FlagSet {
 	flagSet.Bool("cookie-secure", true, "set secure (HTTPS) cookie flag")
 	flagSet.Bool("cookie-httponly", true, "set HttpOnly cookie flag")
 	flagSet.String("cookie-samesite", "", "set SameSite cookie attribute (ie: \"lax\", \"strict\", \"none\", or \"\"). ")
-
+	flagSet.Bool("cookie-csrf-per-request", false, "When this property is set to true, then the CSRF cookie name is built based on the state and varies per request. If property is set to false, then CSRF cookie has the same name for all requests.")
+	flagSet.Duration("cookie-csrf-expire", time.Duration(15)*time.Minute, "expire timeframe for CSRF cookie")
 	return flagSet
 }
 
 // cookieDefaults creates a Cookie populating each field with its default value
 func cookieDefaults() Cookie {
 	return Cookie{
-		Name:     "_oauth2_proxy",
-		Secret:   "",
-		Domains:  nil,
-		Path:     "/",
-		Expire:   time.Duration(168) * time.Hour,
-		Refresh:  time.Duration(0),
-		Secure:   true,
-		HTTPOnly: true,
-		SameSite: "",
+		Name:           "_oauth2_proxy",
+		Secret:         "",
+		Domains:        nil,
+		Path:           "/",
+		Expire:         time.Duration(168) * time.Hour,
+		Refresh:        time.Duration(0),
+		Secure:         true,
+		HTTPOnly:       true,
+		SameSite:       "",
+		CSRFPerRequest: false,
+		CSRFExpire:     time.Duration(15) * time.Minute,
 	}
 }

--- a/pkg/cookies/csrf.go
+++ b/pkg/cookies/csrf.go
@@ -48,6 +48,9 @@ type csrf struct {
 	time       clock.Clock
 }
 
+// csrtStateTrim will indicate the length of the state trimmed for the name of the csrf cookie
+const csrfStateLength int = 9
+
 // NewCSRF creates a CSRF with random nonces
 func NewCSRF(opts *options.Cookie, codeVerifier string) (CSRF, error) {
 	state, err := encryption.Nonce(32)
@@ -70,7 +73,21 @@ func NewCSRF(opts *options.Cookie, codeVerifier string) (CSRF, error) {
 
 // LoadCSRFCookie loads a CSRF object from a request's CSRF cookie
 func LoadCSRFCookie(req *http.Request, opts *options.Cookie) (CSRF, error) {
-	cookie, err := req.Cookie(csrfCookieName(opts))
+
+	// csrfCookieName will include a substring of the state to enable multiple csrf cookies
+	// in case of parallel requests
+	lastChar := csrfStateLength - 1
+
+	stateSubstring := ""
+	state := req.URL.Query()["state"]
+	if state[0] != "" {
+		state := state[0]
+		if lastChar <= len(state) {
+			stateSubstring = state[0:lastChar]
+		}
+	}
+
+	cookie, err := req.Cookie(csrfCookieName(opts, stateSubstring))
 	if err != nil {
 		return nil, err
 	}
@@ -182,11 +199,11 @@ func decodeCSRFCookie(cookie *http.Cookie, opts *options.Cookie) (*csrf, error) 
 // cookieName returns the CSRF cookie's name derived from the base
 // session cookie name
 func (c *csrf) cookieName() string {
-	return csrfCookieName(c.cookieOpts)
+	return csrfCookieName(c.cookieOpts, encryption.HashNonce(c.OAuthState)[0:csrfStateLength-1])
 }
 
-func csrfCookieName(opts *options.Cookie) string {
-	return fmt.Sprintf("%v_csrf", opts.Name)
+func csrfCookieName(opts *options.Cookie, stateSubstring string) string {
+	return fmt.Sprintf("%v_csrf_%v", opts.Name, stateSubstring)
 }
 
 func encrypt(data []byte, opts *options.Cookie) ([]byte, error) {

--- a/pkg/cookies/csrf_per_request_test.go
+++ b/pkg/cookies/csrf_per_request_test.go
@@ -14,7 +14,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("CSRF Cookie Tests", func() {
+var _ = Describe("CSRF Cookie with non-fixed name Tests", func() {
 	var (
 		cookieOpts  *options.Cookie
 		publicCSRF  CSRF
@@ -30,7 +30,8 @@ var _ = Describe("CSRF Cookie Tests", func() {
 			Expire:         time.Hour,
 			Secure:         true,
 			HTTPOnly:       true,
-			CSRFPerRequest: false,
+			CSRFPerRequest: true,
+			CSRFExpire:     time.Duration(5) * time.Minute,
 		}
 
 		var err error


### PR DESCRIPTION
## Description

This change adds a flag to define a expiration time for the CSRF cookie, and adds a flag to allow CSRF cookies per request.
If flag "--cookie-csrf-per-request" is set to true, then  a part of the state nonce is added to the CSRF name, making it possible to have parallel callback requests.

When having parallel ajax requests after the session cookie has expired multiple callbacks occur at the same time, creating multiple CSRF tokens with the name making it impossible for the proxy to authenticate.
It solves https://github.com/oauth2-proxy/oauth2-proxy/issues/1451 and possibly https://github.com/oauth2-proxy/oauth2-proxy/issues/817

Part of the pull request is copied from other pull request [1504](https://github.com/oauth2-proxy/oauth2-proxy/pull/1504), made by [YoavOst](https://github.com/YoavOst).

## Motivation and Context

In face of multiple oauth2 proxy callbacks, the CSRF cookie faces several concurrency problems:

- some requests may fail due to missing CSRF token, in case a concurrent request cleans up the cookie, or
- some requests may fail with CSRF token mismatch, since CSRF cookie value was overriden by other concurrent request.

This fix seems to solve both issues https://github.com/oauth2-proxy/oauth2-proxy/issues/1451 and https://github.com/oauth2-proxy/oauth2-proxy/issues/817 which have more than 2 years.

## How Has This Been Tested?

Deployed using docker-compose with OIDC (keycloak) provider and cookie session store and solve the parallel AJAX requests issue.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.