### PR TITLE
Fix for test race condition on htpasswd file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Changes since v7.4.0
 
+- [#1882](https://github.com/oauth2-proxy/oauth2-proxy/pull/1882) Make `htpasswd.GetUsers` racecondition safe
+
 # V7.4.0
 
 ## Release Highlights

--- a/pkg/authentication/basic/htpasswd.go
+++ b/pkg/authentication/basic/htpasswd.go
@@ -139,6 +139,17 @@ func passShaOrBcrypt(h *htpasswdMap, user, password string) (invalidEntries []st
 	return invalidEntries
 }
 
+// GetUsers return a "thread safe" copy of the internal user list
+func (h *htpasswdMap) GetUsers() map[string]interface{} {
+	newUserList := make(map[string]interface{})
+	h.rwm.Lock()
+	for key, value := range h.users {
+		newUserList[key] = value
+	}
+	h.rwm.Unlock()
+	return newUserList
+}
+
 // Validate checks a users password against the htpasswd entries
 func (h *htpasswdMap) Validate(user string, password string) bool {
 	realPassword, exists := h.users[user]

--- a/pkg/authentication/basic/htpasswd_test.go
+++ b/pkg/authentication/basic/htpasswd_test.go
@@ -149,7 +149,7 @@ var _ = Describe("HTPasswd Suite", func() {
 					fileNames = append(fileNames, file.Name())
 
 					It("has the correct number of users", func() {
-						Expect(len(htpasswd.users)).To(Equal(hu.expectedLen))
+						Expect(len(htpasswd.GetUsers())).To(Equal(hu.expectedLen))
 					})
 
 					It(hu.testText, func() {


### PR DESCRIPTION
## Description

Make `htpasswd.GetUsers` racecondition safe

