### PR TITLE
Update Alpine to 3.17.3 to fix (CVE-2023-0464)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [#1988](https://github.com/oauth2-proxy/oauth2-proxy/pull/1988) Ensure sign-in page background is uniform throughout the page
 - [#2013](https://github.com/oauth2-proxy/oauth2-proxy/pull/2013) Upgrade alpine to version 3.17.2 and library dependencies (@miguelborges99)
 - [#2047](https://github.com/oauth2-proxy/oauth2-proxy/pull/2047) CVE-2022-41717: DoS in Go net/http may lead to DoS (@miguelborges99)
+- [#2071](https://github.com/oauth2-proxy/oauth2-proxy/pull/2071) Update Alpine Linux Version to fix [CVE-2023-0464](https://dso.docker.com/cve/CVE-2023-0464)
 
 # V7.4.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # This ARG has to be at the top, otherwise the docker daemon does not known what to do with FROM ${RUNTIME_IMAGE}
-ARG RUNTIME_IMAGE=alpine:3.17.2
+ARG RUNTIME_IMAGE=alpine:3.17.3
 
 # All builds should be done using the platform native to the build node to allow
 #  cache sharing of the go mod download step.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

There is a critical Secfinding in Alpine Version 3.17.2 [CVE-2023-0464](https://dso.docker.com/cve/CVE-2023-0464). The version needs to be updated to 3.17.3 to fix it.

## Motivation and Context

This vulnerability gets fixed.
https://nvd.nist.gov/vuln/detail/CVE-2023-0464

## How Has This Been Tested?

I built it once. It doesn't change the code itself.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
