### PR TITLE
Fix uninitialized user claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Changes since v7.4.0
 
+- [#1873](https://github.com/oauth2-proxy/oauth2-proxy/pull/1873) Fix empty users with some OIDC providers (@babs)
+
 # V7.4.0
 
 ## Release Highlights

--- a/providers/gitlab.go
+++ b/providers/gitlab.go
@@ -32,7 +32,10 @@ var _ Provider = (*GitLabProvider)(nil)
 
 // NewGitLabProvider initiates a new GitLabProvider
 func NewGitLabProvider(p *ProviderData, opts options.GitLabOptions) (*GitLabProvider, error) {
-	p.ProviderName = gitlabProviderName
+	p.setProviderDefaults(providerDefaults{
+		name: gitlabProviderName,
+	})
+
 	if p.Scope == "" {
 		p.Scope = gitlabDefaultScope
 	}

--- a/providers/keycloak_oidc.go
+++ b/providers/keycloak_oidc.go
@@ -17,7 +17,9 @@ type KeycloakOIDCProvider struct {
 
 // NewKeycloakOIDCProvider makes a KeycloakOIDCProvider using the ProviderData
 func NewKeycloakOIDCProvider(p *ProviderData, opts options.KeycloakOptions) *KeycloakOIDCProvider {
-	p.ProviderName = keycloakOIDCProviderName
+	p.setProviderDefaults(providerDefaults{
+		name: keycloakOIDCProviderName,
+	})
 
 	provider := &KeycloakOIDCProvider{
 		OIDCProvider: &OIDCProvider{

--- a/providers/nextcloud.go
+++ b/providers/nextcloud.go
@@ -21,7 +21,10 @@ const nextCloudProviderName = "Nextcloud"
 
 // NewNextcloudProvider initiates a new NextcloudProvider
 func NewNextcloudProvider(p *ProviderData) *NextcloudProvider {
-	p.ProviderName = nextCloudProviderName
+	p.setProviderDefaults(providerDefaults{
+		name: nextCloudProviderName,
+	})
+
 	p.getAuthorizationHeaderFunc = makeOIDCHeader
 	if p.EmailClaim == options.OIDCEmailClaim {
 		// This implies the email claim has not been overridden, we should set a default

--- a/providers/provider_data.go
+++ b/providers/provider_data.go
@@ -197,10 +197,6 @@ func (p *ProviderData) setProviderDefaults(defaults providerDefaults) {
 	if p.Scope == "" {
 		p.Scope = defaults.scope
 	}
-
-	if p.UserClaim == "" {
-		p.UserClaim = oidcUserClaim
-	}
 }
 
 // defaultURL will set return a default value if the given value is not set.
@@ -245,6 +241,10 @@ func (p *ProviderData) buildSessionFromClaims(rawIDToken, accessToken string) (*
 	extractor, err := p.getClaimExtractor(rawIDToken, accessToken)
 	if err != nil {
 		return nil, err
+	}
+
+	if p.UserClaim == "" {
+		p.UserClaim = oidcUserClaim
 	}
 
 	// Use a slice of a struct (vs map) here in case the same claim is used twice

--- a/providers/provider_data.go
+++ b/providers/provider_data.go
@@ -197,6 +197,10 @@ func (p *ProviderData) setProviderDefaults(defaults providerDefaults) {
 	if p.Scope == "" {
 		p.Scope = defaults.scope
 	}
+
+	if p.UserClaim == "" {
+		p.UserClaim = oidcUserClaim
+	}
 }
 
 // defaultURL will set return a default value if the given value is not set.
@@ -241,10 +245,6 @@ func (p *ProviderData) buildSessionFromClaims(rawIDToken, accessToken string) (*
 	extractor, err := p.getClaimExtractor(rawIDToken, accessToken)
 	if err != nil {
 		return nil, err
-	}
-
-	if p.UserClaim == "" {
-		p.UserClaim = oidcUserClaim
 	}
 
 	// Use a slice of a struct (vs map) here in case the same claim is used twice


### PR DESCRIPTION
## Description

Some providers doesn't initialize data with `setProviderDefaults` function (keycloak-oidc for example), therefore `UserClaim` is never initialized with the default value (`sub`) and stay an empty string. This leads to an empty user.

Should close #1874

## Checklist:

- [X] My change requires a change to the documentation or CHANGELOG.
- [X] I have updated the documentation/CHANGELOG accordingly.
- [X] I have created a feature (non-master) branch for my PR.
