### PR TITLE
fix: adds missing x-forwarded-* headers to responses

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # This ARG has to be at the top, otherwise the docker daemon does not known what to do with FROM ${RUNTIME_IMAGE}
 ARG RUNTIME_IMAGE=alpine:3.16
+ARG BUILDPLATFORM
 
 # All builds should be done using the platform native to the build node to allow
 #  cache sharing of the go mod download step.
@@ -21,7 +22,6 @@ COPY . .
 #  sources have changed.
 ARG VERSION
 ARG TARGETPLATFORM
-ARG BUILDPLATFORM
 
 # Build binary and make sure there is at least an empty key file.
 #  This is useful for GCP App Engine custom runtime builds, because

--- a/main_test.go
+++ b/main_test.go
@@ -62,6 +62,18 @@ injectResponseHeaders:
     prefix: "Basic "
     basicAuthPassword:
       value: c3VwZXItc2VjcmV0LXBhc3N3b3Jk
+- name: X-Forwarded-Groups
+  values:
+  - claim: groups
+- name: X-Forwarded-User
+  values:
+  - claim: user
+- name: X-Forwarded-Email
+  values:
+  - claim: email
+- name: X-Forwarded-Preferred-Username
+  values:
+  - claim: preferred_username
 server:
   bindAddress: "127.0.0.1:4180"
 providers:
@@ -140,7 +152,7 @@ redirect_url="http://localhost:4180/oauth2/callback"
 		}
 
 		opts.InjectRequestHeaders = append([]options.Header{authHeader}, opts.InjectRequestHeaders...)
-		opts.InjectResponseHeaders = append(opts.InjectResponseHeaders, authHeader)
+		opts.InjectResponseHeaders = append([]options.Header{authHeader}, opts.InjectResponseHeaders...)
 
 		opts.Providers = options.Providers{
 			options.Provider{

--- a/pkg/apis/options/legacy_options.go
+++ b/pkg/apis/options/legacy_options.go
@@ -268,6 +268,15 @@ func (l *LegacyHeaders) getResponseHeaders() []Header {
 		responseHeaders = append(responseHeaders, getAuthorizationHeader())
 	}
 
+	if l.PassUserHeaders {
+		responseHeaders = append(responseHeaders, getPassUserHeaders(l.PreferEmailToUser)...)
+		responseHeaders = append(responseHeaders, getPreferredUsernameHeader())
+	}
+
+	if l.PassAccessToken {
+		responseHeaders = append(responseHeaders, getPassAccessTokenHeader())
+	}
+
 	return responseHeaders
 }
 


### PR DESCRIPTION
Fixes issue #1818 

Adds the following headers:
- X-Forwarded-Access-Token
- X-Forwarded-User
- X-Forwarded-Email
- X-Forwarded-Groups
- X-Forwarded-Preferred-Username

to the response headers sent if pass-user-headers and pass-access-token are true.

## Motivation and Context

There's no reason these headers shouldn't be present and it should be possible to use X-Forwarded-* headers exclusively without having to enable X-Auth-Request-* headers. This simplifies the load of knowing which headers to access when.

## How Has This Been Tested?

I have fixed the tests in main to include the new headers and deployed the change to a live environment to observe it working.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [] My change requires a change to the documentation or CHANGELOG.
- [] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
