### PR TITLE
Fix PKCE code verifier generation to never use UTF-8 characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#1873](https://github.com/oauth2-proxy/oauth2-proxy/pull/1873) Fix empty users with some OIDC providers (@babs)
 - [#1882](https://github.com/oauth2-proxy/oauth2-proxy/pull/1882) Make `htpasswd.GetUsers` racecondition safe
 - [#1883](https://github.com/oauth2-proxy/oauth2-proxy/pull/1883) Ensure v8 manifest variant is set on docker images
+- [#1906](https://github.com/oauth2-proxy/oauth2-proxy/pull/1906) Fix PKCE code verifier generation to never use UTF-8 characters
 
 # V7.4.0
 

--- a/pkg/encryption/utils.go
+++ b/pkg/encryption/utils.go
@@ -2,10 +2,12 @@ package encryption
 
 import (
 	"crypto/hmac"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
 	"hash"
+	"math/big"
 	"net/http"
 	"strconv"
 	"strings"
@@ -15,6 +17,7 @@ import (
 const (
 	CodeChallengeMethodPlain = "plain"
 	CodeChallengeMethodS256  = "S256"
+	asciiCharset             = " !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
 )
 
 // SecretBytes attempts to base64 decode the secret, if that fails it treats the secret as binary
@@ -78,6 +81,19 @@ func SignedValue(seed string, key string, value []byte, now time.Time) (string, 
 	}
 	cookieVal := fmt.Sprintf("%s|%s|%s", encodedValue, timeStr, sig)
 	return cookieVal, nil
+}
+
+func GenerateRandomASCIIString(length int) (string, error) {
+	b := make([]byte, length)
+	charsetLen := new(big.Int).SetInt64(int64(len(asciiCharset)))
+	for i := range b {
+		character, err := rand.Int(rand.Reader, charsetLen)
+		if err != nil {
+			return "", err
+		}
+		b[i] = asciiCharset[character.Int64()]
+	}
+	return string(b), nil
 }
 
 func GenerateCodeChallenge(method, codeVerifier string) (string, error) {

--- a/pkg/encryption/utils_test.go
+++ b/pkg/encryption/utils_test.go
@@ -7,7 +7,9 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+	"strings"
 	"testing"
+	"unicode"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -99,4 +101,21 @@ func TestSignAndValidate(t *testing.T) {
 
 	assert.False(t, checkSignature(sha256sig, seed, key, "tampered", epoch))
 	assert.False(t, checkSignature(sha1sig, seed, key, "tampered", epoch))
+}
+
+func TestGenerateRandomASCIIString(t *testing.T) {
+	randomString, err := GenerateRandomASCIIString(96)
+	assert.NoError(t, err)
+
+	// Only 8-bit characters
+	assert.Equal(t, 96, len([]byte(randomString)))
+
+	// All non-ascii characters removed should still be the original string
+	removedChars := strings.Map(func(r rune) rune {
+		if r > unicode.MaxASCII {
+			return -1
+		}
+		return r
+	}, randomString)
+	assert.Equal(t, removedChars, randomString)
 }


### PR DESCRIPTION
## Description

Fix PKCE code verifier generation to never use UTF-8 characters
- This could result in intermittent/random failures of PKCE enabled IdP's

Fixes #1897

## Motivation and Context

See #1897 

## How Has This Been Tested?

Included test cases + test setup with DexIDP

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
