### PR TITLE
Update stale bot to v8

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/stale@v1
+    - uses: actions/stale@v8
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue has been inactive for 60 days. If the issue is still relevant please comment to re-activate the issue. If no action is taken within 7 days, the issue will be marked closed.'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The stale bot hasn't been updated in a while, we should probably update it to take advantage of the newer features (such as closing as not planned and auto removal of stale labels on comments.

<!--- Describe your changes in detail -->


