### PR TITLE
Extract Keycloak roles while creating a session from token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Changes since v7.3.0
 
+- [#1720](https://github.com/oauth2-proxy/oauth2-proxy/pull/1720) Extract roles from authToken, to allow using allowed roles with Keycloak.
+
 # V7.3.0
 
 ## Release Highlights

--- a/providers/keycloak_oidc.go
+++ b/providers/keycloak_oidc.go
@@ -6,6 +6,9 @@ import (
 
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/sessions"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/logger"
+	"github.com/pkg/errors"
+	"golang.org/x/oauth2"
 )
 
 const keycloakOIDCProviderName = "Keycloak OIDC"
@@ -41,6 +44,38 @@ func (p *KeycloakOIDCProvider) addAllowedRoles(roles []string) {
 	for _, role := range roles {
 		p.AllowedGroups[formatRole(role)] = struct{}{}
 	}
+}
+
+// CreateSessionFromToken converts Bearer IDTokens into sessions
+func (p *KeycloakOIDCProvider) CreateSessionFromToken(ctx context.Context, token string) (*sessions.SessionState, error) {
+	logger.Printf("calling CreateSessionFromToken: %s", token)
+
+	idToken, err := p.Verifier.Verify(ctx, token)
+	if err != nil {
+		return nil, err
+	}
+
+	ss, err := p.buildSessionFromClaims(token, "")
+	if err != nil {
+		return nil, err
+	}
+	// Allow empty Email in Bearer case since we can't hit the ProfileURL
+	if ss.Email == "" {
+		ss.Email = ss.User
+	}
+
+	ss.AccessToken = token
+	ss.IDToken = token
+	ss.RefreshToken = ""
+	ss.CreatedAtNow()
+	ss.SetExpiresOn(idToken.Expiry)
+
+	// Extract custom keycloak roles and enrich session
+	if err := p.extractRoles(ctx, ss); err != nil {
+		return nil, err
+	}
+
+	return ss, nil
 }
 
 // EnrichSession is called after Redeem to allow providers to enrich session fields
@@ -144,4 +179,42 @@ func getClientRoles(claims *accessClaims) []string {
 
 func formatRole(role string) string {
 	return fmt.Sprintf("role:%s", role)
+}
+
+// createSession takes an oauth2.Token and creates a SessionState from it.
+// It alters behavior if called from Redeem vs Refresh
+func (p *KeycloakOIDCProvider) createSession(ctx context.Context, token *oauth2.Token, refresh bool) (*sessions.SessionState, error) {
+	logger.Printf("calling createSession: %s", token)
+	_, err := p.verifyIDToken(ctx, token)
+	if err != nil {
+		switch err {
+		case ErrMissingIDToken:
+			// IDToken is mandatory in Redeem but optional in Refresh
+			if !refresh {
+				return nil, errors.New("token response did not contain an id_token")
+			}
+		default:
+			return nil, fmt.Errorf("could not verify id_token: %v", err)
+		}
+	}
+
+	rawIDToken := getIDToken(token)
+	ss, err := p.buildSessionFromClaims(rawIDToken, token.AccessToken)
+	if err != nil {
+		return nil, err
+	}
+
+	ss.AccessToken = token.AccessToken
+	ss.RefreshToken = token.RefreshToken
+	ss.IDToken = rawIDToken
+
+	ss.CreatedAtNow()
+	ss.SetExpiresOn(token.Expiry)
+
+	// Extract custom keycloak roles and enrich session
+	if err := p.extractRoles(ctx, ss); err != nil {
+		return nil, err
+	}
+
+	return ss, nil
 }

--- a/providers/keycloak_oidc_test.go
+++ b/providers/keycloak_oidc_test.go
@@ -199,4 +199,22 @@ var _ = Describe("Keycloak OIDC Provider Tests", func() {
 			Expect(existingSession.Groups).To(BeEquivalentTo([]string{"role:write", "role:default:read"}))
 		})
 	})
+
+	Context("Create new session from token", func() {
+		It("should create a session and extract roles ", func() {
+			server, provider := newTestKeycloakOIDCSetup()
+			url, err := url.Parse(server.URL)
+			Expect(err).To(BeNil())
+			defer server.Close()
+
+			provider.ProfileURL = url
+
+			session, err := provider.CreateSessionFromToken(context.Background(), getAccessToken())
+			Expect(err).To(BeNil())
+			Expect(session.ExpiresOn).ToNot(BeNil())
+			Expect(session.CreatedAt).ToNot(BeNil())
+			Expect(session.Groups).To(BeEquivalentTo([]string{"role:write", "role:default:read"}))
+		})
+	})
+
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
While creating a new Session from an AuthToken the Keycloak roles needs to be extracted. Otherwise they're not part of the session which will break the authentication. (AllowedGroups doesn't match givenGroups.. because it's empty). Since `CreateSessionFromToken` was already used from the OIDC provider, adding a single line shouldn't break anything.
<!--- Describe your changes in detail -->

## Motivation and Context
The main motivation is to fix https://github.com/oauth2-proxy/oauth2-proxy/issues/1457#. It blocks user's from authenticating via token in combination with role checks

## How Has This Been Tested?

Besides alot of manual testing I've also added a small unit test.

To reproduce the issue you need to create an Keycloak Client and a user. Create a auth token and try to authenticate against the proxy using the token.  Use the following settings for the proxy:
``
          "--client-id=xxxxx",
          "--client-secret=xxxx",
          "--upstream=xxxxx",
          "--oidc-issuer-url=xxxxxx",
          "--redeem-url=xxxxxx",
          "--redirect-url=xxxxxx",
          "--http-address=xxxxx",
          "--auth-logging=true",
          "--email-domain=*",
          "--cookie-secret=xxxx",
          "--standard-logging=true",
          "--auth-logging=true",
          "--request-logging=true",
          "--whitelist-domain=xxxxxxx",
          "--skip-provider-button=true",
          "--skip-jwt-bearer-tokens=true",
          "--pass-authorization-header=true",
          "--pass-access-token=true",
          "--pass-user-headers=true",
          "--allowed-role=realm-access-role",
          "--cookie-secure=false",
          "--scope=openid email profile",
          "--skip-auth-route=/health"``
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
