### PR TITLE
Documentation fix missing plural for --oidc-extra-audiences

### DIFF
--- a/docs/docs/configuration/overview.md
+++ b/docs/docs/configuration/overview.md
@@ -141,7 +141,7 @@ An example [oauth2-proxy.cfg](https://github.com/oauth2-proxy/oauth2-proxy/blob/
 | `--oidc-email-claim` | string | which OIDC claim contains the user's email | `"email"` |
 | `--oidc-groups-claim` | string | which OIDC claim contains the user groups | `"groups"` |
 | `--oidc-audience-claim` | string | which OIDC claim contains the audience | `"aud"` |
-| `--oidc-extra-audience` | string \| list | additional audiences which are allowed to pass verification | `"[]"` |
+| `--oidc-extra-audiences` | string \| list | additional audiences which are allowed to pass verification | `"[]"` |
 | `--pass-access-token` | bool | pass OAuth access_token to upstream via X-Forwarded-Access-Token header. When used with `--set-xauthrequest` this adds the X-Auth-Request-Access-Token header to the response | false |
 | `--pass-authorization-header` | bool | pass OIDC IDToken to upstream via Authorization Bearer header | false |
 | `--pass-basic-auth` | bool | pass HTTP Basic Auth, X-Forwarded-User, X-Forwarded-Email and X-Forwarded-Preferred-Username information to upstream | true |


### PR DESCRIPTION
Documentation fix missing plural for --oidc-extra-audiences

## Description
Fixing the missing plural for --oidc-extra-audiences in the https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/overview#command-line-options documentation

## How Has This Been Tested?

I've tested this via setting the envar oidc_extra_audiences in our deployment and am not getting the main.go mapping error any more.