### PR TITLE
Add Azure Workload Identity support & read groups from claim

### DIFF
--- a/docs/docs/configuration/auth.md
+++ b/docs/docs/configuration/auth.md
@@ -71,7 +71,6 @@ https://www.googleapis.com/auth/admin.directory.user.readonly
 Note: The user is checked against the group members list on initial authentication and every time the token is refreshed ( about once an hour ).
 
 ### Azure Auth Provider
-
 1. Add an application: go to [https://portal.azure.com](https://portal.azure.com), choose **Azure Active Directory**, select 
 **App registrations** and then click on **New registration**.
 2. Pick a name, check the supported account type(single-tenant, multi-tenant, etc). In the **Redirect URI** section create a new 
@@ -81,10 +80,12 @@ https://internal.yourcompanycom/oauth2/callback). Click **Register**.
 **Add a permission**, select **Microsoft Graph**, then select **Application permissions**, then click on **Group** and select
 **Group.Read.All**. Hit **Add permissions** and then on **Grant admin consent** (you might need an admin to do this).
 <br/>**IMPORTANT**: Even if this permission is listed with **"Admin consent required=No"** the consent might actually be required, due to AAD policies you won't be able to see. If you get a **"Need admin approval"** during login, most likely this is what you're missing!
-4. Next, if you are planning to use v2.0 Azure Auth endpoint, go to the **Manifest** page and set `"accessTokenAcceptedVersion": 2`
+
+#### Authentication with Client ID & Secret
+* If you are planning to use v2.0 Azure Auth endpoint, go to the **Manifest** page and set `"accessTokenAcceptedVersion": 2`
 in the App registration manifest file.
-5. On the **Certificates & secrets** page of the app, add a new client secret and note down the value after hitting **Add**.
-6. Configure the proxy with:
+* On the **Certificates & secrets** page of the app, add a new client secret and note down the value after hitting **Add**.
+* Configure the proxy with:
 - for V1 Azure Auth endpoint (Azure Active Directory Endpoints - https://login.microsoftonline.com/common/oauth2/authorize)
 
 ```
@@ -103,6 +104,34 @@ in the App registration manifest file.
    --azure-tenant={tenant-id}
    --oidc-issuer-url=https://login.microsoftonline.com/{tenant-id}/v2.0
 ```
+
+#### Authentication with federated credentials on Kubernetes
+* Get hold of the OIDC discovery URL of your cluster. For Azure Kubernetes Service, [when it's enabled](https://learn.microsoft.com/en-us/azure/aks/use-oidc-issuer), can be found in `properties.oidcIssuerProfile.issuerURL` in cluster's JSON model. For on-premises and other cloud providers - see [Installation section](https://azure.github.io/azure-workload-identity/docs/installation.html) in Azure Workload Identity documentation.
+* Install Azure Workload Identity webhook on the cluster. For AKS, you can enable it by an appropriate flag - [see documentation](https://learn.microsoft.com/en-us/azure/aks/learn/tutorial-kubernetes-workload-identity). For on premises, [admission webhook server](https://github.com/Azure/azure-workload-identity) is available.
+* Create federated credential for you application by following [official documentation](https://azure.github.io/azure-workload-identity/docs/topics/federated-identity-credential.html#federated-identity-credential-for-an-azure-ad-application-1)
+* Annotate and label `oauth2-proxy` service account with workload identity-specific settings:
+```
+annotations:
+  azure.workload.identity/client-id: d9f1d870-d52c-4cf2-a399-f3594c843a36
+  [...]
+labels:
+  azure.workload.identity/use: "true"
+``` 
+* Label `oauth2-proxy` pod with workload identity-specific settings:
+```
+labels:
+  azure.workload.identity/use: "true"
+```
+
+And start `oauth2-proxy` with federated credentials enabled:
+```
+    --provider=azure
+    --oidc-issuer-url=https://login.microsoftonline.com/{tenant-id}/v2.0
+    --client-id={client-id}
+    --azure-federated-token-auth-enabled=true
+
+``` 
+Note: Federated credentials can be configured to trust different parties that Azure Kubernetes Service
 
 ***Notes***:
 - When using v2.0 Azure Auth endpoint (`https://login.microsoftonline.com/{tenant-id}/v2.0`) as `--oidc_issuer_url`, in conjunction 

--- a/docs/docs/configuration/overview.md
+++ b/docs/docs/configuration/overview.md
@@ -81,6 +81,7 @@ An example [oauth2-proxy.cfg](https://github.com/oauth2-proxy/oauth2-proxy/blob/
 | `--auth-logging-format` | string | Template for authentication log lines | see [Logging Configuration](#logging-configuration) |
 | `--authenticated-emails-file` | string | authenticate against emails via file (one per line) | |
 | `--azure-tenant` | string | go to a tenant-specific or common (tenant-independent) endpoint. | `"common"` |
+| `--azure-federated-token-auth-enabled` | bool | Whether to authenticate to Azure using federated credential (projected by Workload Identity). Token path is read from `AZURE_FEDERATED_TOKEN_FILE` environment variable | false |
 | `--basic-auth-password` | string | the password to set when passing the HTTP Basic Auth header | |
 | `--client-id` | string | the OAuth Client ID, e.g. `"123456.apps.googleusercontent.com"` | |
 | `--client-secret` | string | the OAuth Client Secret | |

--- a/pkg/apis/options/legacy_options.go
+++ b/pkg/apis/options/legacy_options.go
@@ -484,6 +484,7 @@ type LegacyProvider struct {
 	KeycloakGroups           []string `flag:"keycloak-group" cfg:"keycloak_groups"`
 	AzureTenant              string   `flag:"azure-tenant" cfg:"azure_tenant"`
 	AzureGraphGroupField     string   `flag:"azure-graph-group-field" cfg:"azure_graph_group_field"`
+	AzureFederatedTokenAuth  bool     `flag:"azure-federated-token-auth-enabled" cfg:"azure_federated_token_auth_enabled"`
 	BitbucketTeam            string   `flag:"bitbucket-team" cfg:"bitbucket_team"`
 	BitbucketRepository      string   `flag:"bitbucket-repository" cfg:"bitbucket_repository"`
 	GitHubOrg                string   `flag:"github-org" cfg:"github_org"`
@@ -540,6 +541,7 @@ func legacyProviderFlagSet() *pflag.FlagSet {
 	flagSet.StringSlice("keycloak-group", []string{}, "restrict logins to members of these groups (may be given multiple times)")
 	flagSet.String("azure-tenant", "common", "go to a tenant-specific or common (tenant-independent) endpoint.")
 	flagSet.String("azure-graph-group-field", "", "configures the group field to be used when building the groups list(`id` or `displayName`. Default is `id`) from Microsoft Graph(available only for v2.0 oidc url). Based on this value, the `allowed-group` config values should be adjusted accordingly. If using `id` as group field, `allowed-group` should contains groups IDs, if using `displayName` as group field, `allowed-group` should contains groups name")
+	flagSet.Bool("azure-federated-token-auth-enabled", false, "Whether to authenticate to Azure using federated credential (projected by Workload Identity). Token path is read from AZURE_FEDERATED_TOKEN_FILE environment variable")
 	flagSet.String("bitbucket-team", "", "restrict logins to members of this team")
 	flagSet.String("bitbucket-repository", "", "restrict logins to user with access to this repository")
 	flagSet.String("github-org", "", "restrict logins to members of this organisation")
@@ -579,7 +581,6 @@ func legacyProviderFlagSet() *pflag.FlagSet {
 	flagSet.String("approval-prompt", "force", "OAuth approval_prompt")
 	flagSet.String("code-challenge-method", "", "use PKCE code challenges with the specified method. Either 'plain' or 'S256'")
 	flagSet.String("force-code-challenge-method", "", "Deprecated - use --code-challenge-method")
-
 	flagSet.String("acr-values", "", "acr values string:  optional")
 	flagSet.String("jwt-key", "", "private key in PEM format used to sign JWT, so that you can say something like -jwt-key=\"${OAUTH2_PROXY_JWT_KEY}\": required by login.gov")
 	flagSet.String("jwt-key-file", "", "path to the private key file in PEM format used to sign the JWT so that you can say something like -jwt-key-file=/etc/ssl/private/jwt_signing_key.pem: required by login.gov")
@@ -678,8 +679,9 @@ func (l *LegacyProvider) convert() (Providers, error) {
 	// This part is out of the switch section because azure has a default tenant
 	// that needs to be added from legacy options
 	provider.AzureConfig = AzureOptions{
-		Tenant:          l.AzureTenant,
-		GraphGroupField: l.AzureGraphGroupField,
+		Tenant:            l.AzureTenant,
+		GraphGroupField:   l.AzureGraphGroupField,
+		UseFederatedToken: l.AzureFederatedTokenAuth,
 	}
 
 	switch provider.Type {

--- a/pkg/apis/options/providers.go
+++ b/pkg/apis/options/providers.go
@@ -145,6 +145,9 @@ type AzureOptions struct {
 	// GraphGroupField configures the group field to be used when building the groups list from Microsoft Graph
 	// Default value is 'id'
 	GraphGroupField string `json:"graphGroupField,omitempty"`
+	// UseWorkloadIdentity determines whether we want to use federated credential stored in
+	// $AZURE_FEDERATED_TOKEN_FILE environment variable to access Azure APIs
+	UseFederatedToken bool `json:"useFederatedToken,omitempty"`
 }
 
 type ADFSOptions struct {

--- a/pkg/validation/providers.go
+++ b/pkg/validation/providers.go
@@ -46,8 +46,8 @@ func validateProvider(provider options.Provider, providerIDs map[string]struct{}
 		msgs = append(msgs, "provider missing setting: client-id")
 	}
 
-	// login.gov uses a signed JWT to authenticate, not a client-secret
-	if provider.Type != "login.gov" {
+	// login.gov and Azure with workload identity support uses a signed JWT to authenticate, not a client-secret.
+	if provider.Type != "login.gov" && (provider.Type != "azure" || !provider.AzureConfig.UseFederatedToken) {
 		if provider.ClientSecret == "" && provider.ClientSecretFile == "" {
 			msgs = append(msgs, "missing setting: client-secret or client-secret-file")
 		}

--- a/providers/azure.go
+++ b/providers/azure.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -22,9 +23,10 @@ import (
 // AzureProvider represents an Azure based Identity Provider
 type AzureProvider struct {
 	*ProviderData
-	Tenant          string
-	GraphGroupField string
-	isV2Endpoint    bool
+	Tenant            string
+	GraphGroupField   string
+	isV2Endpoint      bool
+	UseFederatedToken bool
 }
 
 var _ Provider = (*AzureProvider)(nil)
@@ -107,10 +109,11 @@ func NewAzureProvider(p *ProviderData, opts options.AzureOptions) *AzureProvider
 	}
 
 	return &AzureProvider{
-		ProviderData:    p,
-		Tenant:          tenant,
-		GraphGroupField: graphGroupField,
-		isV2Endpoint:    isV2Endpoint,
+		ProviderData:      p,
+		Tenant:            tenant,
+		GraphGroupField:   graphGroupField,
+		isV2Endpoint:      isV2Endpoint,
+		UseFederatedToken: opts.UseFederatedToken,
 	}
 }
 
@@ -208,8 +211,8 @@ func (p *AzureProvider) EnrichSession(ctx context.Context, session *sessions.Ses
 		session.Email = email
 	}
 
-	// If using the v2.0 oidc endpoint we're also querying Microsoft Graph
-	if p.isV2Endpoint {
+	// If using the v2.0 oidc endpoint we're also querying Microsoft Graph if groups were not present in id_token
+	if p.isV2Endpoint && len(session.Groups) == 0 {
 		groups, err := p.getGroupsFromProfileAPI(ctx, session)
 		if err != nil {
 			return fmt.Errorf("unable to get groups from Microsoft Graph: %v", err)
@@ -224,14 +227,29 @@ func (p *AzureProvider) prepareRedeem(redirectURL, code, codeVerifier string) (u
 	if code == "" {
 		return params, ErrMissingCode
 	}
-	clientSecret, err := p.GetClientSecret()
-	if err != nil {
-		return params, err
+
+	if !p.UseFederatedToken {
+		clientSecret, err := p.GetClientSecret()
+		if err != nil {
+			return params, err
+		}
+		params.Add("client_secret", clientSecret)
+	} else {
+		federatedTokenPath := os.Getenv("AZURE_FEDERATED_TOKEN_FILE")
+		if federatedTokenPath == "" {
+			return nil, fmt.Errorf("AZURE_FEDERATED_TOKEN_FILE variable is not set!")
+		}
+
+		federatedToken, err := os.ReadFile(federatedTokenPath)
+		if err != nil {
+			return nil, fmt.Errorf("error reading federated token file %s: %s", federatedTokenPath, err)
+		}
+		params.Add("client_assertion", string(federatedToken))
+		params.Add("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
 	}
 
 	params.Add("redirect_uri", redirectURL)
 	params.Add("client_id", p.ClientID)
-	params.Add("client_secret", clientSecret)
 	params.Add("code", code)
 	params.Add("grant_type", "authorization_code")
 	if codeVerifier != "" {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request enables to use oauth2-proxy with federated credentials offered by Azure Workload Identity. Instead of `client_secret`, every request includes a [certificate credential](https://learn.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow#request-an-access-token-with-a-certificate-credential) that is mounted inside the pod with Workload Identity enabled.

In addition, this PR introduces reading groups from id_token claim for V2 tokens instead of Microsoft Graph API, so the app registration does not need the admin consent. They can be retrieved in the same way as in V1 - read `groups` claim. For both cases this claim contains list of UUIDs. That's why I added condition to call Graph API only when groups were not present in id_token.

## Motivation and Context
Currently, oauth2-proxy needs to have hardcoded secret configured, which causes security issues and requires maintenance like secret rotation. This PR closes https://github.com/oauth2-proxy/oauth2-proxy/issues/1979

## How Has This Been Tested?
Custom image has been built and put on AKS cluster with Workload Identity support enabled. Following configuration was provided:
```
        - --http-address=0.0.0.0:4180
        - --metrics-address=0.0.0.0:44180
        - --provider=azure
        - --oidc-issuer-url=https://login.microsoftonline.com/{tenant-id}/v2.0 # tested with V1 as well
        - --email-domain="*"
        - --cookie-domain=".domain.com"
        - --whitelist-domain="*"
        - --footer="Some msg"
        - --skip-jwt-bearer-tokens=true
        - --set-xauthrequest=true
        - --silence-ping-logging=true
        - --reverse-proxy=true
        - --oidc-email-claim=email
        - --insecure-oidc-allow-unverified-email=true
        - --skip-provider-button=true
        - --upstream=static://202
        - --set-authorization-header=false
        - --client-id={client-id}
        - --cookie-secret={cookie-secret}
        - --azure-federated-token-auth-enabled=true # tested with client secrets as well
```
+ Tested login flow.

## Checklist:

Please advise on CHANGELOG entries.

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [X] I have created a feature (non-master) branch for my PR.
