### PR TITLE
[Feature] Support acr verification

### DIFF
--- a/docs/docs/configuration/alpha_config.md
+++ b/docs/docs/configuration/alpha_config.md
@@ -107,6 +107,7 @@ longer available when using alpha configuration:
 - `approval-prompt`/`approval_prompt`
 - `acr-values`/`acr_values`
 - `user-id-claim`/`user_id_claim`
+- `allowed-acr`/`allowed_acrs`
 - `allowed-group`/`allowed_groups`
 - `allowed-role`/`allowed_roles`
 - `jwt-key`/`jwt_key`
@@ -385,6 +386,7 @@ character.
 | `jwksURL` | _string_ | JwksURL is the OpenID Connect JWKS URL<br/>eg: https://www.googleapis.com/oauth2/v3/certs |
 | `emailClaim` | _string_ | EmailClaim indicates which claim contains the user email,<br/>default set to 'email' |
 | `groupsClaim` | _string_ | GroupsClaim indicates which claim contains the user groups<br/>default set to 'groups' |
+| `acrClaim` | _string_ | AcrClaim indicates which claim contains the ACR level<br/>default set to 'acr' |
 | `userIDClaim` | _string_ | UserIDClaim indicates which claim contains the user ID<br/>default set to 'email' |
 | `audienceClaims` | _[]string_ | AudienceClaim allows to define any claim that is verified against the client id<br/>By default `aud` claim is used for verification. |
 | `extraAudiences` | _[]string_ | ExtraAudiences is a list of additional audiences that are allowed<br/>to pass verification in addition to the client id. |
@@ -421,6 +423,7 @@ Provider holds all configuration for a single provider
 | `validateURL` | _string_ | ValidateURL is the access token validation endpoint |
 | `scope` | _string_ | Scope is the OAuth scope specification |
 | `allowedGroups` | _[]string_ | AllowedGroups is a list of restrict logins to members of this group |
+| `allowedAcrs` | _[]string_ | AllowedAcrs is a list of acrs by preference, one of which must be satisfied by the authorizer |
 | `code_challenge_method` | _string_ | The code challenge method |
 
 ### ProviderType

--- a/docs/docs/configuration/alpha_config.md.tmpl
+++ b/docs/docs/configuration/alpha_config.md.tmpl
@@ -107,6 +107,7 @@ longer available when using alpha configuration:
 - `approval-prompt`/`approval_prompt`
 - `acr-values`/`acr_values`
 - `user-id-claim`/`user_id_claim`
+- `allowed-acr`/`allowed_acrs`
 - `allowed-group`/`allowed_groups`
 - `allowed-role`/`allowed_roles`
 - `jwt-key`/`jwt_key`

