### PR TITLE
Remove deprecated io/ioutil package and gosec issues

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
 
     - name: Get dependencies
       run: |
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.36.0
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.50.0
         curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
         chmod +x ./cc-test-reporter
 

--- a/main_test.go
+++ b/main_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -191,7 +190,7 @@ redirect_url="http://localhost:4180/oauth2/callback"
 
 			if in.configContent != "" {
 				By("Writing the config to a temporary file", func() {
-					file, err := ioutil.TempFile("", "oauth2-proxy-test-config-XXXX.cfg")
+					file, err := os.CreateTemp("", "oauth2-proxy-test-config-XXXX.cfg")
 					Expect(err).ToNot(HaveOccurred())
 					defer file.Close()
 
@@ -204,7 +203,7 @@ redirect_url="http://localhost:4180/oauth2/callback"
 
 			if in.alphaConfigContent != "" {
 				By("Writing the config to a temporary file", func() {
-					file, err := ioutil.TempFile("", "oauth2-proxy-test-alpha-config-XXXX.yaml")
+					file, err := os.CreateTemp("", "oauth2-proxy-test-alpha-config-XXXX.yaml")
 					Expect(err).ToNot(HaveOccurred())
 					defer file.Close()
 

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -1043,7 +1042,7 @@ func TestUserInfoEndpointAccepted(t *testing.T) {
 
 			test.proxy.ServeHTTP(test.rw, test.req)
 			assert.Equal(t, http.StatusOK, test.rw.Code)
-			bodyBytes, _ := ioutil.ReadAll(test.rw.Body)
+			bodyBytes, _ := io.ReadAll(test.rw.Body)
 			assert.Equal(t, tc.expectedResponse, string(bodyBytes))
 		})
 	}
@@ -1094,7 +1093,7 @@ func TestAuthOnlyEndpointAccepted(t *testing.T) {
 
 	test.proxy.ServeHTTP(test.rw, test.req)
 	assert.Equal(t, http.StatusAccepted, test.rw.Code)
-	bodyBytes, _ := ioutil.ReadAll(test.rw.Body)
+	bodyBytes, _ := io.ReadAll(test.rw.Body)
 	assert.Equal(t, "", string(bodyBytes))
 }
 
@@ -1106,7 +1105,7 @@ func TestAuthOnlyEndpointUnauthorizedOnNoCookieSetError(t *testing.T) {
 
 	test.proxy.ServeHTTP(test.rw, test.req)
 	assert.Equal(t, http.StatusUnauthorized, test.rw.Code)
-	bodyBytes, _ := ioutil.ReadAll(test.rw.Body)
+	bodyBytes, _ := io.ReadAll(test.rw.Body)
 	assert.Equal(t, "Unauthorized\n", string(bodyBytes))
 }
 
@@ -1126,7 +1125,7 @@ func TestAuthOnlyEndpointUnauthorizedOnExpiration(t *testing.T) {
 
 	test.proxy.ServeHTTP(test.rw, test.req)
 	assert.Equal(t, http.StatusUnauthorized, test.rw.Code)
-	bodyBytes, _ := ioutil.ReadAll(test.rw.Body)
+	bodyBytes, _ := io.ReadAll(test.rw.Body)
 	assert.Equal(t, "Unauthorized\n", string(bodyBytes))
 }
 
@@ -1145,7 +1144,7 @@ func TestAuthOnlyEndpointUnauthorizedOnEmailValidationFailure(t *testing.T) {
 
 	test.proxy.ServeHTTP(test.rw, test.req)
 	assert.Equal(t, http.StatusUnauthorized, test.rw.Code)
-	bodyBytes, _ := ioutil.ReadAll(test.rw.Body)
+	bodyBytes, _ := io.ReadAll(test.rw.Body)
 	assert.Equal(t, "Unauthorized\n", string(bodyBytes))
 }
 
@@ -1531,7 +1530,7 @@ func (st *SignatureTest) Close() {
 	st.upstream.Close()
 }
 
-// fakeNetConn simulates an http.Request.Body buffer that will be consumed
+// fakeNetConn simulates a http.Request.Body buffer that will be consumed
 // when it is read by the hmacauth.HmacAuth if not handled properly. See:
 //
 //	https://github.com/18F/hmacauth/pull/4
@@ -1561,7 +1560,7 @@ func (st *SignatureTest) MakeRequestWithExpectedKey(method, body, key string) er
 
 	var bodyBuf io.ReadCloser
 	if body != "" {
-		bodyBuf = ioutil.NopCloser(&fakeNetConn{reqBody: body})
+		bodyBuf = io.NopCloser(&fakeNetConn{reqBody: body})
 	}
 	req := httptest.NewRequest(method, "/foo/bar", bodyBuf)
 	req.Header = st.header
@@ -1970,7 +1969,7 @@ func Test_noCacheHeaders(t *testing.T) {
 		assert.Equal(t, http.StatusOK, rec.Code)
 		assert.Equal(t, "upstream", rec.Body.String())
 
-		// checking noCacheHeaders does not exists in response headers from upstream
+		// checking noCacheHeaders does not exist in response headers from upstream
 		for k := range noCacheHeaders {
 			assert.Equal(t, "", rec.Header().Get(k))
 		}

--- a/pkg/apis/options/load.go
+++ b/pkg/apis/options/load.go
@@ -3,7 +3,7 @@ package options
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"reflect"
 	"strings"
 
@@ -16,8 +16,10 @@ import (
 // Load reads in the config file at the path given, then merges in environment
 // variables (prefixed with `OAUTH2_PROXY`) and finally merges in flags from the flagSet.
 // If a config value is unset and the flag has a non-zero value default, this default will be used.
-// Eg. A field defined:
-//    FooBar `cfg:"foo_bar" flag:"foo-bar"`
+// E.g. A field defined:
+//
+//	FooBar `cfg:"foo_bar" flag:"foo-bar"`
+//
 // Can be set in the config file as `foo_bar="baz"`, in the environment as `OAUTH2_PROXY_FOO_BAR=baz`,
 // or via the command line flag `--foo-bar=baz`.
 func Load(configFileName string, flagSet *pflag.FlagSet, into interface{}) error {
@@ -41,8 +43,8 @@ func Load(configFileName string, flagSet *pflag.FlagSet, into interface{}) error
 		return fmt.Errorf("unable to register flags: %w", err)
 	}
 
-	// UnmarhsalExact will return an error if the config includes options that are
-	// not mapped to felds of the into struct
+	// UnmarshalExact will return an error if the config includes options that are
+	// not mapped to fields of the into struct
 	err = v.UnmarshalExact(into, decodeFromCfgTag)
 	if err != nil {
 		return fmt.Errorf("error unmarshalling config: %w", err)
@@ -147,13 +149,13 @@ func LoadYAML(configFileName string, into interface{}) error {
 		return errors.New("no configuration file provided")
 	}
 
-	data, err := ioutil.ReadFile(configFileName)
+	data, err := os.ReadFile(configFileName)
 	if err != nil {
 		return fmt.Errorf("unable to load config file: %w", err)
 	}
 
 	// UnmarshalStrict will return an error if the config includes options that are
-	// not mapped to felds of the into struct
+	// not mapped to fields of the into struct
 	if err := yaml.UnmarshalStrict(data, into, yaml.DisallowUnknownFields); err != nil {
 		return fmt.Errorf("error unmarshalling config: %w", err)
 	}

--- a/pkg/apis/options/load_test.go
+++ b/pkg/apis/options/load_test.go
@@ -3,7 +3,6 @@ package options
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -118,7 +117,7 @@ var _ = Describe("Load", func() {
 
 				if o.configFile != nil {
 					By("Creating a config file")
-					configFile, err := ioutil.TempFile("", "oauth2-proxy-test-legacy-config-file")
+					configFile, err := os.CreateTemp("", "oauth2-proxy-test-legacy-config-file")
 					Expect(err).ToNot(HaveOccurred())
 					defer configFile.Close()
 
@@ -390,7 +389,7 @@ sub:
 
 				if in.configFile != nil {
 					By("Creating a config file")
-					configFile, err := ioutil.TempFile("", "oauth2-proxy-test-config-file")
+					configFile, err := os.CreateTemp("", "oauth2-proxy-test-config-file")
 					Expect(err).ToNot(HaveOccurred())
 					defer configFile.Close()
 
@@ -488,7 +487,7 @@ injectResponseHeaders:
 `)
 
 		By("Creating a config file")
-		configFile, err := ioutil.TempFile("", "oauth2-proxy-test-alpha-config-file")
+		configFile, err := os.CreateTemp("", "oauth2-proxy-test-alpha-config-file")
 		Expect(err).ToNot(HaveOccurred())
 		defer configFile.Close()
 

--- a/pkg/apis/options/login_url_parameters.go
+++ b/pkg/apis/options/login_url_parameters.go
@@ -14,7 +14,7 @@ package options
 //
 // Examples:
 //
-// A parameter whose value is fixed
+// # A parameter whose value is fixed
 //
 // ```
 // name: organization
@@ -62,8 +62,9 @@ package options
 // use the "chomped block" format `|-`:
 //
 // ```
-// - pattern: |-
+//   - pattern: |-
 //     ^[^@]*@example\.com$
+//
 // ```
 //
 // The hyphen is important, a `|` block would have a trailing newline

--- a/pkg/apis/options/util/util.go
+++ b/pkg/apis/options/util/util.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
@@ -16,7 +15,7 @@ func GetSecretValue(source *options.SecretSource) ([]byte, error) {
 	case len(source.Value) == 0 && source.FromEnv != "" && source.FromFile == "":
 		return []byte(os.Getenv(source.FromEnv)), nil
 	case len(source.Value) == 0 && source.FromEnv == "" && source.FromFile != "":
-		return ioutil.ReadFile(source.FromFile)
+		return os.ReadFile(source.FromFile)
 	default:
 		return nil, errors.New("secret source is invalid: exactly one entry required, specify either value, fromEnv or fromFile")
 	}

--- a/pkg/apis/options/util/util_test.go
+++ b/pkg/apis/options/util/util_test.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 
@@ -20,9 +19,9 @@ var _ = Describe("GetSecretValue", func() {
 		os.Setenv(secretEnvKey, secretEnvValue)
 
 		var err error
-		fileDir, err = ioutil.TempDir("", "oauth2-proxy-util-get-secret-value")
+		fileDir, err = os.MkdirTemp("", "oauth2-proxy-util-get-secret-value")
 		Expect(err).ToNot(HaveOccurred())
-		Expect(ioutil.WriteFile(path.Join(fileDir, "secret-file"), secretFileValue, 0600)).To(Succeed())
+		Expect(os.WriteFile(path.Join(fileDir, "secret-file"), secretFileValue, 0600)).To(Succeed())
 	})
 
 	AfterEach(func() {

--- a/pkg/apis/sessions/session_state.go
+++ b/pkg/apis/sessions/session_state.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"time"
 
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/clock"
@@ -225,7 +224,7 @@ func lz4Compress(payload []byte) ([]byte, error) {
 		return nil, fmt.Errorf("error closing lz4 writer: %w", err)
 	}
 
-	compressed, err := ioutil.ReadAll(buf)
+	compressed, err := io.ReadAll(buf)
 	if err != nil {
 		return nil, fmt.Errorf("error reading lz4 buffer: %w", err)
 	}
@@ -244,7 +243,7 @@ func lz4Decompress(compressed []byte) ([]byte, error) {
 		return nil, fmt.Errorf("error copying lz4 stream to buffer: %w", err)
 	}
 
-	payload, err := ioutil.ReadAll(buf)
+	payload, err := io.ReadAll(buf)
 	if err != nil {
 		return nil, fmt.Errorf("error reading lz4 buffer: %w", err)
 	}

--- a/pkg/app/pagewriter/error_page_test.go
+++ b/pkg/app/pagewriter/error_page_test.go
@@ -3,7 +3,7 @@ package pagewriter
 import (
 	"errors"
 	"html/template"
-	"io/ioutil"
+	"io"
 	"net/http/httptest"
 
 	middlewareapi "github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/middleware"
@@ -36,7 +36,7 @@ var _ = Describe("Error Page Writer", func() {
 				AppError:    "Access Denied",
 			})
 
-			body, err := ioutil.ReadAll(recorder.Result().Body)
+			body, err := io.ReadAll(recorder.Result().Body)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(string(body)).To(Equal("Forbidden You do not have permission to access this resource. /prefix/ 403 /redirect 11111111-2222-4333-8444-555555555555 Custom Footer Text v0.0.0-test"))
 		})
@@ -50,7 +50,7 @@ var _ = Describe("Error Page Writer", func() {
 				AppError:    "Access Denied",
 			})
 
-			body, err := ioutil.ReadAll(recorder.Result().Body)
+			body, err := io.ReadAll(recorder.Result().Body)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(string(body)).To(Equal("Internal Server Error Oops! Something went wrong. For more information contact your server administrator. /prefix/ 500 /redirect 11111111-2222-4333-8444-555555555555 Custom Footer Text v0.0.0-test"))
 		})
@@ -68,7 +68,7 @@ var _ = Describe("Error Page Writer", func() {
 				},
 			})
 
-			body, err := ioutil.ReadAll(recorder.Result().Body)
+			body, err := io.ReadAll(recorder.Result().Body)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(string(body)).To(Equal("Forbidden An extra message: with more context. /prefix/ 403 /redirect 11111111-2222-4333-8444-555555555555 Custom Footer Text v0.0.0-test"))
 		})
@@ -82,7 +82,7 @@ var _ = Describe("Error Page Writer", func() {
 				AppError:    "Access Denied",
 			})
 
-			body, err := ioutil.ReadAll(recorder.Result().Body)
+			body, err := io.ReadAll(recorder.Result().Body)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(string(body)).To(Equal("Forbidden You do not have permission to access this resource. /prefix/ 403 /redirect &lt;script&gt;alert(1)&lt;/script&gt; Custom Footer Text v0.0.0-test"))
 		})
@@ -97,7 +97,7 @@ var _ = Describe("Error Page Writer", func() {
 			recorder := httptest.NewRecorder()
 			errorPage.ProxyErrorHandler(recorder, req, errors.New("some upstream error"))
 
-			body, err := ioutil.ReadAll(recorder.Result().Body)
+			body, err := io.ReadAll(recorder.Result().Body)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(string(body)).To(Equal("Bad Gateway There was a problem connecting to the upstream server. /prefix/ 502  11111111-2222-4333-8444-555555555555 Custom Footer Text v0.0.0-test"))
 		})
@@ -121,7 +121,7 @@ var _ = Describe("Error Page Writer", func() {
 					AppError:    "Debug error",
 				})
 
-				body, err := ioutil.ReadAll(recorder.Result().Body)
+				body, err := io.ReadAll(recorder.Result().Body)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(string(body)).To(Equal("Debug error"))
 			})
@@ -136,7 +136,7 @@ var _ = Describe("Error Page Writer", func() {
 				recorder := httptest.NewRecorder()
 				errorPage.ProxyErrorHandler(recorder, req, errors.New("some upstream error"))
 
-				body, err := ioutil.ReadAll(recorder.Result().Body)
+				body, err := io.ReadAll(recorder.Result().Body)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(string(body)).To(Equal("some upstream error"))
 			})

--- a/pkg/app/pagewriter/pagewriter_test.go
+++ b/pkg/app/pagewriter/pagewriter_test.go
@@ -3,7 +3,7 @@ package pagewriter
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -50,7 +50,7 @@ var _ = Describe("Writer", func() {
 					AppError:    "Some debug error",
 				})
 
-				body, err := ioutil.ReadAll(recorder.Result().Body)
+				body, err := io.ReadAll(recorder.Result().Body)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(string(body)).To(HavePrefix("\n<!DOCTYPE html>"))
 			})
@@ -59,7 +59,7 @@ var _ = Describe("Writer", func() {
 				recorder := httptest.NewRecorder()
 				writer.WriteSignInPage(recorder, request, "/redirect", http.StatusOK)
 
-				body, err := ioutil.ReadAll(recorder.Result().Body)
+				body, err := io.ReadAll(recorder.Result().Body)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(string(body)).To(HavePrefix("\n<!DOCTYPE html>"))
 			})
@@ -70,14 +70,14 @@ var _ = Describe("Writer", func() {
 
 			BeforeEach(func() {
 				var err error
-				customDir, err = ioutil.TempDir("", "oauth2-proxy-pagewriter-test")
+				customDir, err = os.MkdirTemp("", "oauth2-proxy-pagewriter-test")
 				Expect(err).ToNot(HaveOccurred())
 
 				templateHTML := `Custom Template`
 				signInFile := filepath.Join(customDir, signInTemplateName)
-				Expect(ioutil.WriteFile(signInFile, []byte(templateHTML), 0600)).To(Succeed())
+				Expect(os.WriteFile(signInFile, []byte(templateHTML), 0600)).To(Succeed())
 				errorFile := filepath.Join(customDir, errorTemplateName)
-				Expect(ioutil.WriteFile(errorFile, []byte(templateHTML), 0600)).To(Succeed())
+				Expect(os.WriteFile(errorFile, []byte(templateHTML), 0600)).To(Succeed())
 
 				opts.TemplatesPath = customDir
 
@@ -97,7 +97,7 @@ var _ = Describe("Writer", func() {
 					AppError:    "Some debug error",
 				})
 
-				body, err := ioutil.ReadAll(recorder.Result().Body)
+				body, err := io.ReadAll(recorder.Result().Body)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(string(body)).To(Equal("Custom Template"))
 			})
@@ -106,7 +106,7 @@ var _ = Describe("Writer", func() {
 				recorder := httptest.NewRecorder()
 				writer.WriteSignInPage(recorder, request, "/redirect", http.StatusOK)
 
-				body, err := ioutil.ReadAll(recorder.Result().Body)
+				body, err := io.ReadAll(recorder.Result().Body)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(string(body)).To(Equal("Custom Template"))
 			})
@@ -117,12 +117,12 @@ var _ = Describe("Writer", func() {
 
 			BeforeEach(func() {
 				var err error
-				customDir, err = ioutil.TempDir("", "oauth2-proxy-pagewriter-test")
+				customDir, err = os.MkdirTemp("", "oauth2-proxy-pagewriter-test")
 				Expect(err).ToNot(HaveOccurred())
 
 				templateHTML := `{{ Custom Broken Template`
 				signInFile := filepath.Join(customDir, signInTemplateName)
-				Expect(ioutil.WriteFile(signInFile, []byte(templateHTML), 0600)).To(Succeed())
+				Expect(os.WriteFile(signInFile, []byte(templateHTML), 0600)).To(Succeed())
 
 				opts.TemplatesPath = customDir
 			})
@@ -155,7 +155,7 @@ var _ = Describe("Writer", func() {
 
 				Expect(rw.Result().StatusCode).To(Equal(in.expectedStatus))
 
-				body, err := ioutil.ReadAll(rw.Result().Body)
+				body, err := io.ReadAll(rw.Result().Body)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(string(body)).To(Equal(in.expectedBody))
 			},
@@ -188,7 +188,7 @@ var _ = Describe("Writer", func() {
 
 				Expect(rw.Result().StatusCode).To(Equal(in.expectedStatus))
 
-				body, err := ioutil.ReadAll(rw.Result().Body)
+				body, err := io.ReadAll(rw.Result().Body)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(string(body)).To(Equal(in.expectedBody))
 			},
@@ -218,7 +218,7 @@ var _ = Describe("Writer", func() {
 
 				Expect(rw.Result().StatusCode).To(Equal(in.expectedStatus))
 
-				body, err := ioutil.ReadAll(rw.Result().Body)
+				body, err := io.ReadAll(rw.Result().Body)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(string(body)).To(Equal(in.expectedBody))
 			},
@@ -257,7 +257,7 @@ var _ = Describe("Writer", func() {
 
 				Expect(rw.Result().StatusCode).To(Equal(in.expectedStatus))
 
-				body, err := ioutil.ReadAll(rw.Result().Body)
+				body, err := io.ReadAll(rw.Result().Body)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(string(body)).To(Equal(in.expectedBody))
 			},

--- a/pkg/app/pagewriter/sign_in_page_test.go
+++ b/pkg/app/pagewriter/sign_in_page_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -56,7 +56,7 @@ var _ = Describe("SignIn Page", func() {
 				recorder := httptest.NewRecorder()
 				signInPage.WriteSignInPage(recorder, request, "/redirect", http.StatusOK)
 
-				body, err := ioutil.ReadAll(recorder.Result().Body)
+				body, err := io.ReadAll(recorder.Result().Body)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(string(body)).To(Equal("/prefix/ My Provider Sign In Here Custom Footer Text v0.0.0-test /redirect true Logo Data"))
 			})
@@ -70,7 +70,7 @@ var _ = Describe("SignIn Page", func() {
 				recorder := httptest.NewRecorder()
 				signInPage.WriteSignInPage(recorder, request, "/redirect", http.StatusOK)
 
-				body, err := ioutil.ReadAll(recorder.Result().Body)
+				body, err := io.ReadAll(recorder.Result().Body)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(string(body)).To(Equal(fmt.Sprintf("Internal Server Error | %s", testRequestID)))
 			})
@@ -84,12 +84,12 @@ var _ = Describe("SignIn Page", func() {
 
 		BeforeEach(func() {
 			var err error
-			customDir, err = ioutil.TempDir("", "oauth2-proxy-sign-in-page-test")
+			customDir, err = os.MkdirTemp("", "oauth2-proxy-sign-in-page-test")
 			Expect(err).ToNot(HaveOccurred())
 
 			for _, ext := range []string{".svg", ".png", ".jpg", ".jpeg", ".gif"} {
 				fileName := filepath.Join(customDir, fmt.Sprintf("logo%s", ext))
-				Expect(ioutil.WriteFile(fileName, []byte(fakeImageData), 0600)).To(Succeed())
+				Expect(os.WriteFile(fileName, []byte(fakeImageData), 0600)).To(Succeed())
 			}
 		})
 

--- a/pkg/app/pagewriter/static_pages_test.go
+++ b/pkg/app/pagewriter/static_pages_test.go
@@ -3,7 +3,7 @@ package pagewriter
 import (
 	"errors"
 	"html/template"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -27,11 +27,11 @@ var _ = Describe("Static Pages", func() {
 			template: errorTmpl,
 		}
 
-		customDir, err = ioutil.TempDir("", "oauth2-proxy-static-pages-test")
+		customDir, err = os.MkdirTemp("", "oauth2-proxy-static-pages-test")
 		Expect(err).ToNot(HaveOccurred())
 
 		robotsTxtFile := filepath.Join(customDir, robotsTxtName)
-		Expect(ioutil.WriteFile(robotsTxtFile, []byte(customRobots), 0400)).To(Succeed())
+		Expect(os.WriteFile(robotsTxtFile, []byte(customRobots), 0400)).To(Succeed())
 
 		request = httptest.NewRequest("", "http://127.0.0.1/", nil)
 		request = middlewareapi.AddRequestScope(request, &middlewareapi.RequestScope{
@@ -58,7 +58,7 @@ var _ = Describe("Static Pages", func() {
 					recorder := httptest.NewRecorder()
 					pageWriter.WriteRobotsTxt(recorder, request)
 
-					body, err := ioutil.ReadAll(recorder.Result().Body)
+					body, err := io.ReadAll(recorder.Result().Body)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(string(body)).To(Equal(customRobots))
 
@@ -81,7 +81,7 @@ var _ = Describe("Static Pages", func() {
 					recorder := httptest.NewRecorder()
 					pageWriter.WriteRobotsTxt(recorder, request)
 
-					body, err := ioutil.ReadAll(recorder.Result().Body)
+					body, err := io.ReadAll(recorder.Result().Body)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(string(body)).To(Equal(string(defaultRobotsTxt)))
 
@@ -94,7 +94,7 @@ var _ = Describe("Static Pages", func() {
 					}
 					pageWriter.WriteRobotsTxt(recorder, request)
 
-					body, err := ioutil.ReadAll(recorder.Result().Body)
+					body, err := io.ReadAll(recorder.Result().Body)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(string(body)).To(Equal(string("Internal Server Error")))
 

--- a/pkg/app/pagewriter/templates_test.go
+++ b/pkg/app/pagewriter/templates_test.go
@@ -3,7 +3,6 @@ package pagewriter
 import (
 	"bytes"
 	"html/template"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -16,14 +15,14 @@ var _ = Describe("Templates", func() {
 
 	BeforeEach(func() {
 		var err error
-		customDir, err = ioutil.TempDir("", "oauth2-proxy-templates-test")
+		customDir, err = os.MkdirTemp("", "oauth2-proxy-templates-test")
 		Expect(err).ToNot(HaveOccurred())
 
 		templateHTML := `{{.TestString}} {{.TestString | ToLower}} {{.TestString | ToUpper}}`
 		signInFile := filepath.Join(customDir, signInTemplateName)
-		Expect(ioutil.WriteFile(signInFile, []byte(templateHTML), 0600)).To(Succeed())
+		Expect(os.WriteFile(signInFile, []byte(templateHTML), 0600)).To(Succeed())
 		errorFile := filepath.Join(customDir, errorTemplateName)
-		Expect(ioutil.WriteFile(errorFile, []byte(templateHTML), 0600)).To(Succeed())
+		Expect(os.WriteFile(errorFile, []byte(templateHTML), 0600)).To(Succeed())
 	})
 
 	AfterEach(func() {
@@ -162,7 +161,7 @@ var _ = Describe("Templates", func() {
 			Context("With an invalid sign_in template", func() {
 				BeforeEach(func() {
 					signInFile := filepath.Join(customDir, signInTemplateName)
-					Expect(ioutil.WriteFile(signInFile, []byte("{{"), 0600))
+					Expect(os.WriteFile(signInFile, []byte("{{"), 0600))
 				})
 
 				It("Should return an error when loading templates", func() {
@@ -175,7 +174,7 @@ var _ = Describe("Templates", func() {
 			Context("With an invalid error template", func() {
 				BeforeEach(func() {
 					errorFile := filepath.Join(customDir, errorTemplateName)
-					Expect(ioutil.WriteFile(errorFile, []byte("{{"), 0600))
+					Expect(os.WriteFile(errorFile, []byte("{{"), 0600))
 				})
 
 				It("Should return an error when loading templates", func() {

--- a/pkg/header/header_suite_test.go
+++ b/pkg/header/header_suite_test.go
@@ -1,7 +1,6 @@
 package header
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -26,9 +25,9 @@ func TestHeaderSuite(t *testing.T) {
 var _ = BeforeSuite(func() {
 	os.Setenv("SECRET_ENV", "super-secret-env")
 
-	dir, err := ioutil.TempDir("", "oauth2-proxy-header-suite")
+	dir, err := os.MkdirTemp("", "oauth2-proxy-header-suite")
 	Expect(err).ToNot(HaveOccurred())
-	Expect(ioutil.WriteFile(path.Join(dir, "secret-file"), []byte("super-secret-file"), 0644)).To(Succeed())
+	Expect(os.WriteFile(path.Join(dir, "secret-file"), []byte("super-secret-file"), 0644)).To(Succeed())
 	filesDir = dir
 })
 

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -186,7 +186,12 @@ func (s *server) Start(ctx context.Context) error {
 // When the given context is cancelled the server will be shutdown.
 // If any errors occur, only the first error will be returned.
 func (s *server) startServer(ctx context.Context, listener net.Listener) error {
-	srv := &http.Server{Handler: s.handler}
+	srv := &http.Server{
+		Handler: s.handler,
+		// an arbitrary reasonable value to fix gosec G112 lint error
+		ReadHeaderTimeout: 2 * time.Second,
+	}
+
 	g, groupCtx := errgroup.WithContext(ctx)
 
 	g.Go(func() error {

--- a/pkg/http/server_test.go
+++ b/pkg/http/server_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
@@ -565,7 +565,7 @@ var _ = Describe("Server", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
-				body, err := ioutil.ReadAll(resp.Body)
+				body, err := io.ReadAll(resp.Body)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(string(body)).To(Equal(hello))
 			})
@@ -619,7 +619,7 @@ var _ = Describe("Server", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
-				body, err := ioutil.ReadAll(resp.Body)
+				body, err := io.ReadAll(resp.Body)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(string(body)).To(Equal(hello))
 			})
@@ -690,7 +690,7 @@ var _ = Describe("Server", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
-				body, err := ioutil.ReadAll(resp.Body)
+				body, err := io.ReadAll(resp.Body)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(string(body)).To(Equal(hello))
 			})
@@ -705,7 +705,7 @@ var _ = Describe("Server", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
-				body, err := ioutil.ReadAll(resp.Body)
+				body, err := io.ReadAll(resp.Body)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(string(body)).To(Equal(hello))
 			})
@@ -761,7 +761,7 @@ var _ = Describe("Server", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
-				body, err := ioutil.ReadAll(resp.Body)
+				body, err := io.ReadAll(resp.Body)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(string(body)).To(Equal(hello))
 			})
@@ -815,7 +815,7 @@ var _ = Describe("Server", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
-				body, err := ioutil.ReadAll(resp.Body)
+				body, err := io.ReadAll(resp.Body)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(string(body)).To(Equal(hello))
 			})
@@ -886,7 +886,7 @@ var _ = Describe("Server", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
-				body, err := ioutil.ReadAll(resp.Body)
+				body, err := io.ReadAll(resp.Body)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(string(body)).To(Equal(hello))
 			})
@@ -901,7 +901,7 @@ var _ = Describe("Server", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
-				body, err := ioutil.ReadAll(resp.Body)
+				body, err := io.ReadAll(resp.Body)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(string(body)).To(Equal(hello))
 			})

--- a/pkg/requests/builder.go
+++ b/pkg/requests/builder.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 )
 
@@ -107,7 +106,7 @@ func (r *builder) do() Result {
 	}
 
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		r.result = &result{err: fmt.Errorf("error reading response body: %v", err)}
 		return r.result

--- a/pkg/requests/requests_suite_test.go
+++ b/pkg/requests/requests_suite_test.go
@@ -3,7 +3,7 @@ package requests
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -82,7 +82,7 @@ func toTestHTTPRequest(req *http.Request) (testHTTPRequest, error) {
 	requestBody := []byte{}
 	if req.Body != http.NoBody {
 		var err error
-		requestBody, err = ioutil.ReadAll(req.Body)
+		requestBody, err = io.ReadAll(req.Body)
 		if err != nil {
 			return testHTTPRequest{}, err
 		}

--- a/pkg/sessions/redis/redis_store.go
+++ b/pkg/sessions/redis/redis_store.go
@@ -5,7 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/go-redis/redis/v8"
@@ -170,7 +170,7 @@ func setupTLSConfig(opts options.RedisStoreOptions, opt *redis.Options) error {
 		if rootCAs == nil {
 			rootCAs = x509.NewCertPool()
 		}
-		certs, err := ioutil.ReadFile(opts.CAPath)
+		certs, err := os.ReadFile(opts.CAPath)
 		if err != nil {
 			return fmt.Errorf("failed to load %q, %v", opts.CAPath, err)
 		}

--- a/pkg/upstream/upstream_suite_test.go
+++ b/pkg/upstream/upstream_suite_test.go
@@ -3,7 +3,7 @@ package upstream
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -35,12 +35,12 @@ func TestUpstreamSuite(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	// Set up files for serving via file servers
-	dir, err := ioutil.TempDir("", "oauth2-proxy-upstream-suite")
+	dir, err := os.MkdirTemp("", "oauth2-proxy-upstream-suite")
 	Expect(err).ToNot(HaveOccurred())
-	Expect(ioutil.WriteFile(path.Join(dir, "foo"), []byte("foo"), 0644)).To(Succeed())
-	Expect(ioutil.WriteFile(path.Join(dir, "bar"), []byte("bar"), 0644)).To(Succeed())
+	Expect(os.WriteFile(path.Join(dir, "foo"), []byte("foo"), 0644)).To(Succeed())
+	Expect(os.WriteFile(path.Join(dir, "bar"), []byte("bar"), 0644)).To(Succeed())
 	Expect(os.Mkdir(path.Join(dir, "subdir"), os.ModePerm)).To(Succeed())
-	Expect(ioutil.WriteFile(path.Join(dir, "subdir", "baz"), []byte("baz"), 0644)).To(Succeed())
+	Expect(os.WriteFile(path.Join(dir, "subdir", "baz"), []byte("baz"), 0644)).To(Succeed())
 	filesDir = dir
 
 	// Set up a webserver that reflects requests
@@ -148,7 +148,7 @@ func toTestHTTPRequest(req *http.Request) (testHTTPRequest, error) {
 	requestBody := []byte{}
 	if req.Body != http.NoBody {
 		var err error
-		requestBody, err = ioutil.ReadAll(req.Body)
+		requestBody, err = io.ReadAll(req.Body)
 		if err != nil {
 			return testHTTPRequest{}, err
 		}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -6,10 +6,10 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"net"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 )
@@ -21,7 +21,7 @@ func GetCertPool(paths []string) (*x509.CertPool, error) {
 	pool := x509.NewCertPool()
 	for _, path := range paths {
 		// Cert paths are a configurable option
-		data, err := ioutil.ReadFile(path) // #nosec G304
+		data, err := os.ReadFile(path) // #nosec G304
 		if err != nil {
 			return nil, fmt.Errorf("certificate authority file (%s) could not be read - %s", path, err)
 		}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -3,7 +3,6 @@ package util
 import (
 	"crypto/x509"
 	"encoding/pem"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -183,7 +182,7 @@ WrW4JMzLaGDtoHxRNNfo8E7fGkQ=
 )
 
 func makeTestCertFile(t *testing.T, pem, dir string) *os.File {
-	file, err := ioutil.TempFile(dir, "test-certfile")
+	file, err := os.CreateTemp(dir, "test-certfile")
 	assert.NoError(t, err)
 	_, err = file.Write([]byte(pem))
 	assert.NoError(t, err)
@@ -196,7 +195,7 @@ func TestGetCertPool_NoRoots(t *testing.T) {
 }
 
 func TestGetCertPool(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "certtest")
+	tempDir, err := os.MkdirTemp("", "certtest")
 	assert.NoError(t, err)
 	defer func(path string) {
 		rerr := os.RemoveAll(path)

--- a/pkg/validation/common_test.go
+++ b/pkg/validation/common_test.go
@@ -1,7 +1,6 @@
 package validation
 
 import (
-	"io/ioutil"
 	"os"
 
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
@@ -18,7 +17,7 @@ var _ = Describe("Common", func() {
 	BeforeEach(func() {
 		validSecretSourceValue = []byte("This is a secret source value")
 		Expect(os.Setenv(validSecretSourceEnv, "This is a secret source env")).To(Succeed())
-		tmp, err := ioutil.TempFile("", "oauth2-proxy-secret-source-test")
+		tmp, err := os.CreateTemp("", "oauth2-proxy-secret-source-test")
 		Expect(err).ToNot(HaveOccurred())
 		defer tmp.Close()
 
@@ -115,7 +114,7 @@ var _ = Describe("Common", func() {
 					FromEnv: "INVALID_ENV",
 				}
 			},
-			expectedMsg: "error loading secret from environent: no value for for key \"INVALID_ENV\"",
+			expectedMsg: "error loading secret from environment: no value for for key \"INVALID_ENV\"",
 		}),
 		Entry("with an invalid FromFile", validateSecretSourceTableInput{
 			source: func() options.SecretSource {

--- a/pkg/validation/options_test.go
+++ b/pkg/validation/options_test.go
@@ -2,7 +2,6 @@ package validation
 
 import (
 	"crypto"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"strings"
@@ -205,7 +204,7 @@ func TestRealClientIPHeader(t *testing.T) {
 }
 
 func TestProviderCAFilesError(t *testing.T) {
-	file, err := ioutil.TempFile("", "absent.*.crt")
+	file, err := os.CreateTemp("", "absent.*.crt")
 	assert.NoError(t, err)
 	assert.NoError(t, file.Close())
 	assert.NoError(t, os.Remove(file.Name()))

--- a/pkg/validation/providers.go
+++ b/pkg/validation/providers.go
@@ -2,14 +2,13 @@ package validation
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
 )
 
-// validateProviders is the initial validation migration for multiple providrers
-// It currently includes only logic that can verify the providers one by one and does not break the valdation pipe
+// validateProviders is the initial validation migration for multiple providers
+// It currently includes only logic that can verify the providers one by one and does not break the validation pipe
 func validateProviders(o *options.Options) []string {
 	msgs := []string{}
 
@@ -53,7 +52,7 @@ func validateProvider(provider options.Provider, providerIDs map[string]struct{}
 			msgs = append(msgs, "missing setting: client-secret or client-secret-file")
 		}
 		if provider.ClientSecret == "" && provider.ClientSecretFile != "" {
-			_, err := ioutil.ReadFile(provider.ClientSecretFile)
+			_, err := os.ReadFile(provider.ClientSecretFile)
 			if err != nil {
 				msgs = append(msgs, "could not read client secret file: "+provider.ClientSecretFile)
 			}

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -44,8 +44,8 @@ func WatchFileForUpdates(filename string, done <-chan bool, action func()) error
 
 // Filter file operations based on the events sent by the watcher.
 // Execute the action() function when the following conditions are met:
-//  - the real path of the file was changed (Kubernetes ConfigMap/Secret)
-//  - the file is modified or created
+//   - the real path of the file was changed (Kubernetes ConfigMap/Secret)
+//   - the file is modified or created
 func filterEvent(watcher *fsnotify.Watcher, event fsnotify.Event, filename string, action func()) {
 	switch filepath.Clean(event.Name) == filename {
 	// In Kubernetes the file path is a symlink, so we should take action

--- a/providers/google.go
+++ b/providers/google.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"strings"
@@ -231,7 +230,7 @@ func (p *GoogleProvider) setGroupRestriction(groups []string, adminEmail string,
 }
 
 func getAdminService(adminEmail string, credentialsReader io.Reader) *admin.Service {
-	data, err := ioutil.ReadAll(credentialsReader)
+	data, err := io.ReadAll(credentialsReader)
 	if err != nil {
 		logger.Fatal("can't read Google credentials file:", err)
 	}

--- a/providers/google_test.go
+++ b/providers/google_test.go
@@ -166,7 +166,6 @@ func TestGoogleProviderGroupValidator(t *testing.T) {
 	}
 }
 
-//
 func TestGoogleProviderGetEmailAddressInvalidEncoding(t *testing.T) {
 	p := newGoogleProvider(t)
 	body, err := json.Marshal(redeemResponse{

--- a/providers/keycloak_oidc.go
+++ b/providers/keycloak_oidc.go
@@ -124,20 +124,21 @@ func (p *KeycloakOIDCProvider) getAccessClaims(ctx context.Context, s *sessions.
 // the format `client:role`.
 //
 // ResourceAccess format:
-// "resource_access": {
-//   "clientA": {
-//     "roles": [
-//       "roleA"
-//     ]
-//   },
-//   "clientB": {
-//     "roles": [
-//       "roleA",
-//       "roleB",
-//       "roleC"
-//     ]
-//   }
-// }
+//
+//	"resource_access": {
+//	  "clientA": {
+//	    "roles": [
+//	      "roleA"
+//	    ]
+//	  },
+//	  "clientB": {
+//	    "roles": [
+//	      "roleA",
+//	      "roleB",
+//	      "roleC"
+//	    ]
+//	  }
+//	}
 func getClientRoles(claims *accessClaims) []string {
 	var clientRoles []string
 	for clientName, access := range claims.ResourceAccess {

--- a/providers/logingov.go
+++ b/providers/logingov.go
@@ -7,9 +7,9 @@ import (
 	"crypto/rsa"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"net/url"
+	"os"
 	"time"
 
 	"github.com/golang-jwt/jwt"
@@ -123,7 +123,7 @@ func (p *LoginGovProvider) configure(opts options.LoginGovOptions) error {
 		p.JWTKey = signKey
 	case opts.JWTKeyFile != "":
 		// The JWT key is in the filesystem
-		keyData, err := ioutil.ReadFile(opts.JWTKeyFile)
+		keyData, err := os.ReadFile(opts.JWTKeyFile)
 		if err != nil {
 			return fmt.Errorf("could not read key file: %v", opts.JWTKeyFile)
 		}

--- a/providers/provider_data.go
+++ b/providers/provider_data.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"regexp"
 	"strings"
 
@@ -67,7 +67,7 @@ func (p *ProviderData) GetClientSecret() (clientSecret string, err error) {
 	}
 
 	// Getting ClientSecret can fail in runtime so we need to report it without returning the file name to the user
-	fileClientSecret, err := ioutil.ReadFile(p.ClientSecretFile)
+	fileClientSecret, err := os.ReadFile(p.ClientSecretFile)
 	if err != nil {
 		logger.Errorf("error reading client secret file %s: %s", p.ClientSecretFile, err)
 		return "", errors.New("could not read client secret file")

--- a/providers/providers_test.go
+++ b/providers/providers_test.go
@@ -1,7 +1,6 @@
 package providers
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -43,7 +42,7 @@ func TestClientSecretFileOptionFails(t *testing.T) {
 func TestClientSecretFileOption(t *testing.T) {
 	g := NewWithT(t)
 
-	f, err := ioutil.TempFile("", "client_secret_temp_file_")
+	f, err := os.CreateTemp("", "client_secret_temp_file_")
 	g.Expect(err).ToNot(HaveOccurred())
 
 	clientSecretFileName := f.Name()

--- a/validator_test.go
+++ b/validator_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -18,7 +17,7 @@ type ValidatorTest struct {
 func NewValidatorTest(t *testing.T) *ValidatorTest {
 	vt := &ValidatorTest{}
 	var err error
-	f, err := ioutil.TempFile("", "test_auth_emails_")
+	f, err := os.CreateTemp("", "test_auth_emails_")
 	if err != nil {
 		t.Fatalf("failed to create temp file: %v", err)
 	}


### PR DESCRIPTION


Remove deprecated io/ioutil package and fix Potential Slowloris Attack gosec issue.

## Description

I've also ran a `go fmt ./...` in order to update format

Updated the `golangci-lint` in CI too to the latest stable.

## Motivation and Context

`io/ioutil` packages was deprecated since go 1.16 based on https://go.dev/doc/go1.16#ioutil and it might be removed in future go releases.

Also, newer version of gosec revealed a Potential Slowloris Attack for the http server

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [X] I have created a feature (non-master) branch for my PR.
