### PR TITLE
Hide bearer token from log on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## Changes since v7.3.0
 
 - [#1709](https://github.com/oauth2-proxy/oauth2-proxy/pull/1709) Show an alert message when basic auth credentials are invalid (@aiciobanu)
+- [#1743](https://github.com/oauth2-proxy/oauth2-proxy/pull/1743) Hide bearer token from log on error from the security point of view (@t-katsumura)
 
 # V7.3.0
 

--- a/pkg/middleware/basic_session.go
+++ b/pkg/middleware/basic_session.go
@@ -93,7 +93,7 @@ func findBasicCredentialsFromHeader(header string) (string, string, error) {
 	}
 
 	if tokenType != "Basic" {
-		return "", "", fmt.Errorf("invalid Authorization header: %q", header)
+		return "", "", fmt.Errorf("invalid token type in Authorization header: %q", tokenType)
 	}
 
 	user, password, err := getBasicAuthCredentials(token)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Hide raw bearer token from log from the security point of view.

oauth2-proxy output raw bearer token in logs when both `htpasswd_file`  and `skip_jwt_bearer_tokens` are used.
i.e.
```
htpasswd_file="/opt/oauth2proxy/basic/htpasswd"
skip_jwt_bearer_tokens="true"
```

If someone might get the token from logs, they can call api through oauth2-proxy.
This problem is caused by the specification that the session is considered to be valid even token had been expired (see jwt_session.go below).

https://github.com/oauth2-proxy/oauth2-proxy/blob/db74661e1099f27b07f7fb94469c94afcaf037bc/pkg/middleware/jwt_session.go#L49-L56

**Before fixation (token is shown in log)**
<img width="535" alt="before" src="https://user-images.githubusercontent.com/83070078/181925772-11c95ac4-72c0-49f1-9eb7-89fc13263c9a.PNG">

**After fixation (token is not shown in log)**
<img width="535" alt="after" src="https://user-images.githubusercontent.com/83070078/181925790-ca06c8f2-644a-4aca-aa4f-4a311f38de01.PNG">


## Motivation and Context

Output confidential information into log is not good from the security point of view.

## How Has This Been Tested?

Tested on my local environment with `make test` command.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
