### PR TITLE
Rename cookie-domain to cookie-domains in docs

### DIFF
--- a/docs/docs/configuration/overview.md
+++ b/docs/docs/configuration/overview.md
@@ -86,7 +86,7 @@ An example [oauth2-proxy.cfg](https://github.com/oauth2-proxy/oauth2-proxy/blob/
 | `--client-secret-file` | string | the file with OAuth Client Secret | |
 | `--code-challenge-method` | string | use PKCE code challenges with the specified method. Either 'plain' or 'S256' (recommended) | |
 | `--config` | string | path to config file | |
-| `--cookie-domain` | string \| list | Optional cookie domains to force cookies to (e.g. `.yourcompany.com`). The longest domain matching the request's host will be used (or the shortest cookie domain if there is no match). | |
+| `--cookie-domains` | string \| list | Optional cookie domains to force cookies to (e.g. `.yourcompany.com`). The longest domain matching the request's host will be used (or the shortest cookie domain if there is no match). | |
 | `--cookie-expire` | duration | expire timeframe for cookie | 168h0m0s |
 | `--cookie-httponly` | bool | set HttpOnly cookie flag | true |
 | `--cookie-name` | string | the name of the cookie that the oauth_proxy creates | `"_oauth2_proxy"` |


### PR DESCRIPTION
Change config documentation so "--cookie-domain" reads "--cookie-domains"

## Description

Adds an s to the config parameter

## Motivation and Context

It appears this config name was changed by this PR - but presumably not updated in the docs.

https://github.com/oauth2-proxy/oauth2-proxy/pull/559


## How Has This Been Tested?

I'm using environment variables for configuration so I've tested with both `OAUTH2_PROXY_COOKIE_DOMAIN` and `OAUTH2_PROXY_COOKIE_DOMAINS` as env var name, and can confirm (according to chrome dev tools) that the domain only gets set correctly when the S is there in the config.

## Checklist:


- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
