### PR TITLE
Feature - Add auth endpoint IP whitelisting capability

### DIFF
--- a/docs/docs/features/endpoints.md
+++ b/docs/docs/features/endpoints.md
@@ -38,9 +38,10 @@ BEWARE that the domain you want to redirect to (`my-oidc-provider.example.com` i
 
 ### Auth
 
-This endpoint returns 202 Accepted response or a 401 Unauthorized response.
+This endpoint returns 202 Accepted response, 403 Forbidden or a 401 Unauthorized response.
 
 It can be configured using the following query parameters query parameters:
 - `allowed_groups`: comma separated list of allowed groups
 - `allowed_email_domains`: comma separated list of allowed email domains
 - `allowed_emails`: comma separated list of allowed emails
+- `whitelisted_ip_ranges`: comma seperated list of allowed IP ranges that can skip auth. MUST be combined with `--reverse-proxy` and `--real-client-ip-header` this will evaluate the trust of the IP stored in an HTTP header by the reverse proxy rather than the layer-3/4 remote address. WARNING: trusting IPs has inherent security flaws, especially when obtaining the IP address from an HTTP header (reverse-proxy mode). Use this option only if you understand the risks and how to manage them.


### PR DESCRIPTION
## Description

This PR adds the ability for the /auth endpoint to whitelist IP addresses via a parameter.

## Motivation and Context

This solves the problem, that when using oauthproxy as a central auth point for multiple ingresses, some Ingresses may need different IP ranges to be whitelisted than others, and therefore the central IP whitelisting option is not an option.

This change allows different ranges to be specified per ingress.

## How Has This Been Tested?

* Unit test added.
* Testing scenarios via postman, with/without cookie set + with/without the parameter set + X-Forwarded-For or X-Real-IP header. Observing the status codes + Headers returned for each of the different combinations.
* Running fork with these changes applied in production.

cookie + whitelis
Code changes only affect the auth endpoint.

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
