### PR TITLE
Added AllowedGroupsHeader option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Changes since v7.3.0
 
+- [#1727](https://github.com/oauth2-proxy/oauth2-proxy/pull/1727) Get extra AllowedGroups from header. `--allowed-groups-header` option make oauth2-proxy to use the header value as additionally group-list to authorize users. Usefull if need differents groups for differents paths and applications. Multiple groups in header value is allowed separates by comma. 
 - [#1709](https://github.com/oauth2-proxy/oauth2-proxy/pull/1709) Show an alert message when basic auth credentials are invalid (@aiciobanu)
 
 # V7.3.0

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -1127,20 +1127,20 @@ func checkAllowedGroupsFromHeader(s *sessionsapi.SessionState, headerValue strin
 	if len(headerValue) == 0 {
 		return true
 	}
-	if len(headerValue) > 128 {
-		logger.Errorf("Header '%s' has too long value. Deny for perfomance protection", headerValue)
+	// if user send his own header with long fake list of groups
+	if len(headerValue) > 256 {
+		logger.Errorf("Error with authorization: header '%s' has too long value. Deny for a performance protection", headerValue)
 		return false
 	}
 	for _, allowed_group := range strings.Split(headerValue, ",") {
 		for _, granted_group := range s.Groups {
 			if allowed_group == granted_group {
-				logger.Printf("(Allowed) User is in %s.", headerValue)
 				return true
 			}
 		}
 	}
 
-	logger.Printf("User %s is not in %s group. Deny access.", s.Email, headerValue)
+	logger.Printf("Invalid authorization: %s is not in %s group.", s.Email, headerValue)
 	return false
 }
 

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -1128,7 +1128,7 @@ func checkAllowedGroupsFromHeader(s *sessionsapi.SessionState, headerValue strin
 		return true
 	}
 	// if user send his own header with long fake list of groups
-	if len(headerValue) > 256 {
+	if len(headerValue) > 1000 {
 		logger.Errorf("Error with authorization: header '%s' has too long value. Deny for a performance protection", headerValue)
 		return false
 	}

--- a/pkg/apis/options/legacy_options.go
+++ b/pkg/apis/options/legacy_options.go
@@ -520,7 +520,7 @@ type LegacyProvider struct {
 	UserIDClaim                        string   `flag:"user-id-claim" cfg:"user_id_claim"`
 	AllowedGroups                      []string `flag:"allowed-group" cfg:"allowed_groups"`
 	AllowedRoles                       []string `flag:"allowed-role" cfg:"allowed_roles"`
-	AllowedGroupsHeader                string   `flag:"allowed-groups-header" cfg:"allowed_group_header"`
+	AllowedGroupsHeader                string   `flag:"allowed-groups-header" cfg:"allowed_groups_header"`
 
 	AcrValues  string `flag:"acr-values" cfg:"acr_values"`
 	JWTKey     string `flag:"jwt-key" cfg:"jwt_key"`

--- a/pkg/apis/options/legacy_options.go
+++ b/pkg/apis/options/legacy_options.go
@@ -520,6 +520,7 @@ type LegacyProvider struct {
 	UserIDClaim                        string   `flag:"user-id-claim" cfg:"user_id_claim"`
 	AllowedGroups                      []string `flag:"allowed-group" cfg:"allowed_groups"`
 	AllowedRoles                       []string `flag:"allowed-role" cfg:"allowed_roles"`
+	AllowedGroupsHeader                string   `flag:"allowed-groups-header" cfg:"allowed_group_header"`
 
 	AcrValues  string `flag:"acr-values" cfg:"acr_values"`
 	JWTKey     string `flag:"jwt-key" cfg:"jwt_key"`
@@ -581,6 +582,7 @@ func legacyProviderFlagSet() *pflag.FlagSet {
 	flagSet.String("user-id-claim", OIDCEmailClaim, "(DEPRECATED for `oidc-email-claim`) which claim contains the user ID")
 	flagSet.StringSlice("allowed-group", []string{}, "restrict logins to members of this group (may be given multiple times)")
 	flagSet.StringSlice("allowed-role", []string{}, "(keycloak-oidc) restrict logins to members of these roles (may be given multiple times)")
+	flagSet.String("allowed-groups-header", "", "name of the header containing a list of additionally required groups")
 
 	return flagSet
 }
@@ -642,6 +644,7 @@ func (l *LegacyProvider) convert() (Providers, error) {
 		ValidateURL:         l.ValidateURL,
 		Scope:               l.Scope,
 		AllowedGroups:       l.AllowedGroups,
+		AllowedGroupsHeader: l.AllowedGroupsHeader,
 		CodeChallengeMethod: l.CodeChallengeMethod,
 	}
 

--- a/pkg/apis/options/providers.go
+++ b/pkg/apis/options/providers.go
@@ -76,6 +76,9 @@ type Provider struct {
 	Scope string `json:"scope,omitempty"`
 	// AllowedGroups is a list of restrict logins to members of this group
 	AllowedGroups []string `json:"allowedGroups,omitempty"`
+	// AllowedGroupsHeader is a name of the header containing a list of additionally required groups.
+	// User must be a member of this group and any from 'AllowedGroups' at the same time
+	AllowedGroupsHeader string `json:"AllowedGroupsHeader,omitempty"`
 	// The forced code challenge method
 	CodeChallengeMethod string `json:"force_code_challenge_method,omitempty"`
 }

--- a/providers/provider_data.go
+++ b/providers/provider_data.go
@@ -51,7 +51,8 @@ type ProviderData struct {
 
 	// Universal Group authorization data structure
 	// any provider can set to consume
-	AllowedGroups map[string]struct{}
+	AllowedGroups       map[string]struct{}
+	AllowedGroupsHeader string
 
 	getAuthorizationHeaderFunc func(string) http.Header
 	loginURLParameterDefaults  url.Values
@@ -176,6 +177,10 @@ func (p *ProviderData) setAllowedGroups(groups []string) {
 	for _, group := range groups {
 		p.AllowedGroups[group] = struct{}{}
 	}
+}
+
+func (p *ProviderData) setAllowedGroupsHeader(groupsHeader string) {
+	p.AllowedGroupsHeader = groupsHeader
 }
 
 type providerDefaults struct {

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -164,6 +164,7 @@ func newProviderDataFromConfig(providerConfig options.Provider) (*ProviderData, 
 	}
 
 	p.setAllowedGroups(providerConfig.AllowedGroups)
+	p.setAllowedGroupsHeader(providerConfig.AllowedGroupsHeader)
 
 	return p, nil
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added option `--allowed-groups-header` (`allowed_groups_header` in configfile) which allow us to authorize logins based on groups in request header.
The `allowed-groups-header` and `allowed-groups`  options are checked independently, and both must match user groups.

## Motivation and Context
This allow:
1. Use single oauth2-proxy deployment for multiple applications 
2. Authorize different path for differents groups

## How Has This Been Tested?

Deployed using helm chart in kubernetes 
with istio.

I'he done this:
1. Run oauth2-proxy with `--allowed-groups-header=X-Header-Allowed-Groups-Example` option

2. added to istio MeshConfig
```
    extensionProviders:
    - name: oauth2-proxy
      envoyExtAuthzHttp:
        service: oauth2-proxy.oauth2-proxy.svc.cluster.local
        port: 80
        timeout: 2s
        includeHeadersInCheck: ["authorization", "cookie", "X-Header-Allowed-Groups-Example"] ## <--
        headersToUpstreamOnAllow: ["x-forwarded-access-token", "authorization", "path", "x-auth-request-user", "x-auth-request-email", "x-auth-request-access-token"]
        headersToDownstreamOnDeny: ["content-type", "set-cookie"]
```
3. created istio AuthorizationPolicy:
```
kind: AuthorizationPolicy
apiVersion: security.istio.io/v1beta1
metadata:
  name: myaplication
spec:
  selector:
    matchLabels:
      app: myaplication   ## must match Myapp sidecar / not gateway
  action: CUSTOM
  provider:
    name: oauth2-proxy
  rules:
    - to:
        - operation:
            hosts: ["protectme.mycompany.com"]
            noPaths: ["/public"]
```
On this point enought to authorize users based on `allowed-groups` option in oauth2-proxy. 
But we want more

4. created istio virtualservice
```
apiVersion: networking.istio.io/v1beta1
kind: VirtualService
metadata:
  name: myaplication
spec:
  gateways:
  - istio-system/istio-ingressgateway
  hosts:
  - protectme.mycompany.com
  http:
  - match:
    - uri:
        prefix: "/admins"
    headers:
      request:
        set:                 ## 'set' - adds header and override it if request already has it
          X-Header-Allowed-Groups-Example: AD-Myapp-Admins  ## header name eq --allowed-groups-header
    route:
    - destination:
        host: myaplication
        port:
          number: 443
  - match:
    - uri:
        prefix: "/managers"
    headers:
      request:
        set:
          X-Header-Allowed-Groups-Example: AD-Myapp-Manager,AD-Myapp-Admins
    route:
    - destination:
        host: myaplication
        port:
          number: 443
  - headers:
      request:
        set:
          X-Header-Allowed-Groups-Example: AD-Myapp-Users,AD-Myapp-Manager,AD-Myapp-Admins
    route:
    - destination:
        host: myaplication
        port:
          number: 443
```
5. 
- Users in AD-Myapp-Admins group could access to `protectme.mycompany.com/` with all paths 
- Users in AD-Myapp-Manager group could access to `protectme.mycompany.com/` except `/admins`
- Users in AD-Myapp-Users group could access to `protectme.mycompany.com/` except `/admins` and `/managers`
- `protectme.mycompany.com/public` - allowed access everybody (we excluded it in AuthorizationPolicy)

6. Also the users should have any group from `allowed-groups` additionally to groups from the header 

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
