### PR TITLE
fix: role extraction from access token in keycloak oidc 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - [#3031](https://github.com/oauth2-proxy/oauth2-proxy/pull/3031) Fixes Refresh Token bug with Entra ID and Workload Identity (#3027)[https://github.com/oauth2-proxy/oauth2-proxy/issues/3028] by using client assertion when redeeming the token (@richard87)
 - [#3001](https://github.com/oauth2-proxy/oauth2-proxy/pull/3001) Allow to set non-default authorization request response mode (@stieler-it)
 - [#3041](https://github.com/oauth2-proxy/oauth2-proxy/pull/3041) chore(deps): upgrade to latest golang v1.23.x release (@TheImplementer)
-- [#1916](https://github.com/oauth2-proxy/oauth2-proxy/pull/1916) Keycloak OIDC provider now uses id token instead of access token (@Elektordi)
+- [#1916](https://github.com/oauth2-proxy/oauth2-proxy/pull/1916) fix: role extraction from access token in keycloak oidc (@Elektordi / @tuunit)
 
 # V7.8.2
 
@@ -222,11 +222,6 @@ The following PR introduces a change to how auth routes are evaluated using the 
 
 ## Changes since v7.4.0
 - [#2028](https://github.com/oauth2-proxy/oauth2-proxy/pull/2028) Update golang.org/x/net to v0.7.0 ato address GHSA-vvpx-j8f3-3w6h (@amrmahdi)
-=======
-- [#1916](https://github.com/oauth2-proxy/oauth2-proxy/pull/1916) Keycloak OIDC provider was using access token instead of id token. After upgrade, it may raise errors on login for people using provider "keycloak-oidc" (not "keycloak") and having customized their tokens in keycloak configuration.
-
-## Changes since v7.4.0
-
 - [#1873](https://github.com/oauth2-proxy/oauth2-proxy/pull/1873) Fix empty users with some OIDC providers (@babs)
 - [#1882](https://github.com/oauth2-proxy/oauth2-proxy/pull/1882) Make `htpasswd.GetUsers` racecondition safe (@babs)
 - [#1883](https://github.com/oauth2-proxy/oauth2-proxy/pull/1883) Ensure v8 manifest variant is set on docker images (@braunsonm)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#3031](https://github.com/oauth2-proxy/oauth2-proxy/pull/3031) Fixes Refresh Token bug with Entra ID and Workload Identity (#3027)[https://github.com/oauth2-proxy/oauth2-proxy/issues/3028] by using client assertion when redeeming the token (@richard87)
 - [#3001](https://github.com/oauth2-proxy/oauth2-proxy/pull/3001) Allow to set non-default authorization request response mode (@stieler-it)
 - [#3041](https://github.com/oauth2-proxy/oauth2-proxy/pull/3041) chore(deps): upgrade to latest golang v1.23.x release (@TheImplementer)
+- [#1916](https://github.com/oauth2-proxy/oauth2-proxy/pull/1916) Keycloak OIDC provider now uses id token instead of access token (@Elektordi)
 
 # V7.8.2
 
@@ -221,6 +222,11 @@ The following PR introduces a change to how auth routes are evaluated using the 
 
 ## Changes since v7.4.0
 - [#2028](https://github.com/oauth2-proxy/oauth2-proxy/pull/2028) Update golang.org/x/net to v0.7.0 ato address GHSA-vvpx-j8f3-3w6h (@amrmahdi)
+=======
+- [#1916](https://github.com/oauth2-proxy/oauth2-proxy/pull/1916) Keycloak OIDC provider was using access token instead of id token. After upgrade, it may raise errors on login for people using provider "keycloak-oidc" (not "keycloak") and having customized their tokens in keycloak configuration.
+
+## Changes since v7.4.0
+
 - [#1873](https://github.com/oauth2-proxy/oauth2-proxy/pull/1873) Fix empty users with some OIDC providers (@babs)
 - [#1882](https://github.com/oauth2-proxy/oauth2-proxy/pull/1882) Make `htpasswd.GetUsers` racecondition safe (@babs)
 - [#1883](https://github.com/oauth2-proxy/oauth2-proxy/pull/1883) Ensure v8 manifest variant is set on docker images (@braunsonm)

--- a/providers/keycloak_oidc.go
+++ b/providers/keycloak_oidc.go
@@ -2,7 +2,10 @@ package providers
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/sessions"
@@ -51,7 +54,7 @@ func (p *KeycloakOIDCProvider) CreateSessionFromToken(ctx context.Context, token
 	}
 
 	// Extract custom keycloak roles and enrich session
-	if err := p.extractRoles(ctx, ss); err != nil {
+	if err := p.extractRoles(ss); err != nil {
 		return nil, err
 	}
 
@@ -65,7 +68,7 @@ func (p *KeycloakOIDCProvider) EnrichSession(ctx context.Context, s *sessions.Se
 	if err != nil {
 		return fmt.Errorf("could not enrich oidc session: %v", err)
 	}
-	return p.extractRoles(ctx, s)
+	return p.extractRoles(s)
 }
 
 // RefreshSession adds role extraction logic to the refresh flow
@@ -77,11 +80,11 @@ func (p *KeycloakOIDCProvider) RefreshSession(ctx context.Context, s *sessions.S
 		return refreshed, err
 	}
 
-	return true, p.extractRoles(ctx, s)
+	return true, p.extractRoles(s)
 }
 
-func (p *KeycloakOIDCProvider) extractRoles(ctx context.Context, s *sessions.SessionState) error {
-	claims, err := p.getAccessClaims(ctx, s)
+func (p *KeycloakOIDCProvider) extractRoles(s *sessions.SessionState) error {
+	claims, err := p.getAccessClaims(s)
 	if err != nil {
 		return err
 	}
@@ -106,17 +109,22 @@ type accessClaims struct {
 	ResourceAccess map[string]interface{} `json:"resource_access"`
 }
 
-func (p *KeycloakOIDCProvider) getAccessClaims(ctx context.Context, s *sessions.SessionState) (*accessClaims, error) {
-	token, err := p.Verifier.Verify(ctx, s.IDToken)
-	if err != nil {
-		return nil, err
+func (p *KeycloakOIDCProvider) getAccessClaims(s *sessions.SessionState) (*accessClaims, error) {
+	parts := strings.Split(s.AccessToken, ".")
+	if len(parts) < 2 {
+		return nil, fmt.Errorf("malformed access token, expected 3 parts got %d", len(parts))
 	}
 
-	var claims *accessClaims
-	if err = token.Claims(&claims); err != nil {
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("malformed access token, couldn't extract jwt payload: %v", err)
+	}
+
+	var claims accessClaims
+	if err := json.Unmarshal(payload, &claims); err != nil {
 		return nil, err
 	}
-	return claims, nil
+	return &claims, nil
 }
 
 // getClientRoles extracts client roles from the `resource_access` claim with

--- a/providers/keycloak_oidc.go
+++ b/providers/keycloak_oidc.go
@@ -107,8 +107,7 @@ type accessClaims struct {
 }
 
 func (p *KeycloakOIDCProvider) getAccessClaims(ctx context.Context, s *sessions.SessionState) (*accessClaims, error) {
-	// HACK: This isn't an ID Token, but has similar structure & signing
-	token, err := p.Verifier.Verify(ctx, s.AccessToken)
+	token, err := p.Verifier.Verify(ctx, s.IDToken)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/keycloak_oidc_test.go
+++ b/providers/keycloak_oidc_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 
 	"github.com/coreos/go-oidc/v3/oidc"
 
@@ -18,28 +19,40 @@ import (
 )
 
 const (
-	idTokenHeader        = "ewogICJhbGciOiAiUlMyNTYiLAogICJ0eXAiOiAiSldUIgp9"
-	idTokenSignature     = "dyt0CoTl4WoVjAHI9Q_CwSKhl6d_9rhM3NrXuJttkao"
+	idTokenHeader        = "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJjV1IteTRzRVU1MjZVelk1SFd6UEZJbWdMMWRKUllfQ0gyY1FFRXh4UGN3In0"
+	idTokenSignature     = "Rh0zQGhWAm-2hn5JTWB3Lzuk9Ahpzs7As7ks-1VInl4"
+	accessTokenHeader    = "ewogICJhbGciOiAiUlMyNTYiLAogICJ0eXAiOiAiSldUIgp9"
+	accessTokenSignature = "dyt0CoTl4WoVjAHI9Q_CwSKhl6d_9rhM3NrXuJttkao"
 	defaultAudienceClaim = "aud"
 	mockClientID         = "cd6d4fae-f6a6-4a34-8454-2c6b598e9532"
 )
 
-var idTokenPayload = base64.StdEncoding.EncodeToString([]byte(
-	fmt.Sprintf(`{"%s": "%s", "realm_access": {"roles": ["write"]}, "resource_access": {"default": {"roles": ["read"]}}}`, defaultAudienceClaim, mockClientID)))
+var (
+	accessTokenPayload = base64.RawURLEncoding.EncodeToString([]byte(
+		fmt.Sprintf(`{"%s": "%s", "realm_access": {"roles": ["write"]}, "resource_access": {"default": {"roles": ["read"]}}}`, defaultAudienceClaim, mockClientID)))
+
+	idTokenPayload = base64.RawURLEncoding.EncodeToString([]byte(
+		fmt.Sprintf(`{"%s": "%s"}`, defaultAudienceClaim, mockClientID)))
+)
 
 type DummyKeySet struct{}
 
-func (DummyKeySet) VerifySignature(_ context.Context, _ string) (payload []byte, err error) {
-	p, _ := base64.RawURLEncoding.DecodeString(idTokenPayload)
+func (DummyKeySet) VerifySignature(_ context.Context, jwt string) (payload []byte, err error) {
+	parts := strings.Split(jwt, ".")
+	p, _ := base64.RawURLEncoding.DecodeString(parts[1])
 	return p, nil
 }
 
-func getIdToken() string {
+func makeIDToken() string {
 	return fmt.Sprintf("%s.%s.%s", idTokenHeader, idTokenPayload, idTokenSignature)
 }
 
+func makeAccessToken() string {
+	return fmt.Sprintf("%s.%s.%s", accessTokenHeader, accessTokenPayload, accessTokenSignature)
+}
+
 func newTestKeycloakOIDCSetup() (*httptest.Server, *KeycloakOIDCProvider) {
-	redeemURL, server := newOIDCServer([]byte(fmt.Sprintf(`{"email": "new@thing.com", "expires_in": 300, "id_token": "%v", "access_token": "%v"}`, getIdToken(), getIdToken())))
+	redeemURL, server := newOIDCServer([]byte(fmt.Sprintf(`{"email": "new@thing.com", "expires_in": 300, "id_token": "%v", "access_token": "%v"}`, makeIDToken(), makeAccessToken())))
 	provider := newKeycloakOIDCProvider(redeemURL, options.Provider{})
 	return server, provider
 }
@@ -134,16 +147,16 @@ var _ = Describe("Keycloak OIDC Provider Tests", func() {
 				User:         "already",
 				Email:        "a@b.com",
 				Groups:       nil,
-				IDToken:      getIdToken(),
-				AccessToken:  accessToken,
+				IDToken:      makeIDToken(),
+				AccessToken:  makeAccessToken(),
 				RefreshToken: refreshToken,
 			}
 			expectedSession := &sessions.SessionState{
 				User:         "already",
 				Email:        "a@b.com",
 				Groups:       []string{"role:write", "role:default:read"},
-				IDToken:      getIdToken(),
-				AccessToken:  accessToken,
+				IDToken:      makeIDToken(),
+				AccessToken:  makeAccessToken(),
 				RefreshToken: refreshToken,
 			}
 
@@ -164,16 +177,16 @@ var _ = Describe("Keycloak OIDC Provider Tests", func() {
 				User:         "already",
 				Email:        "a@b.com",
 				Groups:       []string{"existing", "group"},
-				IDToken:      getIdToken(),
-				AccessToken:  accessToken,
+				IDToken:      makeIDToken(),
+				AccessToken:  makeAccessToken(),
 				RefreshToken: refreshToken,
 			}
 			expectedSession := &sessions.SessionState{
 				User:         "already",
 				Email:        "a@b.com",
 				Groups:       []string{"existing", "group", "role:write", "role:default:read"},
-				IDToken:      getIdToken(),
-				AccessToken:  accessToken,
+				IDToken:      makeIDToken(),
+				AccessToken:  makeAccessToken(),
 				RefreshToken: refreshToken,
 			}
 
@@ -196,8 +209,8 @@ var _ = Describe("Keycloak OIDC Provider Tests", func() {
 				User:         "already",
 				Email:        "a@b.com",
 				Groups:       nil,
-				IDToken:      getIdToken(),
-				AccessToken:  accessToken,
+				IDToken:      makeIDToken(),
+				AccessToken:  makeAccessToken(),
 				RefreshToken: refreshToken,
 			}
 
@@ -219,7 +232,7 @@ var _ = Describe("Keycloak OIDC Provider Tests", func() {
 
 			provider.ProfileURL = url
 
-			session, err := provider.CreateSessionFromToken(context.Background(), getIdToken())
+			session, err := provider.CreateSessionFromToken(context.Background(), makeAccessToken())
 			Expect(err).To(BeNil())
 			Expect(session.ExpiresOn).ToNot(BeNil())
 			Expect(session.CreatedAt).ToNot(BeNil())


### PR DESCRIPTION
The keycloak_oidc provider uses the access_token instead of the id_token.

## Description

I had 500 errors when using keycloak_oidc provider out of the box, and logs where indicating a problem with the audience:

```[oauthproxy.go:830] Error creating session during OAuth2 callback: audience claims [aud] do not exist in claims: [...]```

## Motivation and Context

oauth2-proxy relies on the audience "aud" field, and the officiel keycloak documentation states that the access_token is not design to hold the audience of the client requesting the token:

https://www.keycloak.org/docs/latest/server_admin/#_audience_resolve

> The frontend client itself is not automatically added to the access token audience, therefore allowing easy differentiation between the access token and the ID token, since the access token will not contain the client for which the token is issued as an audience.

It is the id_token which is designed for this, and this token is for the OIDC protocol. (where the access_token is for OAuth2 protocol)

It was also confirmed by Keycloak devs on their mailing list some time ago: https://lists.jboss.org/pipermail/keycloak-user/2019-August/018924.html

## How Has This Been Tested?

It has been tested with a brand now keycloak and oauth2-proxy, both deployed with docker, and using traefik/whoami as a backend.
Command line: `docker run --rm --name oauth2proxy -p 4180:4180 oauth2-proxy --provider=keycloak-oidc --oidc-issuer-url=http://172.17.0.1:8080/realms/test --email-domain=* --upstream=http://172.17.0.1:49156/ --reverse-proxy --http-address=0.0.0.0:4180 --client-id=dev-localhost --client-secret=xxxxxxxxxxxx --cookie-secret=xxxxxxxxxxxxxxxx --redirect-url=http://localhost:4180/oauth2/callback --skip-jwt-bearer-tokens --insecure-oidc-allow-unverified-email`

It was tested with both web access, and bearer api access.

Before change: HTTP 500 error on auth2-proxy

After change : No problem.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.

(I'm not sure if I need to update "Breaking Changes" in CHANGELOG, because it may break installations where people have customized their KC to add specific stuff to their access_token, even is the specs says you should not)