### PR TITLE
Ignore-expired-csrf-cookie-if-valid-auth-cookie-at-oauthcallback

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -815,16 +815,10 @@ func (p *OAuthProxy) OAuthCallback(rw http.ResponseWriter, req *http.Request) {
 	if err == nil {
 		if authOnlyAuthorize(req, existingSession) {
 			_, appRedirect, err := decodeState(req)
-			if err != nil {
-				logger.Errorf("Error while parsing OAuth2 state: %v", err)
-				p.ErrorPage(rw, req, http.StatusInternalServerError, err.Error())
-				return
-			}
-
-			if !p.redirectValidator.IsValidRedirect(appRedirect) {
+			if err != nil || !p.redirectValidator.IsValidRedirect(appRedirect) {
 				appRedirect = "/"
 			}
-			logger.Printf("Redirecting user with valid session: %v", appRedirect)
+			logger.Printf("Redirecting user with valid session: %s", appRedirect)
 			http.Redirect(rw, req, appRedirect, http.StatusFound)
 			return
 		}

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -826,6 +826,7 @@ func (p *OAuthProxy) OAuthCallback(rw http.ResponseWriter, req *http.Request) {
 			}
 			logger.Printf("Redirecting user with valid session: %v", appRedirect)
 			http.Redirect(rw, req, appRedirect, http.StatusFound)
+			return
 		}
 	}
 


### PR DESCRIPTION
Detailed description of the problem and the solution is described here: https://github.com/oauth2-proxy/oauth2-proxy/issues/1888 ; 

## How Has This Been Tested?

The changes have been tested by rolling out the patched version in our k8s test environment. We use keycloak-19.0.1 as auth provider.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
