### PR TITLE
Redirect to '/' instead of rd URL

### DIFF
--- a/contrib/local-environment/nginx.conf
+++ b/contrib/local-environment/nginx.conf
@@ -53,10 +53,10 @@ server {
 
     # If the auth_request denies the request (401), redirect to the sign_in page
     # and include the final rd URL back to the user's original request.
-    error_page 401 = http://oauth2-proxy.oauth2-proxy.localhost/oauth2/sign_in?rd=$scheme://$host$request_uri;
+    error_page 401 = http://oauth2-proxy.oauth2-proxy.localhost/oauth2/sign_in?rd=$request_uri;
 
     # Alternatively send the request to `start` to skip the provider button
-    # error_page 401 = http://oauth2-proxy.oauth2-proxy.localhost/oauth2/start?rd=$scheme://$host$request_uri;
+    # error_page 401 = http://oauth2-proxy.oauth2-proxy.localhost/oauth2/start?rd=$request_uri;
 
 
     root   /usr/share/nginx/html;


### PR DESCRIPTION
I have build my own nginx config after this example and found above problem. My proposed change is the solution according to this issue: https://github.com/oauth2-proxy/oauth2-proxy/issues/378

## Description
Redirect to '/' instead of rd URL

## Motivation and Context
Just want others to stop searching for hours why the config is not working they took from official repository

## How Has This Been Tested?

tested for my own application. Searched some hours for solutions unti I found:
https://github.com/oauth2-proxy/oauth2-proxy/issues/378

## Checklist:

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
