### PR TITLE
Remove unsupported special characters from the code verifier runes

### DIFF
--- a/pkg/encryption/utils.go
+++ b/pkg/encryption/utils.go
@@ -17,7 +17,7 @@ import (
 const (
 	CodeChallengeMethodPlain = "plain"
 	CodeChallengeMethodS256  = "S256"
-	asciiCharset             = " !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
+	asciiCharset             = "-.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz~"
 )
 
 // SecretBytes attempts to base64 decode the secret, if that fails it treats the secret as binary


### PR DESCRIPTION
## Description

- Not all special ASCII characters are strictly supported by the spec

See discussion here: https://github.com/oauth2-proxy/oauth2-proxy/pull/1906
