### PR TITLE
#1636 fix. Special ValidateURLspecial field was added for Gitea provider.

### DIFF
--- a/docs/docs/configuration/auth.md
+++ b/docs/docs/configuration/auth.md
@@ -666,6 +666,7 @@ The default configuration allows everyone with Bitbucket account to authenticate
     --login-url="https://< your gitea host >/login/oauth/authorize"
     --redeem-url="https://< your gitea host >/login/oauth/access_token"
     --validate-url="https://< your gitea host >/api/v1"
+    --validate-url-special="https://< your gitea host >/api/v1/user/emails"
 ```
 
 

--- a/pkg/apis/options/legacy_options.go
+++ b/pkg/apis/options/legacy_options.go
@@ -517,6 +517,7 @@ type LegacyProvider struct {
 	ProfileURL                         string   `flag:"profile-url" cfg:"profile_url"`
 	ProtectedResource                  string   `flag:"resource" cfg:"resource"`
 	ValidateURL                        string   `flag:"validate-url" cfg:"validate_url"`
+	ValidateURLspecial                 string   `flag:"validate-url-special" cfg:"validate_url_special"`
 	Scope                              string   `flag:"scope" cfg:"scope"`
 	Prompt                             string   `flag:"prompt" cfg:"prompt"`
 	ApprovalPrompt                     string   `flag:"approval-prompt" cfg:"approval_prompt"` // Deprecated by OIDC 1.0
@@ -556,6 +557,21 @@ func legacyProviderFlagSet() *pflag.FlagSet {
 	flagSet.String("client-secret", "", "the OAuth Client Secret")
 	flagSet.String("client-secret-file", "", "the file with OAuth Client Secret")
 
+	addIntegrationFlags( flagSet )	
+
+	flagSet.String("acr-values", "", "acr values string:  optional")
+	flagSet.String("jwt-key", "", "private key in PEM format used to sign JWT, so that you can say something like -jwt-key=\"${OAUTH2_PROXY_JWT_KEY}\": required by login.gov")
+	flagSet.String("jwt-key-file", "", "path to the private key file in PEM format used to sign the JWT so that you can say something like -jwt-key-file=/etc/ssl/private/jwt_signing_key.pem: required by login.gov")
+	flagSet.String("pubjwk-url", "", "JWK pubkey access endpoint: required by login.gov")
+
+	flagSet.String("user-id-claim", OIDCEmailClaim, "(DEPRECATED for `oidc-email-claim`) which claim contains the user ID")
+	flagSet.StringSlice("allowed-group", []string{}, "restrict logins to members of this group (may be given multiple times)")
+	flagSet.StringSlice("allowed-role", []string{}, "(keycloak-oidc) restrict logins to members of these roles (may be given multiple times)")
+
+	return flagSet
+}
+
+func addIntegrationFlags( flagSet *pflag.FlagSet ) {
 	flagSet.String("provider", "google", "OAuth provider")
 	flagSet.String("provider-display-name", "", "Provider display name")
 	flagSet.StringSlice("provider-ca-file", []string{}, "One or more paths to CA certificates that should be used when connecting to the provider.  If not specified, the default Go trust sources are used instead.")
@@ -574,22 +590,12 @@ func legacyProviderFlagSet() *pflag.FlagSet {
 	flagSet.String("profile-url", "", "Profile access endpoint")
 	flagSet.String("resource", "", "The resource that is protected (Azure AD only)")
 	flagSet.String("validate-url", "", "Access token validation endpoint")
+	flagSet.String("validate-url-special", "", "Optional access token validation endpoint used in special cases")
 	flagSet.String("scope", "", "OAuth scope specification")
 	flagSet.String("prompt", "", "OIDC prompt")
 	flagSet.String("approval-prompt", "force", "OAuth approval_prompt")
 	flagSet.String("code-challenge-method", "", "use PKCE code challenges with the specified method. Either 'plain' or 'S256'")
 	flagSet.String("force-code-challenge-method", "", "Deprecated - use --code-challenge-method")
-
-	flagSet.String("acr-values", "", "acr values string:  optional")
-	flagSet.String("jwt-key", "", "private key in PEM format used to sign JWT, so that you can say something like -jwt-key=\"${OAUTH2_PROXY_JWT_KEY}\": required by login.gov")
-	flagSet.String("jwt-key-file", "", "path to the private key file in PEM format used to sign the JWT so that you can say something like -jwt-key-file=/etc/ssl/private/jwt_signing_key.pem: required by login.gov")
-	flagSet.String("pubjwk-url", "", "JWK pubkey access endpoint: required by login.gov")
-
-	flagSet.String("user-id-claim", OIDCEmailClaim, "(DEPRECATED for `oidc-email-claim`) which claim contains the user ID")
-	flagSet.StringSlice("allowed-group", []string{}, "restrict logins to members of this group (may be given multiple times)")
-	flagSet.StringSlice("allowed-role", []string{}, "(keycloak-oidc) restrict logins to members of these roles (may be given multiple times)")
-
-	return flagSet
 }
 
 func (l LegacyServer) convert() (Server, Server) {
@@ -650,6 +656,7 @@ func (l *LegacyProvider) convert() (Providers, error) {
 		ProfileURL:          l.ProfileURL,
 		ProtectedResource:   l.ProtectedResource,
 		ValidateURL:         l.ValidateURL,
+		ValidateURLspecial:  l.ValidateURLspecial,
 		Scope:               l.Scope,
 		AllowedGroups:       l.AllowedGroups,
 		CodeChallengeMethod: l.CodeChallengeMethod,

--- a/pkg/apis/options/providers.go
+++ b/pkg/apis/options/providers.go
@@ -72,6 +72,8 @@ type Provider struct {
 	ProtectedResource string `json:"resource,omitempty"`
 	// ValidateURL is the access token validation endpoint
 	ValidateURL string `json:"validateURL,omitempty"`
+	// ValidateURLspecial is the optional access token validation endpoint in special cases
+	ValidateURLspecial string `json:"validateURLspecial,omitempty"`
 	// Scope is the OAuth scope specification
 	Scope string `json:"scope,omitempty"`
 	// AllowedGroups is a list of restrict logins to members of this group

--- a/pkg/cookies/csrf.go
+++ b/pkg/cookies/csrf.go
@@ -219,7 +219,9 @@ func ExtractStateSubstring(req *http.Request) string {
 	stateSubstring := ""
 
 	state := req.URL.Query()["state"]
-	if state[0] != "" {
+	// If the application authorization was rejected by the OAuth2 provider's login page,
+    // the "state" can be empty. That's why to check len(state) is mandatory to avoid the panic.
+	if 0 < len(state) && state[0] != "" {
 		state := state[0]
 		if lastChar <= len(state) {
 			stateSubstring = state[0:lastChar]

--- a/providers/internal_util.go
+++ b/providers/internal_util.go
@@ -47,10 +47,10 @@ func stripParam(param, endpoint string) string {
 
 // validateToken returns true if token is valid
 func validateToken(ctx context.Context, p Provider, accessToken string, header http.Header) bool {
-	if accessToken == "" || p.Data().ValidateURL == nil || p.Data().ValidateURL.String() == "" {
+	if accessToken == "" || p.Data().GetTokenValidateURL() == nil || p.Data().GetTokenValidateURL().String() == "" {
 		return false
 	}
-	endpoint := p.Data().ValidateURL.String()
+	endpoint := p.Data().GetTokenValidateURL().String()
 	if len(header) == 0 {
 		params := url.Values{"access_token": {accessToken}}
 		if hasQueryParams(endpoint) {

--- a/providers/provider_data.go
+++ b/providers/provider_data.go
@@ -27,16 +27,17 @@ const (
 // ProviderData contains information required to configure all implementations
 // of OAuth2 providers
 type ProviderData struct {
-	ProviderName      string
-	LoginURL          *url.URL
-	RedeemURL         *url.URL
-	ProfileURL        *url.URL
-	ProtectedResource *url.URL
-	ValidateURL       *url.URL
-	ClientID          string
-	ClientSecret      string
-	ClientSecretFile  string
-	Scope             string
+	ProviderName        string
+	LoginURL            *url.URL
+	RedeemURL           *url.URL
+	ProfileURL          *url.URL
+	ProtectedResource   *url.URL
+	ValidateURL         *url.URL
+	ValidateURLspecial  *url.URL
+	ClientID            string
+	ClientSecret        string
+	ClientSecretFile    string
+	Scope               string
 	// The picked CodeChallenge Method or empty if none.
 	CodeChallengeMethod string
 	// Code challenge methods supported by the Provider
@@ -60,6 +61,17 @@ type ProviderData struct {
 
 // Data returns the ProviderData
 func (p *ProviderData) Data() *ProviderData { return p }
+
+func (p *ProviderData) GetTokenValidateURL() *url.URL {
+	// By default ValidateURLspecial is not initialized because ValidateURL should be used.
+	// But with Gitea ValidateURL can't be used, because GET by such URL returns error 404. 
+	// So the special URL is required for validation.
+	if p.ValidateURLspecial != nil {
+		return p.ValidateURLspecial
+	} 
+	
+	return p.ValidateURL
+}
 
 func (p *ProviderData) GetClientSecret() (clientSecret string, err error) {
 	if p.ClientSecret != "" || p.ClientSecretFile == "" {

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -119,6 +119,7 @@ func newProviderDataFromConfig(providerConfig options.Provider) (*ProviderData, 
 		"redeem":   {dst: &p.RedeemURL, raw: providerConfig.RedeemURL},
 		"profile":  {dst: &p.ProfileURL, raw: providerConfig.ProfileURL},
 		"validate": {dst: &p.ValidateURL, raw: providerConfig.ValidateURL},
+		"val_spec": {dst: &p.ValidateURLspecial, raw: providerConfig.ValidateURLspecial},
 		"resource": {dst: &p.ProtectedResource, raw: providerConfig.ProtectedResource},
 	} {
 		var err error


### PR DESCRIPTION
## Description

The OAuth2-proxy ver.7.4.0 fails with Gitea, see #1636 for details.
This PR strives to be minimal as possible for restoring the Gitea support.

## Motivation and Context

We do need the Gitea support. So this PR is just a fix of #1636 issue.
The URL provided by `--validate-url` parameter is used as base for other resources URL composition, but if it is used directly for validation with Gitea, then Gitea just retuns error 404.
So the new `--validate-url-special` parameter was introduced to specify the valid URL used with Gitea,
Note, the `--validate-url-special` is optional. If it is omitted, then everything works as before and the value from `--validate-url` is used in validation (in particular with Github).

## How Has This Been Tested?
The web site with static content was configured as documented in [OAuth2-proxy Docs](https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/overview/#configuring-for-use-with-the-nginx-auth_request-directive).
Then it was tested manually with real internal Gitea ver.1.18.3 instance.

## Checklist:

- [x] My change **may** require a change in the CHANGELOG add require one line addition to the documentation.
- [x] I have updated the documentation (but not CHANGELOG) accordingly.
- [x] I have created a feature (non-master) branch for my PR.
