### PR TITLE
Replace --skip-auth-regex with --skip-auth-route

### DIFF
--- a/docs/versioned_docs/version-7.4.x/behaviour.md
+++ b/docs/versioned_docs/version-7.4.x/behaviour.md
@@ -3,7 +3,7 @@ id: behaviour
 title: Behaviour
 ---
 
-1. Any request passing through the proxy (and not matched by `--skip-auth-regex`) is checked for the proxy's session cookie (`--cookie-name`) (or, if allowed, a JWT token - see `--skip-jwt-bearer-tokens`).
+1. Any request passing through the proxy (and not matched by `--skip-auth-route`) is checked for the proxy's session cookie (`--cookie-name`) (or, if allowed, a JWT token - see `--skip-jwt-bearer-tokens`).
 2. If authentication is required but missing then the user is asked to log in and redirected to the authentication provider (unless it is an Ajax request, i.e. one with `Accept: application/json`, in which case 401 Unauthorized is returned)
 3. After returning from the authentication provider, the oauth tokens are stored in the configured session store (cookie, redis, ...) and a cookie is set
 4. The request is forwarded to the upstream server with added user info and authentication headers (depending on the configuration)


### PR DESCRIPTION
The Behaviour page references a deprecated flag (`--skip-auth-regex`), replacing with `--skip-auth-route`.

According to the 7.4 Configuration overview, [the `--skip-auth-regex` flag is deprecated](https://github.com/oauth2-proxy/oauth2-proxy/blob/0832488af39a7a7b19d3fa0092fdbd47cdbdb093/docs/versioned_docs/version-7.4.x/configuration/overview.md?plain=1#L189).

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
