### PR TITLE
Compare allowed path/method with X-Original-Url instead of req.URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [#1906](https://github.com/oauth2-proxy/oauth2-proxy/pull/1906) Fix PKCE code verifier generation to never use UTF-8 characters
 - [#1839](https://github.com/oauth2-proxy/oauth2-proxy/pull/1839) Add readiness checks for deeper health checks (@kobim)
 - [#1927](https://github.com/oauth2-proxy/oauth2-proxy/pull/1927) Fix default scope settings for none oidc providers
+- [#1971](https://github.com/oauth2-proxy/oauth2-proxy/pull/1971) Fix skip-auth-route by comparing regex to X-Original-URL path
 
 
 # V7.4.0


### PR DESCRIPTION
`skip-auth-route` (and `skip_auth_routes`) is not working because it is comparing the path against the URL of the oauth2-proxy request, not the URL of the original request which is forwarded to oath2-proxy in the `X-Original-Url` header.

Fixes  https://github.com/oauth2-proxy/oauth2-proxy/issues/1970

## Expected Behavior

It is expected that if I set 

      skip_auth_routes = [ "GET=^/healthz" ]

then my application would allow that URL through without authentication. For example,

    $ curl https://app.example.com/healthz -v |& grep ^..HTTP.2
    < HTTP/2 200

And that other URLs would be redirected to the oauth2-proxy auth-signin URL (`/oauth2/start`). For example,

    $ curl https://app.example.com/asdf -v |& grep ^..HTTP.2
    < HTTP/2 302

## Current Behavior

When setting:

      skip_auth_routes = [ "GET=^/healthz" ]

this endpoint still requires authentication:

    $ curl https://app.example.com/healthz -v |& grep ^..HTTP.2
    < HTTP/2 302

And for further evidence that `skip_auth_routes` is comparing against the oauth2-proxy URL, set

      skip_auth_routes = [ "GET=^/oauth2" ]

(assuming `proxy-prefix` is set to that) and see that any URL will make it through

    $ curl https://app.example.com/healthz -v |& grep ^..HTTP.2
    < HTTP/2 200

    $ curl https://app.example.com/asdf -v |& grep ^..HTTP.2
    < HTTP/2 200

# Changes

Test the `skip_auth_routes` regex against `X-Original-Url` path and not against `req.URL`

## Motivation and Context

This allows a request to a path such as `/healthz` to succeed without authorization using oauth2-proxy configuration alone. 

## How Has This Been Tested?

These changes have been built into a container and used in a test environment that fails with the `master` branch, but succeeds with this PR.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
