### PR TITLE
Session aware sign_out for redirect `{id_token}` placeholder replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Changes since v7.4.0
 
+- [#1875](https://github.com/oauth2-proxy/oauth2-proxy/pull/1875) Session aware sign_out for `${id_token}` usage in `rd` parameter(@babs)
+
 # V7.4.0
 
 ## Release Highlights

--- a/docs/docs/features/endpoints.md
+++ b/docs/docs/features/endpoints.md
@@ -17,10 +17,14 @@ OAuth2 Proxy responds directly to the following endpoints. All other endpoints w
 
 ### Sign out
 
-To sign the user out, redirect them to `/oauth2/sign_out`. This endpoint only removes oauth2-proxy's own cookies, i.e. the user is still logged in with the authentication provider and may automatically re-login when accessing the application again. You will also need to redirect the user to the authentication provider's sign out page afterwards using the `rd` query parameter, i.e. redirect the user to something like (notice the url-encoding!):
+To sign the user out, redirect them to `/oauth2/sign_out`. This endpoint only removes oauth2-proxy's own cookies, i.e. the user is still logged in with the authentication provider and may automatically re-login when accessing the application again. You will also need to redirect the user to the authentication provider's sign out page afterwards using the `rd` query parameter where `${id_token}` can be used as placeholder for the session's id_token, i.e. redirect the user to something like (notice the url-encoding!):
 
 ```
 /oauth2/sign_out?rd=https%3A%2F%2Fmy-oidc-provider.example.com%2Fsign_out_page
+```
+or
+```
+/oauth2/sign_out?rd=https%3A%2F%2Fmy-oidc-provider.example.com%2Fsign_out_page%3Fid_token=$%7Bid_token%7D
 ```
 
 Alternatively, include the redirect URL in the `X-Auth-Request-Redirect` header:


### PR DESCRIPTION
## Description

Try to load the session at sign_out to handle redirect's placeholder replacement: `${id_token}`

Allow usage of `{id_token}` as a `rd` parameter placeholder for newer keycloak, example:

http://localhost:4180/oauth2/sign_out?rd=http://localhost:8080/auth/realms/testrealm/protocol/openid-connect/logout?id_token_hint={id_token}%26post_logout_redirect_uri=http://localhost:4180/

## Motivation and Context

Might be a start for closing #884

## How Has This Been Tested?

Tested against local keycloak using a `testrealm` and a `testapp` listening on 8080.
The demo link leads to the root path of the app with a properly signed out session from both keycloak and oauth2-proxy

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
