### PR TITLE
Add support for unix socket as upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [#2274](https://github.com/oauth2-proxy/oauth2-proxy/pull/2274) Upgrade golang.org/x/net to v0.17.0 (@pierluigilenoci)
 - [#2282](https://github.com/oauth2-proxy/oauth2-proxy/pull/2282) Fixed checking Google Groups membership using Google Application Credentials (@kvanzuijlen)
 - [#2183](https://github.com/oauth2-proxy/oauth2-proxy/pull/2183) Allowing relative redirect url though an option
+- [#1866](https://github.com/oauth2-proxy/oauth2-proxy/pull/1866) Add support for unix socker as upstream (@babs)
 - 
 # V7.5.1
 

--- a/docs/docs/configuration/overview.md
+++ b/docs/docs/configuration/overview.md
@@ -223,7 +223,11 @@ See below for provider specific options
 
 ### Upstreams Configuration
 
-`oauth2-proxy` supports having multiple upstreams, and has the option to pass requests on to HTTP(S) servers or serve static files from the file system. HTTP and HTTPS upstreams are configured by providing a URL such as `http://127.0.0.1:8080/` for the upstream parameter. This will forward all authenticated requests to the upstream server. If you instead provide `http://127.0.0.1:8080/some/path/` then it will only be requests that start with `/some/path/` which are forwarded to the upstream.
+`oauth2-proxy` supports having multiple upstreams, and has the option to pass requests on to HTTP(S) servers, unix socket or serve static files from the file system.
+
+HTTP and HTTPS upstreams are configured by providing a URL such as `http://127.0.0.1:8080/` for the upstream parameter. . This will forward all authenticated requests to the upstream server. If you instead provide `http://127.0.0.1:8080/some/path/` then it will only be requests that start with `/some/path/` which are forwarded to the upstream.
+
+Unix socket upstreams are configured as `unix:///path/to/unix.sock`.
 
 Static file paths are configured as a file:// URL. `file:///var/www/static/` will serve the files from that directory at `http://[oauth2-proxy url]/var/www/static/`, which may not be what you want. You can provide the path to where the files should be available by adding a fragment to the configured URL. The value of the fragment will then be used to specify which path the files are available at, e.g. `file:///var/www/static/#/static/` will make `/var/www/static/` available at `http://[oauth2-proxy url]/static/`.
 

--- a/pkg/apis/options/legacy_options.go
+++ b/pkg/apis/options/legacy_options.go
@@ -176,6 +176,8 @@ func (l *LegacyUpstreams) convert() (UpstreamConfig, error) {
 			upstream.ProxyWebSockets = nil
 			upstream.FlushInterval = nil
 			upstream.Timeout = nil
+		case "unix":
+			upstream.Path = "/"
 		}
 
 		upstreams.Upstreams = append(upstreams.Upstreams, upstream)

--- a/pkg/upstream/http_test.go
+++ b/pkg/upstream/http_test.go
@@ -312,6 +312,29 @@ var _ = Describe("HTTP Upstream Suite", func() {
 			},
 			expectedUpstream: "passExistingHostHeader",
 		}),
+		Entry("request using UNIX socket upstream", &httpUpstreamTableInput{
+			id:           "unix-upstream",
+			serverAddr:   &unixServerAddr,
+			target:       "http://example.localhost/file",
+			method:       "GET",
+			body:         []byte{},
+			errorHandler: nil,
+			expectedResponse: testHTTPResponse{
+				code: 200,
+				header: map[string][]string{
+					contentType: {applicationJSON},
+				},
+				request: testHTTPRequest{
+					Method:     "GET",
+					URL:        "http://example.localhost/file",
+					Header:     map[string][]string{},
+					Body:       []byte{},
+					Host:       "example.localhost",
+					RequestURI: "http://example.localhost/file",
+				},
+			},
+			expectedUpstream: "unix-upstream",
+		}),
 	)
 
 	It("ServeHTTP, when not passing a host header", func() {

--- a/pkg/upstream/proxy.go
+++ b/pkg/upstream/proxy.go
@@ -48,9 +48,9 @@ func NewProxy(upstreams options.UpstreamConfig, sigData *options.SignatureData, 
 			if err := m.registerFileServer(upstream, u, writer); err != nil {
 				return nil, fmt.Errorf("could not register file upstream %q: %v", upstream.ID, err)
 			}
-		case httpScheme, httpsScheme:
+		case httpScheme, httpsScheme, unixScheme:
 			if err := m.registerHTTPUpstreamProxy(upstream, u, sigData, writer); err != nil {
-				return nil, fmt.Errorf("could not register HTTP upstream %q: %v", upstream.ID, err)
+				return nil, fmt.Errorf("could not register %s upstream %q: %v", u.Scheme, upstream.ID, err)
 			}
 		default:
 			return nil, fmt.Errorf("unknown scheme for upstream %q: %q", upstream.ID, u.Scheme)

--- a/pkg/upstream/proxy_test.go
+++ b/pkg/upstream/proxy_test.go
@@ -98,6 +98,11 @@ var _ = Describe("Proxy Suite", func() {
 							RewriteTarget: "/double-match/rewrite/$1",
 							URI:           serverAddr,
 						},
+						{
+							ID:   "unix-upstream",
+							Path: "/unix/",
+							URI:  unixServerAddr,
+						},
 					}
 				}
 
@@ -336,6 +341,27 @@ var _ = Describe("Proxy Suite", func() {
 					raw: "404 page not found\n",
 				},
 				upstream: "",
+			}),
+			Entry("with a request to the UNIX socket backend", &proxyTableInput{
+				target: "http://example.localhost/unix/file",
+				response: testHTTPResponse{
+					code: 200,
+					header: map[string][]string{
+						contentType: {applicationJSON},
+					},
+					request: testHTTPRequest{
+						Method: "GET",
+						URL:    "http://example.localhost/unix/file",
+						Header: map[string][]string{
+							"Gap-Auth":      {""},
+							"Gap-Signature": {"sha256 4ux8esLj2fw9sTWZwgFhb00bGbw0Fnhed5Fm9jz5Blw="},
+						},
+						Body:       []byte{},
+						Host:       "example.localhost",
+						RequestURI: "http://example.localhost/unix/file",
+					},
+				},
+				upstream: "unix-upstream",
 			}),
 		)
 	})

