### PR TITLE
Add some docs on `X-Auth-Request-Redirect` headers

### DIFF
--- a/docs/docs/behaviour.md
+++ b/docs/docs/behaviour.md
@@ -8,4 +8,12 @@ title: Behaviour
 3. After returning from the authentication provider, the oauth tokens are stored in the configured session store (cookie, redis, ...) and a cookie is set
 4. The request is forwarded to the upstream server with added user info and authentication headers (depending on the configuration)
 
+The log in interface will, by default, redirect back to the configured domain with the user's original path.
+If you wish to use the same oauth proxy instance across multiple domains, you can specify the `X-Auth-Request-Redirect` header via a proxy to refer to the domain you want to redirect to after authentication along with the path.
+For example, with nginx you would use the `proxy_set_header` directive:
+
+```
+proxy_set_header X-Auth-Request-Redirect $scheme://$http_host$request_uri;
+```
+
 Notice that the proxy also provides a number of useful [endpoints](features/endpoints.md).


### PR DESCRIPTION
These are useful for re-using the same instance of oauth2-proxy across domains.

<!--- Provide a general summary of your changes in the Title above -->

## Description

Document how oauth2-proxy handles `X-Auth-Request-Redirect` headers

<!--- Describe your changes in detail -->

## Motivation and Context

I flailed around trying to find a solution here and only found out about this after much spelunking through the source.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Docs-only change.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
