### PR TITLE
feat(cors): Add Cors headers to errorJson response

### DIFF
--- a/pkg/apis/options/options.go
+++ b/pkg/apis/options/options.go
@@ -60,6 +60,10 @@ type Options struct {
 	SkipAuthPreflight     bool     `flag:"skip-auth-preflight" cfg:"skip_auth_preflight"`
 	ForceJSONErrors       bool     `flag:"force-json-errors" cfg:"force_json_errors"`
 
+	CorsCredentials bool     `flag:"cors-credentials" cfg:"cors_credentials"`
+	CorsHeaders     []string `flag:"cors-headers" cfg:"cors_headers"`
+	CorsOrigin      []string `flag:"cors-origin" cfg:"cors_origin"`
+
 	SignatureKey    string `flag:"signature-key" cfg:"signature_key"`
 	GCPHealthChecks bool   `flag:"gcp-healthchecks" cfg:"gcp_healthchecks"`
 
@@ -148,6 +152,10 @@ func NewFlagSet() *pflag.FlagSet {
 	flagSet.Int("redis-connection-idle-timeout", 0, "Redis connection idle timeout seconds, if Redis timeout option is non-zero, the --redis-connection-idle-timeout must be less then Redis timeout option")
 	flagSet.String("signature-key", "", "GAP-Signature request signature key (algorithm:secretkey)")
 	flagSet.Bool("gcp-healthchecks", false, "Enable GCP/GKE healthcheck endpoints")
+
+	flagSet.Bool("cors-credentials", false, "Enable Access-Control-Allow-Credentials header on error responses")
+	flagSet.StringSlice("cors-headers", []string{}, "Sets Access-Control-Allow-Headers header on error responses")
+	flagSet.StringSlice("cors-origin", []string{}, "Sets Access-Control-Allow-Origin header on error responses")
 
 	flagSet.AddFlagSet(cookieFlagSet())
 	flagSet.AddFlagSet(loggingFlagSet())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

There are new config options for setting the cors origin, credentials and header on error responses.

## Motivation and Context

We had cors issues when getting a 401 in api mode (on api routes). 


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
