### PR TITLE
fix default scope settings for none oidc providers

### DIFF
--- a/providers/providers.go
+++ b/providers/providers.go
@@ -152,7 +152,7 @@ func newProviderDataFromConfig(providerConfig options.Provider) (*ProviderData, 
 		p.EmailClaim = providerConfig.OIDCConfig.UserIDClaim
 	}
 
-	if p.Scope == "" {
+	if p.ProviderName == "oidc" && p.Scope == "" {
 		p.Scope = "openid email profile"
 
 		if len(providerConfig.AllowedGroups) > 0 {

--- a/providers/providers_test.go
+++ b/providers/providers_test.go
@@ -125,32 +125,48 @@ func TestScope(t *testing.T) {
 
 	testCases := []struct {
 		name            string
+		configuredType  options.ProviderType
 		configuredScope string
 		expectedScope   string
 		allowedGroups   []string
 	}{
 		{
-			name:            "with no scope provided",
+			name:            "oidc: with no scope provided",
+			configuredType:  "oidc",
 			configuredScope: "",
 			expectedScope:   "openid email profile",
 		},
 		{
-			name:            "with no scope provided and groups",
+			name:            "oidc: with no scope provided and groups",
+			configuredType:  "oidc",
 			configuredScope: "",
 			expectedScope:   "openid email profile groups",
 			allowedGroups:   []string{"foo"},
 		},
 		{
-			name:            "with a configured scope provided",
+			name:            "oidc: with a configured scope provided",
+			configuredType:  "oidc",
 			configuredScope: "openid",
 			expectedScope:   "openid",
+		},
+		{
+			name:            "github: with no scope provided",
+			configuredType:  "github",
+			configuredScope: "",
+			expectedScope:   "user:email",
+		},
+		{
+			name:            "github: with a configured scope provided",
+			configuredType:  "github",
+			configuredScope: "user:email org:read",
+			expectedScope:   "user:email org:read",
 		},
 	}
 
 	for _, tc := range testCases {
 		providerConfig := options.Provider{
 			ID:               providerID,
-			Type:             "oidc",
+			Type:             tc.configuredType,
 			ClientID:         clientID,
 			ClientSecretFile: clientSecret,
 			LoginURL:         msAuthURL,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
As described in detail in bug #1903 and related to #1724.
The current implementation overrides the default scope for all providers with the default oidc scopes when no scope is set in the configuration file. Which is obviously not the expected behaviour.

As the config file values are loaded before the default values of the providers:
https://github.com/oauth2-proxy/oauth2-proxy/blob/fd2807c091686a2a23f41123e3470a1076e877a0/providers/providers.go#L34-L71

https://github.com/oauth2-proxy/oauth2-proxy/blob/fd2807c091686a2a23f41123e3470a1076e877a0/providers/providers.go#L155-L169

The scope is overwritten with "openid email profile" which leads to issues later on in the setProviderDefaults method. As the p.Scope will never be empty, therefore all provider default scopes are ignored.
https://github.com/oauth2-proxy/oauth2-proxy/blob/fd2807c091686a2a23f41123e3470a1076e877a0/providers/provider_data.go#L197-L199

<!--- Describe your changes in detail -->

I added a check for the providerName as an additional condition in the default setter while loading the data from config file.

## How Has This Been Tested?

I tested it locally with GitHub and dex, to ensure both implementations still work and I extended the unit test cases.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
