### PR TITLE
Support http.AllowQuerySemicolons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ## Release Highlights
 
+- Added support for semicolons in query strings.
 - New Azure groups support for Azure OAuth2 v2.0
 - Option to configure API routes - paths that will not redirect to login when unauthenticated
 - CSRF and session cookies now have different timeouts

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -79,21 +79,22 @@ type OAuthProxy struct {
 
 	SignInPath string
 
-	allowedRoutes       []allowedRoute
-	apiRoutes           []apiRoute
-	redirectURL         *url.URL // the url to receive requests at
-	whitelistDomains    []string
-	provider            providers.Provider
-	sessionStore        sessionsapi.SessionStore
-	ProxyPrefix         string
-	basicAuthValidator  basic.Validator
-	basicAuthGroups     []string
-	SkipProviderButton  bool
-	skipAuthPreflight   bool
-	skipJwtBearerTokens bool
-	forceJSONErrors     bool
-	realClientIPParser  ipapi.RealClientIPParser
-	trustedIPs          *ip.NetSet
+	allowedRoutes        []allowedRoute
+	apiRoutes            []apiRoute
+	redirectURL          *url.URL // the url to receive requests at
+	whitelistDomains     []string
+	provider             providers.Provider
+	sessionStore         sessionsapi.SessionStore
+	ProxyPrefix          string
+	basicAuthValidator   basic.Validator
+	basicAuthGroups      []string
+	SkipProviderButton   bool
+	skipAuthPreflight    bool
+	skipJwtBearerTokens  bool
+	forceJSONErrors      bool
+	allowQuerySemicolons bool
+	realClientIPParser   ipapi.RealClientIPParser
+	trustedIPs           *ip.NetSet
 
 	sessionChain      alice.Chain
 	headersChain      alice.Chain
@@ -208,19 +209,20 @@ func NewOAuthProxy(opts *options.Options, validator func(string) bool) (*OAuthPr
 
 		SignInPath: fmt.Sprintf("%s/sign_in", opts.ProxyPrefix),
 
-		ProxyPrefix:         opts.ProxyPrefix,
-		provider:            provider,
-		sessionStore:        sessionStore,
-		redirectURL:         redirectURL,
-		apiRoutes:           apiRoutes,
-		allowedRoutes:       allowedRoutes,
-		whitelistDomains:    opts.WhitelistDomains,
-		skipAuthPreflight:   opts.SkipAuthPreflight,
-		skipJwtBearerTokens: opts.SkipJwtBearerTokens,
-		realClientIPParser:  opts.GetRealClientIPParser(),
-		SkipProviderButton:  opts.SkipProviderButton,
-		forceJSONErrors:     opts.ForceJSONErrors,
-		trustedIPs:          trustedIPs,
+		ProxyPrefix:          opts.ProxyPrefix,
+		provider:             provider,
+		sessionStore:         sessionStore,
+		redirectURL:          redirectURL,
+		apiRoutes:            apiRoutes,
+		allowedRoutes:        allowedRoutes,
+		whitelistDomains:     opts.WhitelistDomains,
+		skipAuthPreflight:    opts.SkipAuthPreflight,
+		skipJwtBearerTokens:  opts.SkipJwtBearerTokens,
+		realClientIPParser:   opts.GetRealClientIPParser(),
+		SkipProviderButton:   opts.SkipProviderButton,
+		forceJSONErrors:      opts.ForceJSONErrors,
+		allowQuerySemicolons: opts.AllowQuerySemicolons,
+		trustedIPs:           trustedIPs,
 
 		basicAuthValidator: basicAuthValidator,
 		basicAuthGroups:    opts.HtpasswdUserGroups,
@@ -267,6 +269,11 @@ func (p *OAuthProxy) setupServer(opts *options.Options) error {
 		BindAddress:       opts.Server.BindAddress,
 		SecureBindAddress: opts.Server.SecureBindAddress,
 		TLS:               opts.Server.TLS,
+	}
+
+	// Option: AllowQuerySemicolons
+	if opts.AllowQuerySemicolons {
+		serverOpts.Handler = http.AllowQuerySemicolons(p)
 	}
 
 	appServer, err := proxyhttp.NewServer(serverOpts)

--- a/pkg/apis/options/options.go
+++ b/pkg/apis/options/options.go
@@ -59,6 +59,7 @@ type Options struct {
 	SSLInsecureSkipVerify bool     `flag:"ssl-insecure-skip-verify" cfg:"ssl_insecure_skip_verify"`
 	SkipAuthPreflight     bool     `flag:"skip-auth-preflight" cfg:"skip_auth_preflight"`
 	ForceJSONErrors       bool     `flag:"force-json-errors" cfg:"force_json_errors"`
+	AllowQuerySemicolons  bool     `flag:"allow-query-semicolons" cfg:"allow_query_semicolons"`
 
 	SignatureKey    string `flag:"signature-key" cfg:"signature_key"`
 	GCPHealthChecks bool   `flag:"gcp-healthchecks" cfg:"gcp_healthchecks"`
@@ -123,6 +124,7 @@ func NewFlagSet() *pflag.FlagSet {
 	flagSet.Bool("ssl-insecure-skip-verify", false, "skip validation of certificates presented when using HTTPS providers")
 	flagSet.Bool("skip-jwt-bearer-tokens", false, "will skip requests that have verified JWT bearer tokens (default false)")
 	flagSet.Bool("force-json-errors", false, "will force JSON errors instead of HTTP error pages or redirects")
+	flagSet.Bool("allow-query-semicolons", false, "allow the use of semicolons in query args")
 	flagSet.StringSlice("extra-jwt-issuers", []string{}, "if skip-jwt-bearer-tokens is set, a list of extra JWT issuer=audience pairs (where the issuer URL has a .well-known/openid-configuration or a .well-known/jwks.json)")
 
 	flagSet.StringSlice("email-domain", []string{}, "authenticate emails with the specified domain (may be given multiple times). Use * to authenticate any email")

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -42,6 +42,7 @@ func NewServer(opts Opts) (Server, error) {
 	s := &server{
 		handler: opts.Handler,
 	}
+
 	if err := s.setupListener(opts); err != nil {
 		return nil, fmt.Errorf("error setting up listener: %v", err)
 	}


### PR DESCRIPTION
## Description

Provide support for using semicolons in query strings. This adds a new bool flag `--allow-query-semicolons`.

## Motivation and Context

See Issue https://github.com/oauth2-proxy/oauth2-proxy/issues/1841

## How Has This Been Tested?

Tested against OTRS, (the original requester was using this ticket system).

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
