### PR TITLE
feat: add support for Google Cloud Identity API

### DIFF
--- a/docs/docs/configuration/auth.md
+++ b/docs/docs/configuration/auth.md
@@ -48,8 +48,8 @@ For Google, the registration steps are:
 
 It's recommended to refresh sessions on a short interval (1h) with `cookie-refresh` setting which validates that the account is still authorized.
 
-#### Restrict auth to specific Google groups on your domain. (optional)
-
+#### Restrict auth to specific Google groups on your domain. (optional, follow either one of the methods)
+#### Using service account with admin access:
 1.  Create a service account: https://developers.google.com/identity/protocols/OAuth2ServiceAccount and make sure to download the json file.
 2.  Make note of the Client ID for a future step.
 3.  Under "APIs & Auth", choose APIs.
@@ -67,6 +67,15 @@ https://www.googleapis.com/auth/admin.directory.user.readonly
     and the user will be checked against all the provided groups.
 9.  Lock down the permissions on the json file downloaded from step 1 so only oauth2-proxy is able to read the file and set the path to the file in the `google-service-account-json` flag.
 10. Restart oauth2-proxy.
+
+#### Using Cloud Identity API
+1. Create or choose an existing email group and set that email to the `google-group` flag. You can pass multiple instances of this flag with different groups and the user will be checked against all the provided groups.
+2. Configure `scope` flag with the following scopes:
+```
+profile email https://www.googleapis.com/auth/cloud-identity.groups.readonly
+```
+3. Make sure users of the google group can view other members. Configure it in "Access Settings" for the group in admin console.
+4. Restart oauth2-proxy.
 
 Note: The user is checked against the group members list on initial authentication and every time the token is refreshed ( about once an hour ).
 

--- a/pkg/validation/options_test.go
+++ b/pkg/validation/options_test.go
@@ -57,12 +57,12 @@ func TestNewOptions(t *testing.T) {
 
 func TestGoogleGroupOptions(t *testing.T) {
 	o := testOptions()
-	o.Providers[0].GoogleConfig.Groups = []string{"googlegroup"}
+	o.Providers[0].GoogleConfig.AdminEmail = "user@google.com"
 	err := Validate(o)
 	assert.NotEqual(t, nil, err)
 
 	expected := errorMsg([]string{
-		"missing setting: google-admin-email",
+		"missing setting: google-group",
 		"missing setting: google-service-account-json"})
 	assert.Equal(t, expected, err.Error())
 }

--- a/pkg/validation/providers.go
+++ b/pkg/validation/providers.go
@@ -66,8 +66,7 @@ func validateProvider(provider options.Provider, providerIDs map[string]struct{}
 
 func validateGoogleConfig(provider options.Provider) []string {
 	msgs := []string{}
-	if len(provider.GoogleConfig.Groups) > 0 ||
-		provider.GoogleConfig.AdminEmail != "" ||
+	if provider.GoogleConfig.AdminEmail != "" ||
 		provider.GoogleConfig.ServiceAccountJSON != "" {
 		if len(provider.GoogleConfig.Groups) < 1 {
 			msgs = append(msgs, "missing setting: google-group")

--- a/providers/google.go
+++ b/providers/google.go
@@ -273,13 +273,14 @@ func getGroupID(service *cloudidentity.Service, groupEmail string) (string, erro
 	resp, err := service.Groups.Lookup().
 		GroupKeyId(groupEmail).Do()
 	if err != nil {
-		if resp.HTTPStatusCode == 404 {
+		if resp != nil && resp.HTTPStatusCode == 404 {
 			logger.Errorf("error getting group id for group %s: group does not exist", groupEmail)
 		} else {
 			logger.Error("failed to get group id from group email:", err)
 		}
+		return "", err
 	}
-	return resp.Name, err
+	return resp.Name, nil
 }
 
 func getAdminService(adminEmail string, credentialsReader io.Reader) *admin.Service {

--- a/providers/google_test.go
+++ b/providers/google_test.go
@@ -125,14 +125,14 @@ func TestGoogleProviderGroupValidator(t *testing.T) {
 
 	testCases := map[string]struct {
 		session       *sessions.SessionState
-		validatorFunc func(*sessions.SessionState) bool
+		validatorFunc func(context.Context, *sessions.SessionState) bool
 		expectedAuthZ bool
 	}{
 		"Email is authorized with groupValidator": {
 			session: &sessions.SessionState{
 				Email: sessionEmail,
 			},
-			validatorFunc: func(s *sessions.SessionState) bool {
+			validatorFunc: func(_ context.Context, s *sessions.SessionState) bool {
 				return s.Email == sessionEmail
 			},
 			expectedAuthZ: true,
@@ -141,7 +141,7 @@ func TestGoogleProviderGroupValidator(t *testing.T) {
 			session: &sessions.SessionState{
 				Email: sessionEmail,
 			},
-			validatorFunc: func(s *sessions.SessionState) bool {
+			validatorFunc: func(_ context.Context, s *sessions.SessionState) bool {
 				return s.Email != sessionEmail
 			},
 			expectedAuthZ: false,
@@ -161,7 +161,7 @@ func TestGoogleProviderGroupValidator(t *testing.T) {
 			if tc.validatorFunc != nil {
 				p.groupValidator = tc.validatorFunc
 			}
-			g.Expect(p.groupValidator(tc.session)).To(Equal(tc.expectedAuthZ))
+			g.Expect(p.groupValidator(context.Background(), tc.session)).To(Equal(tc.expectedAuthZ))
 		})
 	}
 }


### PR DESCRIPTION
Add support for using Cloud Identity API for group membership resolution

## Description

Google provider uses an admin email and JSON credential to perform group membership verification. This can be avoided by using the Cloud Identity API which uses the authenticating user's credentials to verify membership. This will avoid creating an admin user with wider permissions.

## Motivation and Context

Avoids creating a user with domain wide user and group read access.
Implements: #728

## How Has This Been Tested?

Tested with the following configuration against GSuite.
```
provider = "google"
google_group = "my-group@example.org"
email_domains ="example.org"
scope = "profile email https://www.googleapis.com/auth/cloud-identity.groups.readonly"
client_id ="<client-id>"
client_secret ="<client-secret>"
```

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
