### PR TITLE
Inconsistent code-challenge-method CLI flag and config file naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ## Changes since v7.3.0
 
+- [#1667](https://github.com/oauth2-proxy/oauth2-proxy/issues/1667) Rename configuration file flag for PKCE
+to remain consistent with CLI flags. You should specify `code_challenge_method` in your configuration instead of
+`force_code_challenge_method`.
+
 # V7.3.0
 
 ## Release Highlights

--- a/docs/docs/configuration/alpha_config.md
+++ b/docs/docs/configuration/alpha_config.md
@@ -419,7 +419,7 @@ Provider holds all configuration for a single provider
 | `validateURL` | _string_ | ValidateURL is the access token validation endpoint |
 | `scope` | _string_ | Scope is the OAuth scope specification |
 | `allowedGroups` | _[]string_ | AllowedGroups is a list of restrict logins to members of this group |
-| `force_code_challenge_method` | _string_ | The forced code challenge method |
+| `code_challenge_method` | _string_ | The code challenge method |
 
 ### ProviderType
 #### (`string` alias)

--- a/pkg/apis/options/legacy_options.go
+++ b/pkg/apis/options/legacy_options.go
@@ -526,7 +526,9 @@ type LegacyProvider struct {
 	JWTKeyFile string `flag:"jwt-key-file" cfg:"jwt_key_file"`
 	PubJWKURL  string `flag:"pubjwk-url" cfg:"pubjwk_url"`
 	// PKCE Code Challenge method to use (either S256 or plain)
-	CodeChallengeMethod string `flag:"code-challenge-method" cfg:"force_code_challenge_method"`
+	CodeChallengeMethod string `flag:"code-challenge-method" cfg:"code_challenge_method"`
+	// Provided for legacy reasons, to be dropped in newer version see #1667
+	ForceCodeChallengeMethod string `flag:"force-code-challenge-method" cfg:"force_code_challenge_method"`
 }
 
 func legacyProviderFlagSet() *pflag.FlagSet {
@@ -572,6 +574,7 @@ func legacyProviderFlagSet() *pflag.FlagSet {
 	flagSet.String("prompt", "", "OIDC prompt")
 	flagSet.String("approval-prompt", "force", "OAuth approval_prompt")
 	flagSet.String("code-challenge-method", "", "use PKCE code challenges with the specified method. Either 'plain' or 'S256'")
+	flagSet.String("force-code-challenge-method", "", "Deprecated - use --code-challenge-method")
 
 	flagSet.String("acr-values", "", "acr values string:  optional")
 	flagSet.String("jwt-key", "", "private key in PEM format used to sign JWT, so that you can say something like -jwt-key=\"${OAUTH2_PROXY_JWT_KEY}\": required by login.gov")
@@ -658,6 +661,11 @@ func (l *LegacyProvider) convert() (Providers, error) {
 		GroupsClaim:                    l.OIDCGroupsClaim,
 		AudienceClaims:                 l.OIDCAudienceClaims,
 		ExtraAudiences:                 l.OIDCExtraAudiences,
+	}
+
+	// Support for legacy configuration option
+	if l.ForceCodeChallengeMethod != "" && l.CodeChallengeMethod == "" {
+		provider.CodeChallengeMethod = l.ForceCodeChallengeMethod
 	}
 
 	// This part is out of the switch section because azure has a default tenant

--- a/pkg/apis/options/providers.go
+++ b/pkg/apis/options/providers.go
@@ -76,8 +76,8 @@ type Provider struct {
 	Scope string `json:"scope,omitempty"`
 	// AllowedGroups is a list of restrict logins to members of this group
 	AllowedGroups []string `json:"allowedGroups,omitempty"`
-	// The forced code challenge method
-	CodeChallengeMethod string `json:"force_code_challenge_method,omitempty"`
+	// The code challenge method
+	CodeChallengeMethod string `json:"code_challenge_method,omitempty"`
 }
 
 // ProviderType is used to enumerate the different provider type options


### PR DESCRIPTION
- Allow previous config option for now to prevent breaking configs

Fixes #1667

<!--- Provide a general summary of your changes in the Title above -->

## Description

See #1667 

## How Has This Been Tested?

Locally with contrib

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