--- a/pkg/upstream/upstream_suite_test.go
+++ b/pkg/upstream/upstream_suite_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -18,10 +19,12 @@ import (
 )
 
 var (
-	filesDir      string
-	server        *httptest.Server
-	serverAddr    string
-	invalidServer = "http://::1"
+	filesDir       string
+	server         *httptest.Server
+	serverAddr     string
+	unixServer     *httptest.Server
+	unixServerAddr string
+	invalidServer  = "http://::1"
 )
 
 func TestUpstreamSuite(t *testing.T) {
@@ -46,10 +49,17 @@ var _ = BeforeSuite(func() {
 	// Set up a webserver that reflects requests
 	server = httptest.NewServer(&testHTTPUpstream{})
 	serverAddr = fmt.Sprintf("http://%s", server.Listener.Addr().String())
+
+	unixServer = httptest.NewUnstartedServer(&testHTTPUpstream{})
+	unixListener, _ := net.Listen("unix", "test.sock")
+	unixServer.Listener = unixListener
+	unixServer.Start()
+	unixServerAddr = fmt.Sprintf("unix://%s", "test.sock")
 })
 
 var _ = AfterSuite(func() {
 	server.Close()
+	unixServer.Close()
 	Expect(os.RemoveAll(filesDir)).To(Succeed())
 })
 

--- a/pkg/upstream/upstream_suite_test.go
+++ b/pkg/upstream/upstream_suite_test.go
@@ -51,10 +51,10 @@ var _ = BeforeSuite(func() {
 	serverAddr = fmt.Sprintf("http://%s", server.Listener.Addr().String())
 
 	unixServer = httptest.NewUnstartedServer(&testHTTPUpstream{})
-	unixListener, _ := net.Listen("unix", "test.sock")
+	unixListener, _ := net.Listen("unix", path.Join(filesDir, "test.sock"))
 	unixServer.Listener = unixListener
 	unixServer.Start()
-	unixServerAddr = fmt.Sprintf("unix://%s", "test.sock")
+	unixServerAddr = fmt.Sprintf("unix://%s", path.Join(filesDir, "test.sock"))
 })
 
 var _ = AfterSuite(func() {

--- a/pkg/validation/upstreams.go
+++ b/pkg/validation/upstreams.go
@@ -102,7 +102,7 @@ func validateUpstreamURI(upstream options.Upstream) []string {
 	}
 
 	switch u.Scheme {
-	case "http", "https", "file":
+	case "http", "https", "file", "unix":
 		// Valid, do nothing
 	default:
 		msgs = append(msgs, fmt.Sprintf("upstream %q has invalid scheme: %q", upstream.ID, u.Scheme))


### PR DESCRIPTION
## Description

Add support for unix socket at upstream
Might require some rework.

Should be able to close #1865

## Motivation and Context

Some apps might require to go through a unix socket when listening on a tcp port, even bound locally is not secure enough and socket ownership is used as an extra isolation layer.

## How Has This Been Tested?

I created a simple uvicorn app that listen to unix socket and used `--upstream=unix:///path/pf/the/unix.sock` .

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
