### PR TITLE
Ignore port when matching cookie domain

### DIFF
--- a/pkg/cookies/cookies.go
+++ b/pkg/cookies/cookies.go
@@ -45,6 +45,9 @@ func MakeCookieFromOptions(req *http.Request, name string, value string, opts *o
 // by checking the X-Fowarded-Host and host header of an an http request
 func GetCookieDomain(req *http.Request, cookieDomains []string) string {
 	host := requestutil.GetRequestHost(req)
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
 	for _, domain := range cookieDomains {
 		if strings.HasSuffix(host, domain) {
 			return domain

--- a/pkg/cookies/cookies_test.go
+++ b/pkg/cookies/cookies_test.go
@@ -74,6 +74,11 @@ var _ = Describe("Cookie Tests", func() {
 				cookieDomains:  []string{".cookies.wrong", ".cookies.false"},
 				expectedOutput: "",
 			}),
+			Entry("matching against host:port", getCookieDomainTableInput{
+				host:           "www.cookies.test:8080",
+				cookieDomains:  []string{".cookies.test"},
+				expectedOutput: ".cookies.test",
+			}),
 		)
 	})
 })


### PR DESCRIPTION
Discard `:<port>` from the host string when performing cookie domain matching against host string in form of `<host>:<port>`

## Description

This PR propose a minor change to the cookie domain matching logic.
- Current behavior:
  The entire host string, which may inculde a port number, participate in the cookie domain matching. 
- Proposed behavior:
  Only the hostname part from the host string participate in the cookie domain matching.

Per [RFC 6265 Section 8.5](https://www.rfc-editor.org/rfc/rfc6265#section-8.5), cookies do not provide isolation by port. Thus using port number in the current cookie domain matching logic (i.e. plain suffix matching) does not provide any value. Furthermore, setting cookie domain to a string in form of `<host>:<port>` does not work (cookies not set) based on my very limited test on Chrome 106.0.5249.119 .

## Motivation and Context
oauth2-proxy instance deployed as nginx `auth_request` module and passing host = $host:$server_port.
instance is configured with:
```
cookie_domains = ["abcdef.com", "xyz.com"]
```
when visitng oauth2-proxy endpoints through url `https://abcdef.com:8080/....`, string `xyz.com` will be used as cookie domain (expecting `abcdef.com`).

## How Has This Been Tested?

Add a unit test for this case.
Code change passed exisiting and the newly added unit test.

## Checklist:

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
