### PR TITLE
Allow Redis keys to be prefixed with a user-configurable string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Release Highlights
 
+- [#1711](https://github.com/oauth2-proxy/oauth2-proxy/pull/1711) Allow Redis keys to be prefixed with a user-configurable string (@chrisnovakovic)
+
 ## Important Notes
 
 ## Breaking Changes

--- a/docs/docs/configuration/overview.md
+++ b/docs/docs/configuration/overview.md
@@ -167,6 +167,7 @@ An example [oauth2-proxy.cfg](https://github.com/oauth2-proxy/oauth2-proxy/blob/
 | `--redis-sentinel-connection-urls` | string \| list | List of Redis sentinel connection URLs (e.g. `redis://HOST[:PORT]`). Used in conjunction with `--redis-use-sentinel` | |
 | `--redis-use-cluster` | bool | Connect to redis cluster. Must set `--redis-cluster-connection-urls` to use this feature | false |
 | `--redis-use-sentinel` | bool | Connect to redis via sentinels. Must set `--redis-sentinel-master-name` and `--redis-sentinel-connection-urls` to use this feature | false |
+| `--redis-key-prefix` | string | A string to prepend to each Redis key created or queried by oauth2-proxy. Useful for restricting access to keys used by oauth2-proxy via Redis ACLs | |
 | `--request-id-header` | string | Request header to use as the request ID in logging | X-Request-Id |
 | `--request-logging` | bool | Log requests | true |
 | `--request-logging-format` | string | Template for request log lines | see [Logging Configuration](#logging-configuration) |

--- a/docs/docs/configuration/sessions.md
+++ b/docs/docs/configuration/sessions.md
@@ -65,3 +65,7 @@ Redis Cluster is available to be the backend store as well. To leverage it, you 
 `--redis-use-cluster=true` flag, and configure the flags `--redis-cluster-connection-urls` appropriately.
 
 Note that flags `--redis-use-sentinel=true` and `--redis-use-cluster=true` are mutually exclusive.
+
+If `--redis-key-prefix` is specified, every key created or queried by oauth2-proxy is prepended with the given
+value. This makes it easier to prevent other users from reading or modifying oauth2-proxy's keys on a multi-tenant
+Redis server using [ACLs with key permissions](https://redis.io/docs/manual/security/acl/#key-permissions).

--- a/pkg/apis/options/alpha_options.go
+++ b/pkg/apis/options/alpha_options.go
@@ -43,6 +43,10 @@ type AlphaOptions struct {
 
 	// Providers is used to configure multiple providers.
 	Providers Providers `json:"providers,omitempty"`
+
+	// Redis is used to configure the Redis client. Redis may optionally be used as
+	// a session store.
+	Redis RedisStoreOptions `json:"redis,omitempty"`
 }
 
 // MergeInto replaces alpha options in the Options struct with the values
@@ -54,6 +58,7 @@ func (a *AlphaOptions) MergeInto(opts *Options) {
 	opts.Server = a.Server
 	opts.MetricsServer = a.MetricsServer
 	opts.Providers = a.Providers
+	opts.Session.Redis = a.Redis
 }
 
 // ExtractFrom populates the fields in the AlphaOptions with the values from
@@ -65,4 +70,5 @@ func (a *AlphaOptions) ExtractFrom(opts *Options) {
 	a.Server = opts.Server
 	a.MetricsServer = opts.MetricsServer
 	a.Providers = opts.Providers
+	a.Redis = opts.Session.Redis
 }

--- a/pkg/apis/options/options.go
+++ b/pkg/apis/options/options.go
@@ -143,6 +143,7 @@ func NewFlagSet() *pflag.FlagSet {
 	flagSet.StringSlice("redis-sentinel-connection-urls", []string{}, "List of Redis sentinel connection URLs (eg redis://HOST[:PORT]). Used in conjunction with --redis-use-sentinel")
 	flagSet.Bool("redis-use-cluster", false, "Connect to redis cluster. Must set --redis-cluster-connection-urls to use this feature")
 	flagSet.StringSlice("redis-cluster-connection-urls", []string{}, "List of Redis cluster connection URLs (eg redis://HOST[:PORT]). Used in conjunction with --redis-use-cluster")
+	flagSet.String("redis-key-prefix", "", "A string to prepend to each Redis key created or queried by oauth2-proxy. Useful for restricting access to keys used by oauth2-proxy via Redis ACLs")
 
 	flagSet.String("signature-key", "", "GAP-Signature request signature key (algorithm:secretkey)")
 	flagSet.Bool("gcp-healthchecks", false, "Enable GCP/GKE healthcheck endpoints")

--- a/pkg/apis/options/sessions.go
+++ b/pkg/apis/options/sessions.go
@@ -32,6 +32,7 @@ type RedisStoreOptions struct {
 	ClusterConnectionURLs  []string `flag:"redis-cluster-connection-urls" cfg:"redis_cluster_connection_urls"`
 	CAPath                 string   `flag:"redis-ca-path" cfg:"redis_ca_path"`
 	InsecureSkipTLSVerify  bool     `flag:"redis-insecure-skip-tls-verify" cfg:"redis_insecure_skip_tls_verify"`
+	KeyPrefix              string   `flag:"redis-key-prefix" cfg:"redis_key_prefix"`
 }
 
 func sessionOptionsDefaults() SessionOptions {

--- a/pkg/apis/options/sessions.go
+++ b/pkg/apis/options/sessions.go
@@ -22,17 +22,20 @@ type CookieStoreOptions struct {
 
 // RedisStoreOptions contains configuration options for the RedisSessionStore.
 type RedisStoreOptions struct {
-	ConnectionURL          string   `flag:"redis-connection-url" cfg:"redis_connection_url"`
-	Password               string   `flag:"redis-password" cfg:"redis_password"`
-	UseSentinel            bool     `flag:"redis-use-sentinel" cfg:"redis_use_sentinel"`
-	SentinelPassword       string   `flag:"redis-sentinel-password" cfg:"redis_sentinel_password"`
-	SentinelMasterName     string   `flag:"redis-sentinel-master-name" cfg:"redis_sentinel_master_name"`
-	SentinelConnectionURLs []string `flag:"redis-sentinel-connection-urls" cfg:"redis_sentinel_connection_urls"`
-	UseCluster             bool     `flag:"redis-use-cluster" cfg:"redis_use_cluster"`
-	ClusterConnectionURLs  []string `flag:"redis-cluster-connection-urls" cfg:"redis_cluster_connection_urls"`
-	CAPath                 string   `flag:"redis-ca-path" cfg:"redis_ca_path"`
-	InsecureSkipTLSVerify  bool     `flag:"redis-insecure-skip-tls-verify" cfg:"redis_insecure_skip_tls_verify"`
-	KeyPrefix              string   `flag:"redis-key-prefix" cfg:"redis_key_prefix"`
+	ConnectionURL          string   `json:"-" flag:"redis-connection-url" cfg:"redis_connection_url"`
+	Password               string   `json:"-" flag:"redis-password" cfg:"redis_password"`
+	UseSentinel            bool     `json:"-" flag:"redis-use-sentinel" cfg:"redis_use_sentinel"`
+	SentinelPassword       string   `json:"-" flag:"redis-sentinel-password" cfg:"redis_sentinel_password"`
+	SentinelMasterName     string   `json:"-" flag:"redis-sentinel-master-name" cfg:"redis_sentinel_master_name"`
+	SentinelConnectionURLs []string `json:"-" flag:"redis-sentinel-connection-urls" cfg:"redis_sentinel_connection_urls"`
+	UseCluster             bool     `json:"-" flag:"redis-use-cluster" cfg:"redis_use_cluster"`
+	ClusterConnectionURLs  []string `json:"-" flag:"redis-cluster-connection-urls" cfg:"redis_cluster_connection_urls"`
+	CAPath                 string   `json:"-" flag:"redis-ca-path" cfg:"redis_ca_path"`
+	InsecureSkipTLSVerify  bool     `json:"-" flag:"redis-insecure-skip-tls-verify" cfg:"redis_insecure_skip_tls_verify"`
+	// KeyPrefix is a string to prepend to each Redis key created or queried by
+	// oauth2-proxy. This is useful for restricting access to keys used by
+	// oauth2-proxy via Redis ACLs.
+	KeyPrefix string `json:"keyPrefix,omitempty" flag:"redis-key-prefix" cfg:"redis_key_prefix"`
 }
 
 func sessionOptionsDefaults() SessionOptions {

--- a/pkg/validation/sessions.go
+++ b/pkg/validation/sessions.go
@@ -57,7 +57,7 @@ func validateRedisSessionStore(o *options.Options) []string {
 	}
 	nonce := base64.RawURLEncoding.EncodeToString(n)
 
-	key := fmt.Sprintf("%s-healthcheck-%s", o.Cookie.Name, nonce)
+	key := fmt.Sprintf("%s%s-healthcheck-%s", o.Session.Redis.KeyPrefix, o.Cookie.Name, nonce)
 	return sendRedisConnectionTest(client, key, nonce)
 }
 


### PR DESCRIPTION
## Description

Add a `--redis-key-prefix` command line option (and `redis_key_prefix` configuration file setting) defining a string that is prepended to all Redis keys created and queried by oauth2-proxy. This makes it possible to enforce an access control policy on keys used by oauth2-proxy via Redis ACLs. The default value is the empty string for backwards compatibility.

## Motivation and Context

This PR makes it safer to store oauth2-proxy's session data on a multi-tenant Redis instance, with the help of [ACLs](https://redis.io/docs/manual/security/acl/) (added in Redis 6) and [key permissions](https://redis.io/docs/manual/security/acl/#key-permissions) (added in Redis 7). For instance, when oauth2-proxy is invoked with `--redis-connection-url=redis://oauth2_proxy:<password>@127.0.0.1:6379 --redis-key-prefix=oauth2_proxy:`, oauth2-proxy can be prevented from accessing other users' keys by granting it the `~oauth2_proxy:*` key permission. Other users can be prevented from accessing oauth2-proxy's data via ACLs that use key permissions and possibly [selectors](https://redis.io/docs/manual/security/acl/#selectors) (also added in Redis 7).

Without this change, the only way to partition oauth2-proxy's data and other Redis users' data is to either:

* Set the `db` query parameter in `--redis-connection-url` to the ID of an unused database. However, databases do not have a sound access control policy, [there are no plans to implement one](https://github.com/redis/redis/issues/8099), and [the database feature is slated for removal in a future version of Redis anyway](https://github.com/redis/redis/issues/8099#issuecomment-741868975).
* Rely on the fact that Redis keys are already implicitly prefixed with the value of `--cookie-name`, and enforce access control policies using the key permission `~<cookie name>*`. However, cookie names are user-facing and it may not be desirable to change them just so that ACLs can be enforced on session data cached by the back-end.

## How Has This Been Tested?

I've verified that keys are created with the correct name by running oauth2-proxy with the following configuration:

```
cookie_name = "_auth"
session_store_type = "redis"
redis_connection_url = "redis://oauth2_proxy:<password>@127.0.0.1:6379"
redis_key_prefix = "oauth2_proxy:"
```

and confirming which keys are present on the Redis server after authenticating once with oauth2-proxy:

```
# redis-cli
127.0.0.1:6379> keys *
1) "oauth2_proxy:_auth-f625df562f54e109cc73ac95fe143b63"
127.0.0.1:6379>
```

I'm able to use the proxied webapp without encountering any further authentication requests from oauth2-proxy, indicating that the correct keys are also being used during session lookups.

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.