### PR TITLE
Allow service accounts to be authorized when group authorization enabled

### DIFF
--- a/pkg/apis/options/legacy_options.go
+++ b/pkg/apis/options/legacy_options.go
@@ -481,20 +481,21 @@ type LegacyProvider struct {
 	ClientSecret     string `flag:"client-secret" cfg:"client_secret"`
 	ClientSecretFile string `flag:"client-secret-file" cfg:"client_secret_file"`
 
-	KeycloakGroups           []string `flag:"keycloak-group" cfg:"keycloak_groups"`
-	AzureTenant              string   `flag:"azure-tenant" cfg:"azure_tenant"`
-	BitbucketTeam            string   `flag:"bitbucket-team" cfg:"bitbucket_team"`
-	BitbucketRepository      string   `flag:"bitbucket-repository" cfg:"bitbucket_repository"`
-	GitHubOrg                string   `flag:"github-org" cfg:"github_org"`
-	GitHubTeam               string   `flag:"github-team" cfg:"github_team"`
-	GitHubRepo               string   `flag:"github-repo" cfg:"github_repo"`
-	GitHubToken              string   `flag:"github-token" cfg:"github_token"`
-	GitHubUsers              []string `flag:"github-user" cfg:"github_users"`
-	GitLabGroup              []string `flag:"gitlab-group" cfg:"gitlab_groups"`
-	GitLabProjects           []string `flag:"gitlab-project" cfg:"gitlab_projects"`
-	GoogleGroups             []string `flag:"google-group" cfg:"google_group"`
-	GoogleAdminEmail         string   `flag:"google-admin-email" cfg:"google_admin_email"`
-	GoogleServiceAccountJSON string   `flag:"google-service-account-json" cfg:"google_service_account_json"`
+	KeycloakGroups                  []string `flag:"keycloak-group" cfg:"keycloak_groups"`
+	AzureTenant                     string   `flag:"azure-tenant" cfg:"azure_tenant"`
+	BitbucketTeam                   string   `flag:"bitbucket-team" cfg:"bitbucket_team"`
+	BitbucketRepository             string   `flag:"bitbucket-repository" cfg:"bitbucket_repository"`
+	GitHubOrg                       string   `flag:"github-org" cfg:"github_org"`
+	GitHubTeam                      string   `flag:"github-team" cfg:"github_team"`
+	GitHubRepo                      string   `flag:"github-repo" cfg:"github_repo"`
+	GitHubToken                     string   `flag:"github-token" cfg:"github_token"`
+	GitHubUsers                     []string `flag:"github-user" cfg:"github_users"`
+	GitLabGroup                     []string `flag:"gitlab-group" cfg:"gitlab_groups"`
+	GitLabProjects                  []string `flag:"gitlab-project" cfg:"gitlab_projects"`
+	GoogleGroups                    []string `flag:"google-group" cfg:"google_group"`
+	GoogleAdminEmail                string   `flag:"google-admin-email" cfg:"google_admin_email"`
+	GoogleServiceAccountJSON        string   `flag:"google-service-account-json" cfg:"google_service_account_json"`
+	GoogleAuthorizedServiceAccounts []string `flag:"google-authorized-service-accounts" cfg:"google_authorized_service_accounts"`
 
 	// These options allow for other providers besides Google, with
 	// potential overrides.
@@ -550,6 +551,7 @@ func legacyProviderFlagSet() *pflag.FlagSet {
 	flagSet.StringSlice("google-group", []string{}, "restrict logins to members of this google group (may be given multiple times).")
 	flagSet.String("google-admin-email", "", "the google admin to impersonate for api calls")
 	flagSet.String("google-service-account-json", "", "the path to the service account json credentials")
+	flagSet.StringSlice("google-authorized-service-accounts", []string{}, "restrict logins to these service accounts (may be given multiple times).")
 	flagSet.String("client-id", "", "the OAuth Client ID: ie: \"123456.apps.googleusercontent.com\"")
 	flagSet.String("client-secret", "", "the OAuth Client Secret")
 	flagSet.String("client-secret-file", "", "the file with OAuth Client Secret")
@@ -715,9 +717,10 @@ func (l *LegacyProvider) convert() (Providers, error) {
 		}
 	case "google":
 		provider.GoogleConfig = GoogleOptions{
-			Groups:             l.GoogleGroups,
-			AdminEmail:         l.GoogleAdminEmail,
-			ServiceAccountJSON: l.GoogleServiceAccountJSON,
+			Groups:                    l.GoogleGroups,
+			AdminEmail:                l.GoogleAdminEmail,
+			ServiceAccountJSON:        l.GoogleServiceAccountJSON,
+			AuthorizedServiceAccounts: l.GoogleAuthorizedServiceAccounts,
 		}
 	}
 

--- a/pkg/apis/options/providers.go
+++ b/pkg/apis/options/providers.go
@@ -186,6 +186,8 @@ type GoogleOptions struct {
 	AdminEmail string `json:"adminEmail,omitempty"`
 	// ServiceAccountJSON is the path to the service account json credentials
 	ServiceAccountJSON string `json:"serviceAccountJson,omitempty"`
+	// AuthorizedServiceAccounts is used when group authorization is enabled.
+	AuthorizedServiceAccounts []string `json:"authorizedServiceAccounts,omitempty"`
 }
 
 type OIDCOptions struct {


### PR DESCRIPTION
Adds a new flag for google service accounts that needs to be authorized.

## Motivation and Context

We do use google service accounts for machine to machine communication - recently we wanted to try enabling group based authorization on our oauth-proxy, however, when we add `google-group` parameter, our service accounts stops working as the google service accounts doesn't have group claims in the JWT token, thus the authorization logic here is not authorizing the service accounts request: https://github.com/oauth2-proxy/oauth2-proxy/blob/master/providers/provider_default.go#L118-L130

I have added another flag in this PR, called `google-authorized-service-accounts` and override authorization logic that is specified in `provider_default.go` file in `providers/google.go` to also check the authenticated email against the values specified in this paramter. 

This PR is fixing the issue reported here: https://github.com/oauth2-proxy/oauth2-proxy/issues/1803

Please note; I'm not familiar with the oauth2-proxy codebase and with golang in general, if there are better ways to solve issue #1803 and if the maintainers would be kind enough to direct me, I can improve the PR accordingly. 

## How Has This Been Tested?

I have a small utility script that can create JWT tokens using a service account and google.golang.org/api/idtoken library. During the testing I usually manually created a JWT token, and do a GET request against locally running oauth2-proxy with my changes. 

I've passed the parameter `OAUTH2_PROXY_GOOGLE_AUTHORIZED_SERVICE_ACCOUNTS` while launching oauth2-proxy locally, and provided the service-account email address in this environment variable; which then allowed oauth2-proxy to authorize my JWT tokens. 

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