--- a/docs/docs/configuration/overview.md
+++ b/docs/docs/configuration/overview.md
@@ -140,6 +140,7 @@ An example [oauth2-proxy.cfg](https://github.com/oauth2-proxy/oauth2-proxy/blob/
 | `--oidc-jwks-url` | string | OIDC JWKS URI for token verification; required if OIDC discovery is disabled | |
 | `--oidc-email-claim` | string | which OIDC claim contains the user's email | `"email"` |
 | `--oidc-groups-claim` | string | which OIDC claim contains the user groups | `"groups"` |
+| `--oidc-acr-claim` | string | which OIDC claim contains the acr | `"acr"` |
 | `--oidc-audience-claim` | string | which OIDC claim contains the audience | `"aud"` |
 | `--oidc-extra-audience` | string \| list | additional audiences which are allowed to pass verification | `"[]"` |
 | `--pass-access-token` | bool | pass OAuth access_token to upstream via X-Forwarded-Access-Token header. When used with `--set-xauthrequest` this adds the X-Auth-Request-Access-Token header to the response | false |
@@ -203,6 +204,7 @@ An example [oauth2-proxy.cfg](https://github.com/oauth2-proxy/oauth2-proxy/blob/
 | `--tls-min-version` | string | minimum TLS version that is acceptable, either `"TLS1.2"` or `"TLS1.3"` | `"TLS1.2"` |
 | `--upstream` | string \| list | the http url(s) of the upstream endpoint, file:// paths for static files or `static://<status_code>` for static response. Routing is based on the path | |
 | `--upstream-timeout` | duration | maximum amount of time the server will wait for a response from the upstream | 30s |
+| `--allowed-acr` | string \| list | restrict sessions to authorization responses verified with the specified Authentication Context Class References (may be given multiple times) | |
 | `--allowed-group` | string \| list | restrict logins to members of this group (may be given multiple times) | |
 | `--allowed-role` | string \| list | restrict logins to users with this role (may be given multiple times). Only works with the keycloak-oidc provider. | |
 | `--validate-url` | string | Access token validation endpoint | |

--- a/pkg/apis/middleware/session.go
+++ b/pkg/apis/middleware/session.go
@@ -25,6 +25,7 @@ func CreateTokenToSessionFunc(verify VerifyFunc) TokenToSessionFunc {
 			Verified          *bool    `json:"email_verified"`
 			PreferredUsername string   `json:"preferred_username"`
 			Groups            []string `json:"groups"`
+			Acr               string   `json:"acr"`
 		}
 
 		idToken, err := verify(ctx, token)
@@ -49,6 +50,7 @@ func CreateTokenToSessionFunc(verify VerifyFunc) TokenToSessionFunc {
 			User:              claims.Subject,
 			Groups:            claims.Groups,
 			PreferredUsername: claims.PreferredUsername,
+			Acr:               claims.Acr,
 			AccessToken:       token,
 			IDToken:           token,
 			RefreshToken:      "",

--- a/pkg/apis/options/providers.go
+++ b/pkg/apis/options/providers.go
@@ -6,6 +6,9 @@ const (
 
 	// OIDCGroupsClaim is the generic groups claim used by the OIDC provider.
 	OIDCGroupsClaim = "groups"
+
+	// OIDCAcrClaim is the generic acr claim used by the OIDC provider.
+	OIDCAcrClaim = "acr"
 )
 
 // OIDCAudienceClaims is the generic audience claim list used by the OIDC provider.
@@ -76,6 +79,8 @@ type Provider struct {
 	Scope string `json:"scope,omitempty"`
 	// AllowedGroups is a list of restrict logins to members of this group
 	AllowedGroups []string `json:"allowedGroups,omitempty"`
+	// AllowedAcrs is a list of acrs by preference, one of which must be satisfied by the authorizer
+	AllowedAcrs []string `json:"allowedAcrs,omitempty"`
 	// The code challenge method
 	CodeChallengeMethod string `json:"code_challenge_method,omitempty"`
 }
@@ -219,6 +224,9 @@ type OIDCOptions struct {
 	// GroupsClaim indicates which claim contains the user groups
 	// default set to 'groups'
 	GroupsClaim string `json:"groupsClaim,omitempty"`
+	// AcrClaim indicates which claim contains the ACR level
+	// default set to 'acr'
+	AcrClaim string `json:"acrClaim,omitempty"`
 	// UserIDClaim indicates which claim contains the user ID
 	// default set to 'email'
 	UserIDClaim string `json:"userIDClaim,omitempty"`
@@ -253,6 +261,7 @@ func providerDefaults() Providers {
 				UserIDClaim:                  OIDCEmailClaim, // Deprecated: Use OIDCEmailClaim
 				EmailClaim:                   OIDCEmailClaim,
 				GroupsClaim:                  OIDCGroupsClaim,
+				AcrClaim:                     OIDCAcrClaim,
 				AudienceClaims:               OIDCAudienceClaims,
 				ExtraAudiences:               []string{},
 			},

--- a/pkg/apis/sessions/session_state.go
+++ b/pkg/apis/sessions/session_state.go
@@ -28,6 +28,7 @@ type SessionState struct {
 	User              string   `msgpack:"u,omitempty"`
 	Groups            []string `msgpack:"g,omitempty"`
 	PreferredUsername string   `msgpack:"pu,omitempty"`
+	Acr               string   `msgpack:"a,omitempty"`
 
 	// Internal helpers, not serialized
 	Clock clock.Clock `msgpack:"-"`

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -138,6 +138,7 @@ func newProviderDataFromConfig(providerConfig options.Provider) (*ProviderData, 
 	p.AllowUnverifiedEmail = providerConfig.OIDCConfig.InsecureAllowUnverifiedEmail
 	p.EmailClaim = providerConfig.OIDCConfig.EmailClaim
 	p.GroupsClaim = providerConfig.OIDCConfig.GroupsClaim
+	p.AcrClaim = providerConfig.OIDCConfig.AcrClaim
 
 	// Set PKCE enabled or disabled based on discovery and force options
 	p.CodeChallengeMethod = parseCodeChallengeMethod(providerConfig)
@@ -164,6 +165,7 @@ func newProviderDataFromConfig(providerConfig options.Provider) (*ProviderData, 
 	}
 
 	p.setAllowedGroups(providerConfig.AllowedGroups)
+	p.setAllowedAcrs(providerConfig.AllowedAcrs)
 
 	return p, nil
 }


### PR DESCRIPTION
## Description

This commit adds new options to oauth2-proxy to request and verify various ACR values. This is intended as a replacement for the existing --acr-values flag, while maintaining it's existence for backwards compatibility.

When using the new arguments, the acr values as passed as a url parameter and verified in the oauth response handler. Should the response not provide a matching acr claim, the user is not authorized.

## Motivation and Context

The existing --acr-values flag submits the specified value as a parameter of the login request, but does no verification of the response. A relatively unsophisticated attacker could remove the parameter from the url after being redirected by oauth2-proxy, potentially bypassing additional verification, and oauth2-proxy would complete the oauth exchange successfully.

## How Has This Been Tested?

I have been running oauth2-proxy in my homelab with the new parameter, without any issues.

## Checklist:

- [X] My change requires a change to the documentation or CHANGELOG.
- [?] I have updated the documentation/CHANGELOG accordingly.
- [X] I have created a feature (non-master) branch for my PR.
