### PR TITLE
Fix azure provider to set expirement of session properly for v2.0 endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [#1988](https://github.com/oauth2-proxy/oauth2-proxy/pull/1988) Ensure sign-in page background is uniform throughout the page
 - [#2013](https://github.com/oauth2-proxy/oauth2-proxy/pull/2013) Upgrade alpine to version 3.17.2 and library dependencies (@miguelborges99)
 - [#2047](https://github.com/oauth2-proxy/oauth2-proxy/pull/2047) CVE-2022-41717: DoS in Go net/http may lead to DoS (@miguelborges99)
+- [#2096](https://github.com/oauth2-proxy/oauth2-proxy/pull/2096) Fix azure provider to set expirement of session properly for azure v2.0 endpoints (@nhahn1312)
 
 # V7.4.0
 


### PR DESCRIPTION
## Motivation and Context

Fix #2095. See the issue for more information

## How Has This Been Tested?

1. I have updated the unit tests for the azure provider to include a test case for v2.0 redeem of an access_token 
2. I have tested the changes with a local oauth proxy instance with azure provider v2.0 config to verify the functionality

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
