### PR TITLE
Treat session validation error like no cookie error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## Breaking Changes
 
 ## Changes since v7.4.0
+- [#1986](https://github.com/oauth2-proxy/oauth2-proxy/pull/1986) Treat session validation error like no cookie error
 - [#2133](https://github.com/oauth2-proxy/oauth2-proxy/pull/2133) Use X-Forwarded-Uri if it exists for pathRegex match
 - [#2028](https://github.com/oauth2-proxy/oauth2-proxy/pull/2028) Update golang.org/x/net to v0.7.0 ato address GHSA-vvpx-j8f3-3w6h
 - [#1873](https://github.com/oauth2-proxy/oauth2-proxy/pull/1873) Fix empty users with some OIDC providers (@babs)

--- a/pkg/sessions/persistence/manager.go
+++ b/pkg/sessions/persistence/manager.go
@@ -79,8 +79,8 @@ func (m *Manager) Clear(rw http.ResponseWriter, req *http.Request) error {
 			options: m.Options,
 		}
 		tckt.clearCookie(rw, req)
-		// Don't raise an error if we didn't have a Cookie
-		if err == http.ErrNoCookie {
+		// Don't raise an error if we didn't have a Cookie or it is invalid
+		if err == http.ErrNoCookie || err == ErrCookieValidationFailed {
 			return nil
 		}
 		return fmt.Errorf("error decoding ticket to clear session: %v", err)

--- a/pkg/sessions/persistence/ticket.go
+++ b/pkg/sessions/persistence/ticket.go
@@ -43,6 +43,8 @@ type ticket struct {
 	options *options.Cookie
 }
 
+var ErrCookieValidationFailed = errors.New("session ticket cookie failed validation")
+
 // newTicket creates a new ticket. The ID & secret will be randomly created
 // with 16 byte sizes. The ID will be prefixed & hex encoded.
 func newTicket(cookieOpts *options.Cookie) (*ticket, error) {
@@ -102,7 +104,7 @@ func decodeTicketFromRequest(req *http.Request, cookieOpts *options.Cookie) (*ti
 	// An existing cookie exists, try to retrieve the ticket
 	val, _, ok := encryption.Validate(requestCookie, cookieOpts.Secret, cookieOpts.Expire)
 	if !ok {
-		return nil, fmt.Errorf("session ticket cookie failed validation: %v", err)
+		return nil, ErrCookieValidationFailed
 	}
 
 	// Valid cookie, decode the ticket


### PR DESCRIPTION
## Description

If the session in the cookie cannot be validated an internal server error was generated.
This commit changes this behaviour. A session validation error is now ignored and a redirect is performed. This is now the same beaviour as if no cookie is present at all.

## Motivation and Context

We have an embedded linux device with a web ui that uses oauth2-proxy during user authentication. 

Scenario:
* a user is logged in using the web ui (browser 1)
* via a different interface (e.g. different browser) a firmware upgrade is performed
* the device reboots (loses its internal state)
* the user reloads the page in browser 1
* Internal Server Error (500) is displayed

Excerpt from the log (using oauth2-proxy 7.3.0):
```
Jan 24 08:48:37 dev oauth2-proxy[933]: [2023/01/24 08:48:37] [stored_session.go:94] Error loading cookied session: session ticket cookie failed validation: <nil>, removing session
Jan 24 08:48:37 dev oauth2-proxy[933]: [2023/01/24 08:48:37] [stored_session.go:97] Error removing session: error decoding ticket to clear session: session ticket cookie failed validation: <nil>
Jan 24 08:48:37 dev oauth2-proxy[933]: 10.1.2.199 - e10329c3-8eea-4827-99f4-4e2cc310333f - - [2023/01/24 08:48:37] 10.1.2.11 GET - "/auth/auth" HTTP/1.1 "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36 Edg/108.0.1462.46" 401 13 0.005
Jan 24 08:48:37 dev oauth2-proxy[933]: [2023/01/24 08:48:37] [oauthproxy.go:554] Error clearing session cookie: error decoding ticket to clear session: session ticket cookie failed validation: <nil>
Jan 24 08:48:37 dev oauth2-proxy[933]: 10.1.2.199 - 6a4b5a3c-8225-4890-ad6d-4a8b0dfdfd8a - - [2023/01/24 08:48:37] 10.1.2.11 GET - "/auth/sign_in" HTTP/1.0 "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36 Edg/108.0.1462.46" 500 404 0.002
```

Without this change, the user has to manually navigate to the main authentication url to login again.

With this change the user is automatically redirected to the login page.

## How Has This Been Tested?

The above scenarion was manually tested with a patched 7.3.0.

I don't know if this affects other parts of the code.

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
