### PR TITLE
GKE Workload Identity support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [#1906](https://github.com/oauth2-proxy/oauth2-proxy/pull/1906) Fix PKCE code verifier generation to never use UTF-8 characters
 - [#1839](https://github.com/oauth2-proxy/oauth2-proxy/pull/1839) Add readiness checks for deeper health checks (@kobim)
 - [#1927](https://github.com/oauth2-proxy/oauth2-proxy/pull/1927) Fix default scope settings for none oidc providers
+- [#1967](https://github.com/oauth2-proxy/oauth2-proxy/pull/1967) Added support for GKE Workload Identity (@kvanzuijlen)
 
 
 # V7.4.0

--- a/docs/docs/configuration/overview.md
+++ b/docs/docs/configuration/overview.md
@@ -120,6 +120,8 @@ An example [oauth2-proxy.cfg](https://github.com/oauth2-proxy/oauth2-proxy/blob/
 | `--google-admin-email` | string | the google admin to impersonate for api calls | |
 | `--google-group` | string | restrict logins to members of this google group (may be given multiple times). | |
 | `--google-service-account-json` | string | the path to the service account json credentials | |
+| `--google-use-application-default-credentials` | bool | use application default credentials instead of service account json (i.e. GKE Workload Identity) | |
+| `--google-target-principal` | string | service account to use/impersonate | |
 | `--htpasswd-file` | string | additionally authenticate against a htpasswd file. Entries must be created with `htpasswd -B` for bcrypt encryption | |
 | `--htpasswd-user-group` | string \| list | the groups to be set on sessions for htpasswd users | |
 | `--http-address` | string | `[http://]<addr>:<port>` or `unix://<path>` to listen on for HTTP clients. Square brackets are required for ipv6 address, e.g. `http://[::1]:4180` | `"127.0.0.1:4180"` |

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -124,7 +124,7 @@ func NewOAuthProxy(opts *options.Options, validator func(string) bool) (*OAuthPr
 
 	provider, err := providers.NewProvider(opts.Providers[0])
 	if err != nil {
-		return nil, fmt.Errorf("error intiailising provider: %v", err)
+		return nil, fmt.Errorf("error initiailising provider: %v", err)
 	}
 
 	pageWriter, err := pagewriter.NewWriter(pagewriter.Opts{

--- a/pkg/apis/options/legacy_options.go
+++ b/pkg/apis/options/legacy_options.go
@@ -554,7 +554,7 @@ func legacyProviderFlagSet() *pflag.FlagSet {
 	flagSet.StringSlice("google-group", []string{}, "restrict logins to members of this google group (may be given multiple times).")
 	flagSet.String("google-admin-email", "", "the google admin to impersonate for api calls")
 	flagSet.String("google-service-account-json", "", "the path to the service account json credentials")
-	flagSet.String("google-use-application-default-credentials", "", "use application default credentials instead of service account json (i.e. Workload Identity)")
+	flagSet.String("google-use-application-default-credentials", "", "use application default credentials instead of service account json (i.e. GKE Workload Identity)")
 	flagSet.String("google-target-principal", "", "service account to use/impersonate")
 	flagSet.String("client-id", "", "the OAuth Client ID: ie: \"123456.apps.googleusercontent.com\"")
 	flagSet.String("client-secret", "", "the OAuth Client Secret")

--- a/pkg/apis/options/legacy_options.go
+++ b/pkg/apis/options/legacy_options.go
@@ -555,6 +555,7 @@ func legacyProviderFlagSet() *pflag.FlagSet {
 	flagSet.String("google-admin-email", "", "the google admin to impersonate for api calls")
 	flagSet.String("google-service-account-json", "", "the path to the service account json credentials")
 	flagSet.String("google-use-application-default-credentials", "", "use application default credentials instead of service account json (i.e. Workload Identity)")
+	flagSet.String("google-target-principal", "", "service account to use/impersonate")
 	flagSet.String("client-id", "", "the OAuth Client ID: ie: \"123456.apps.googleusercontent.com\"")
 	flagSet.String("client-secret", "", "the OAuth Client Secret")
 	flagSet.String("client-secret-file", "", "the file with OAuth Client Secret")

--- a/pkg/apis/options/legacy_options.go
+++ b/pkg/apis/options/legacy_options.go
@@ -497,6 +497,7 @@ type LegacyProvider struct {
 	GoogleAdminEmail                       string   `flag:"google-admin-email" cfg:"google_admin_email"`
 	GoogleServiceAccountJSON               string   `flag:"google-service-account-json" cfg:"google_service_account_json"`
 	GoogleUseApplicationDefaultCredentials bool     `flag:"google-use-application-default-credentials" cfg:"google_use_application_default_credentials"`
+	TargetPrincipal                        string   `flag:"google-target-principal" cfg:"google_target_principal"`
 
 	// These options allow for other providers besides Google, with
 	// potential overrides.
@@ -724,6 +725,7 @@ func (l *LegacyProvider) convert() (Providers, error) {
 			AdminEmail:                       l.GoogleAdminEmail,
 			ServiceAccountJSON:               l.GoogleServiceAccountJSON,
 			UseApplicationDefaultCredentials: l.GoogleUseApplicationDefaultCredentials,
+			TargetPrincipal:                  l.TargetPrincipal,
 		}
 	}
 

--- a/pkg/apis/options/legacy_options.go
+++ b/pkg/apis/options/legacy_options.go
@@ -481,21 +481,22 @@ type LegacyProvider struct {
 	ClientSecret     string `flag:"client-secret" cfg:"client_secret"`
 	ClientSecretFile string `flag:"client-secret-file" cfg:"client_secret_file"`
 
-	KeycloakGroups           []string `flag:"keycloak-group" cfg:"keycloak_groups"`
-	AzureTenant              string   `flag:"azure-tenant" cfg:"azure_tenant"`
-	AzureGraphGroupField     string   `flag:"azure-graph-group-field" cfg:"azure_graph_group_field"`
-	BitbucketTeam            string   `flag:"bitbucket-team" cfg:"bitbucket_team"`
-	BitbucketRepository      string   `flag:"bitbucket-repository" cfg:"bitbucket_repository"`
-	GitHubOrg                string   `flag:"github-org" cfg:"github_org"`
-	GitHubTeam               string   `flag:"github-team" cfg:"github_team"`
-	GitHubRepo               string   `flag:"github-repo" cfg:"github_repo"`
-	GitHubToken              string   `flag:"github-token" cfg:"github_token"`
-	GitHubUsers              []string `flag:"github-user" cfg:"github_users"`
-	GitLabGroup              []string `flag:"gitlab-group" cfg:"gitlab_groups"`
-	GitLabProjects           []string `flag:"gitlab-project" cfg:"gitlab_projects"`
-	GoogleGroups             []string `flag:"google-group" cfg:"google_group"`
-	GoogleAdminEmail         string   `flag:"google-admin-email" cfg:"google_admin_email"`
-	GoogleServiceAccountJSON string   `flag:"google-service-account-json" cfg:"google_service_account_json"`
+	KeycloakGroups                         []string `flag:"keycloak-group" cfg:"keycloak_groups"`
+	AzureTenant                            string   `flag:"azure-tenant" cfg:"azure_tenant"`
+	AzureGraphGroupField                   string   `flag:"azure-graph-group-field" cfg:"azure_graph_group_field"`
+	BitbucketTeam                          string   `flag:"bitbucket-team" cfg:"bitbucket_team"`
+	BitbucketRepository                    string   `flag:"bitbucket-repository" cfg:"bitbucket_repository"`
+	GitHubOrg                              string   `flag:"github-org" cfg:"github_org"`
+	GitHubTeam                             string   `flag:"github-team" cfg:"github_team"`
+	GitHubRepo                             string   `flag:"github-repo" cfg:"github_repo"`
+	GitHubToken                            string   `flag:"github-token" cfg:"github_token"`
+	GitHubUsers                            []string `flag:"github-user" cfg:"github_users"`
+	GitLabGroup                            []string `flag:"gitlab-group" cfg:"gitlab_groups"`
+	GitLabProjects                         []string `flag:"gitlab-project" cfg:"gitlab_projects"`
+	GoogleGroups                           []string `flag:"google-group" cfg:"google_group"`
+	GoogleAdminEmail                       string   `flag:"google-admin-email" cfg:"google_admin_email"`
+	GoogleServiceAccountJSON               string   `flag:"google-service-account-json" cfg:"google_service_account_json"`
+	GoogleUseApplicationDefaultCredentials bool     `flag:"google-use-application-default-credentials" cfg:"google_use_application_default_credentials"`
 
 	// These options allow for other providers besides Google, with
 	// potential overrides.
@@ -552,6 +553,7 @@ func legacyProviderFlagSet() *pflag.FlagSet {
 	flagSet.StringSlice("google-group", []string{}, "restrict logins to members of this google group (may be given multiple times).")
 	flagSet.String("google-admin-email", "", "the google admin to impersonate for api calls")
 	flagSet.String("google-service-account-json", "", "the path to the service account json credentials")
+	flagSet.String("google-use-application-default-credentials", "", "use application default credentials instead of service account json (i.e. Workload Identity)")
 	flagSet.String("client-id", "", "the OAuth Client ID: ie: \"123456.apps.googleusercontent.com\"")
 	flagSet.String("client-secret", "", "the OAuth Client Secret")
 	flagSet.String("client-secret-file", "", "the file with OAuth Client Secret")
@@ -718,9 +720,10 @@ func (l *LegacyProvider) convert() (Providers, error) {
 		}
 	case "google":
 		provider.GoogleConfig = GoogleOptions{
-			Groups:             l.GoogleGroups,
-			AdminEmail:         l.GoogleAdminEmail,
-			ServiceAccountJSON: l.GoogleServiceAccountJSON,
+			Groups:                           l.GoogleGroups,
+			AdminEmail:                       l.GoogleAdminEmail,
+			ServiceAccountJSON:               l.GoogleServiceAccountJSON,
+			UseApplicationDefaultCredentials: l.GoogleUseApplicationDefaultCredentials,
 		}
 	}
 

--- a/pkg/apis/options/providers.go
+++ b/pkg/apis/options/providers.go
@@ -189,8 +189,10 @@ type GoogleOptions struct {
 	AdminEmail string `json:"adminEmail,omitempty"`
 	// ServiceAccountJSON is the path to the service account json credentials
 	ServiceAccountJSON string `json:"serviceAccountJson,omitempty"`
-	// UseApplicationDefaultCredentials is a boolean whether or not to use Application Default credentials instead of a ServiceAccountJSON
+	// UseApplicationDefaultCredentials is a boolean whether to use Application Default Credentials instead of a ServiceAccountJSON
 	UseApplicationDefaultCredentials bool `json:"useApplicationDefaultCredentials,omitempty"`
+	// TargetPrincipal is the Google Service Account to impersonate when using Application Default Credentials
+	TargetPrincipal string `json:"targetPrincipal,omitempty"`
 }
 
 type OIDCOptions struct {

--- a/pkg/apis/options/providers.go
+++ b/pkg/apis/options/providers.go
@@ -189,6 +189,8 @@ type GoogleOptions struct {
 	AdminEmail string `json:"adminEmail,omitempty"`
 	// ServiceAccountJSON is the path to the service account json credentials
 	ServiceAccountJSON string `json:"serviceAccountJson,omitempty"`
+	// UseApplicationDefaultCredentials is a boolean whether or not to use Application Default credentials instead of a ServiceAccountJSON
+	UseApplicationDefaultCredentials bool `json:"useApplicationDefaultCredentials,omitempty"`
 }
 
 type OIDCOptions struct {

--- a/pkg/validation/providers.go
+++ b/pkg/validation/providers.go
@@ -68,17 +68,22 @@ func validateGoogleConfig(provider options.Provider) []string {
 	msgs := []string{}
 	if len(provider.GoogleConfig.Groups) > 0 ||
 		provider.GoogleConfig.AdminEmail != "" ||
-		provider.GoogleConfig.ServiceAccountJSON != "" {
+		provider.GoogleConfig.ServiceAccountJSON != "" ||
+		provider.GoogleConfig.UseApplicationDefaultCredentials {
 		if len(provider.GoogleConfig.Groups) < 1 {
 			msgs = append(msgs, "missing setting: google-group")
 		}
 		if provider.GoogleConfig.AdminEmail == "" {
 			msgs = append(msgs, "missing setting: google-admin-email")
 		}
-		if provider.GoogleConfig.ServiceAccountJSON == "" {
-			msgs = append(msgs, "missing setting: google-service-account-json")
-		} else if _, err := os.Stat(provider.GoogleConfig.ServiceAccountJSON); err != nil {
-			msgs = append(msgs, fmt.Sprintf("invalid Google credentials file: %s", provider.GoogleConfig.ServiceAccountJSON))
+		if provider.GoogleConfig.ServiceAccountJSON == "" && !provider.GoogleConfig.UseApplicationDefaultCredentials {
+			msgs = append(msgs, "missing setting: google-service-account-json or enable use-application-default-credentials")
+		} else if provider.GoogleConfig.UseApplicationDefaultCredentials && provider.GoogleConfig.ServiceAccountJSON != "" {
+			msgs = append(msgs, "invalid setting: can't configure both google-service-account-json and enable use-application-default-credentials")
+		} else if !provider.GoogleConfig.UseApplicationDefaultCredentials {
+			if _, err := os.Stat(provider.GoogleConfig.ServiceAccountJSON); err != nil {
+				msgs = append(msgs, fmt.Sprintf("invalid Google credentials file: %s", provider.GoogleConfig.ServiceAccountJSON))
+			}
 		}
 	}
 

--- a/pkg/validation/providers.go
+++ b/pkg/validation/providers.go
@@ -69,7 +69,8 @@ func validateGoogleConfig(provider options.Provider) []string {
 	if len(provider.GoogleConfig.Groups) == 0 &&
 		provider.GoogleConfig.AdminEmail == "" &&
 		provider.GoogleConfig.ServiceAccountJSON == "" &&
-		!provider.GoogleConfig.UseApplicationDefaultCredentials {
+		!provider.GoogleConfig.UseApplicationDefaultCredentials &&
+		provider.GoogleConfig.TargetPrincipal == "" {
 		return msgs
 	}
 
@@ -80,9 +81,11 @@ func validateGoogleConfig(provider options.Provider) []string {
 		msgs = append(msgs, "missing setting: google-admin-email")
 	}
 	if provider.GoogleConfig.ServiceAccountJSON == "" && !provider.GoogleConfig.UseApplicationDefaultCredentials {
-		msgs = append(msgs, "missing setting: google-service-account-json or enable use-application-default-credentials")
+		msgs = append(msgs, "missing setting: google-service-account-json or google-use-application-default-credentials")
 	} else if provider.GoogleConfig.UseApplicationDefaultCredentials && provider.GoogleConfig.ServiceAccountJSON != "" {
-		msgs = append(msgs, "invalid setting: can't configure both google-service-account-json and enable use-application-default-credentials")
+		msgs = append(msgs, "invalid setting: can't use both google-service-account-json and google-use-application-default-credentials")
+	} else if provider.GoogleConfig.UseApplicationDefaultCredentials && provider.GoogleConfig.TargetPrincipal == "" {
+		msgs = append(msgs, "missing setting: google-target-principal when google-use-application-default-credentials")
 	} else if !provider.GoogleConfig.UseApplicationDefaultCredentials {
 		if _, err := os.Stat(provider.GoogleConfig.ServiceAccountJSON); err != nil {
 			msgs = append(msgs, fmt.Sprintf("invalid Google credentials file: %s", provider.GoogleConfig.ServiceAccountJSON))

--- a/pkg/validation/providers.go
+++ b/pkg/validation/providers.go
@@ -66,24 +66,26 @@ func validateProvider(provider options.Provider, providerIDs map[string]struct{}
 
 func validateGoogleConfig(provider options.Provider) []string {
 	msgs := []string{}
-	if len(provider.GoogleConfig.Groups) > 0 ||
-		provider.GoogleConfig.AdminEmail != "" ||
-		provider.GoogleConfig.ServiceAccountJSON != "" ||
-		provider.GoogleConfig.UseApplicationDefaultCredentials {
-		if len(provider.GoogleConfig.Groups) < 1 {
-			msgs = append(msgs, "missing setting: google-group")
-		}
-		if provider.GoogleConfig.AdminEmail == "" {
-			msgs = append(msgs, "missing setting: google-admin-email")
-		}
-		if provider.GoogleConfig.ServiceAccountJSON == "" && !provider.GoogleConfig.UseApplicationDefaultCredentials {
-			msgs = append(msgs, "missing setting: google-service-account-json or enable use-application-default-credentials")
-		} else if provider.GoogleConfig.UseApplicationDefaultCredentials && provider.GoogleConfig.ServiceAccountJSON != "" {
-			msgs = append(msgs, "invalid setting: can't configure both google-service-account-json and enable use-application-default-credentials")
-		} else if !provider.GoogleConfig.UseApplicationDefaultCredentials {
-			if _, err := os.Stat(provider.GoogleConfig.ServiceAccountJSON); err != nil {
-				msgs = append(msgs, fmt.Sprintf("invalid Google credentials file: %s", provider.GoogleConfig.ServiceAccountJSON))
-			}
+	if len(provider.GoogleConfig.Groups) == 0 &&
+		provider.GoogleConfig.AdminEmail == "" &&
+		provider.GoogleConfig.ServiceAccountJSON == "" &&
+		!provider.GoogleConfig.UseApplicationDefaultCredentials {
+		return msgs
+	}
+
+	if len(provider.GoogleConfig.Groups) < 1 {
+		msgs = append(msgs, "missing setting: google-group")
+	}
+	if provider.GoogleConfig.AdminEmail == "" {
+		msgs = append(msgs, "missing setting: google-admin-email")
+	}
+	if provider.GoogleConfig.ServiceAccountJSON == "" && !provider.GoogleConfig.UseApplicationDefaultCredentials {
+		msgs = append(msgs, "missing setting: google-service-account-json or enable use-application-default-credentials")
+	} else if provider.GoogleConfig.UseApplicationDefaultCredentials && provider.GoogleConfig.ServiceAccountJSON != "" {
+		msgs = append(msgs, "invalid setting: can't configure both google-service-account-json and enable use-application-default-credentials")
+	} else if !provider.GoogleConfig.UseApplicationDefaultCredentials {
+		if _, err := os.Stat(provider.GoogleConfig.ServiceAccountJSON); err != nil {
+			msgs = append(msgs, fmt.Sprintf("invalid Google credentials file: %s", provider.GoogleConfig.ServiceAccountJSON))
 		}
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR will enable Workload Identity (on GKE)/Application Default Credentials support for the Google Provider.

The workspace admin account needs to have the `iam.serviceAccounts.signJwt` permission (i.e. `roles/iam.serviceAccountTokenCreator`) (does this need to be added to the docs?). This PR also adds 2 new flags; `--google-use-application-default-credentials` and `--google-target-principal`.  The last one is in my understanding used to impersonate the correct Google Service Account using the Kubernetes Service Account.
<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes #1808

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Integration-tested by building a test image and deploying to a Kubernetes cluster in combination with Nginx OAuth annotations. Tested it with and without allowed_groups.
Also tested it on localhost with an Nginx reverse proxy with self-signed certs for SSL using application default credentials (using `gcloud auth application-default login`).

Not yet tested on GCE/Anthos

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
