### PR TITLE
Fixed build status badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![OAuth2 Proxy](/docs/static/img/logos/OAuth2_Proxy_horizontal.svg)
 
-[![Build Status](https://secure.travis-ci.org/oauth2-proxy/oauth2-proxy.svg?branch=master)](http://travis-ci.org/oauth2-proxy/oauth2-proxy)
+[![Continuous Integration](https://github.com/oauth2-proxy/oauth2-proxy/actions/workflows/ci.yaml/badge.svg)](https://github.com/oauth2-proxy/oauth2-proxy/actions/workflows/ci.yaml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/oauth2-proxy/oauth2-proxy)](https://goreportcard.com/report/github.com/oauth2-proxy/oauth2-proxy)
 [![GoDoc](https://godoc.org/github.com/oauth2-proxy/oauth2-proxy?status.svg)](https://godoc.org/github.com/oauth2-proxy/oauth2-proxy)
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The README.md still tries to show the old Travis CI status badge, which is now broken.

This might show to visitors that this project is not well-maintained, and that the build is currently broken. 
The builds actually run nicely and are green on GitHub actions.

## Motivation and Context

The current status badge in the README is broken: 

![image](https://user-images.githubusercontent.com/3957921/232200087-a5b5d794-6fd5-47d7-bb14-444cf771f347.png)

This project removed the TravisCI configuration in e9d46bfe32ab9db6622e8d2c2b2b54a60357d9ec, and is now using GitHub actions, see #546

## How Has This Been Tested?

Screenshot in forked repo: https://github.com/ahus1/oauth2-proxy/tree/fix-build-status-badge

![image](https://user-images.githubusercontent.com/3957921/232200186-e849e54c-44a5-4154-ac39-777d51fabf9d.png)


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
