### PR TITLE
Add documentation for --redis-insecure-skip-tls-verify flag

### DIFF
--- a/docs/docs/configuration/overview.md
+++ b/docs/docs/configuration/overview.md
@@ -165,6 +165,7 @@ An example [oauth2-proxy.cfg](https://github.com/oauth2-proxy/oauth2-proxy/blob/
 | `--redirect-url` | string | the OAuth Redirect URL, e.g. `"https://internalapp.yourcompany.com/oauth2/callback"` | |
 | `--redis-cluster-connection-urls` | string \| list | List of Redis cluster connection URLs (e.g. `redis://HOST[:PORT]`). Used in conjunction with `--redis-use-cluster` | |
 | `--redis-connection-url` | string | URL of redis server for redis session storage (e.g. `redis://HOST[:PORT]`) | |
+| `--redis-insecure-skip-tls-verify` | bool | skip TLS verification when connecting to Redis | false |
 | `--redis-password` | string | Redis password. Applicable for all Redis configurations. Will override any password set in `--redis-connection-url` | |
 | `--redis-sentinel-password` | string | Redis sentinel password. Used only for sentinel connection; any redis node passwords need to use `--redis-password` | |
 | `--redis-sentinel-master-name` | string | Redis sentinel master name. Used in conjunction with `--redis-use-sentinel` | |


### PR DESCRIPTION
This is a doc change to Fix https://github.com/oauth2-proxy/oauth2-proxy/issues/2038
The `--redis-insecure-skip-tls-verify `flag is missing from the docs. So adding this flag in the docs



## Motivation and Context

It took us a while to debug why oauth2-proxy was not able to connect to Redis. We noticed it has something to do with TLS but did not find any flag in docs so had to dig through the code

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
