### PR TITLE
Fix a typo in oauthproxy.go

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -124,7 +124,7 @@ func NewOAuthProxy(opts *options.Options, validator func(string) bool) (*OAuthPr
 
 	provider, err := providers.NewProvider(opts.Providers[0])
 	if err != nil {
-		return nil, fmt.Errorf("error intiailising provider: %v", err)
+		return nil, fmt.Errorf("error initialising provider: %v", err)
 	}
 
 	pageWriter, err := pagewriter.NewWriter(pagewriter.Opts{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- [x] Fix a typo in `oauthproxy.go:L127`
    * Before: `intiailising` (https://github.com/oauth2-proxy/oauth2-proxy/blob/fd50a35784457d4766e487a1edb9677f8e93cc30/oauthproxy.go#L127)
    * After: `initialising`

<!--- Describe your changes in detail -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
