### PR TITLE
Fill empty UserIDClaim before assigning it to other values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [#1906](https://github.com/oauth2-proxy/oauth2-proxy/pull/1906) Fix PKCE code verifier generation to never use UTF-8 characters
 - [#1839](https://github.com/oauth2-proxy/oauth2-proxy/pull/1839) Add readiness checks for deeper health checks (@kobim)
 - [#1927](https://github.com/oauth2-proxy/oauth2-proxy/pull/1927) Fix default scope settings for none oidc providers
+- [#1920](https://github.com/oauth2-proxy/oauth2-proxy/pull/1920) Make sure emailClaim is not overriden if userIDClaim is not set
 
 
 # V7.4.0

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -145,6 +145,10 @@ func newProviderDataFromConfig(providerConfig options.Provider) (*ProviderData, 
 		logger.Printf("Warning: Your provider supports PKCE methods %+q, but you have not enabled one with --code-challenge-method", p.SupportedCodeChallengeMethods)
 	}
 
+	if providerConfig.OIDCConfig.UserIDClaim == "" {
+		providerConfig.OIDCConfig.UserIDClaim = "email"
+	}
+
 	// TODO (@NickMeves) - Remove This
 	// Backwards Compatibility for Deprecated UserIDClaim option
 	if providerConfig.OIDCConfig.EmailClaim == options.OIDCEmailClaim &&
@@ -158,9 +162,6 @@ func newProviderDataFromConfig(providerConfig options.Provider) (*ProviderData, 
 		if len(providerConfig.AllowedGroups) > 0 {
 			p.Scope += " groups"
 		}
-	}
-	if providerConfig.OIDCConfig.UserIDClaim == "" {
-		providerConfig.OIDCConfig.UserIDClaim = "email"
 	}
 
 	p.setAllowedGroups(providerConfig.AllowedGroups)


### PR DESCRIPTION
the email claim gets overridden if userIDClaim is not set.

## Description

During login I am getting the error:

```
 Error creating session during OAuth2 callback: neither the id_token nor the profileURL set an email
```

## Motivation and Context

It seems to be related to:
https://github.com/oauth2-proxy/oauth2-proxy/issues/1623
https://github.com/oauth2-proxy/oauth2-proxy/issues/1732

The underlying problem seems to be the code that handles `Backwards Compatibility for Deprecated UserIDClaim option`. it overrides the EmailClaim if they are different. But at that point the UserIDClaim is still empty, if not explicitly set and so it clears EmailClaim. Later in the code it actually is explicitly set, so I just pulled this piece of code up.
As this seems to be a workaround I am unsure about the behavior it should have and potential additional side-effects.

## How Has This Been Tested?

I wrote a new test-case.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
