### PR TITLE
docs/docs/configuration/auth: fixed example of oidc-issuer-url for Keycloak

### DIFF
--- a/docs/docs/configuration/auth.md
+++ b/docs/docs/configuration/auth.md
@@ -192,7 +192,7 @@ Make sure you set the following to the appropriate url:
     --client-id=<your client's id>
     --client-secret=<your client's secret>
     --redirect-url=https://myapp.com/oauth2/callback
-    --oidc-issuer-url=https://<keycloak host>/realms/<your realm>
+    --oidc-issuer-url=https://<keycloak host>/auth/realms/<your realm>
     --allowed-role=<realm role name> // Optional, required realm role
     --allowed-role=<client id>:<client role name> // Optional, required client role
 ```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixed docs

## Motivation and Context

The example will produce error

```python
[2022/08/15 20:35:32] [provider.go:55] Performing OIDC Discovery...
[2022/08/15 20:35:32] [main.go:60] ERROR: Failed to initialise OAuth2 Proxy: error intiailising provider: could not create provider data: error building OIDC ProviderVerifier: could not get verifier builder: er
ror while discovery OIDC configuration: failed to discover OIDC configuration: unexpected status "404": {"error":"Realm does not exist"}
```