### PR TITLE
Introspection support

### DIFF
--- a/pkg/apis/middleware/scope.go
+++ b/pkg/apis/middleware/scope.go
@@ -35,6 +35,10 @@ type RequestScope struct {
 	// ClearSession indicates whether the user should be logged out or not.
 	ClearSession bool
 
+	// IntrospectToken indicates whether to introspect the session token.
+	// This is set if the request has the header `X-Oauth2-Proxy-Introspect-Token`.
+	IntrospectToken bool
+
 	// SessionRevalidated indicates whether the session has been revalidated since
 	// it was loaded or not.
 	SessionRevalidated bool

--- a/pkg/apis/options/providers.go
+++ b/pkg/apis/options/providers.go
@@ -60,12 +60,15 @@ type Provider struct {
 	// If not specified, the default Go trust sources are used instead
 	CAFiles []string `json:"caFiles,omitempty"`
 
+	EndSessionURL    string `json:"endSessionURL,omitempty"`
+	IntrospectionURL string `json:"introspectionURL,omitempty"`
 	// LoginURL is the authentication endpoint
 	LoginURL string `json:"loginURL,omitempty"`
 	// LoginURLParameters defines the parameters that can be passed from the start URL to the IdP login URL
 	LoginURLParameters []LoginURLParameter `json:"loginURLParameters,omitempty"`
 	// RedeemURL is the token redemption endpoint
-	RedeemURL string `json:"redeemURL,omitempty"`
+	RedeemURL     string `json:"redeemURL,omitempty"`
+	RevocationURL string `json:"revocationURL,omitempty"`
 	// ProfileURL is the profile access endpoint
 	ProfileURL string `json:"profileURL,omitempty"`
 	// ProtectedResource is the resource that is protected (Azure AD and ADFS only)

--- a/pkg/apis/sessions/session_state.go
+++ b/pkg/apis/sessions/session_state.go
@@ -30,8 +30,9 @@ type SessionState struct {
 	PreferredUsername string   `msgpack:"pu,omitempty"`
 
 	// Internal helpers, not serialized
-	Clock clock.Clock `msgpack:"-"`
-	Lock  Lock        `msgpack:"-"`
+	Clock           clock.Clock `msgpack:"-"`
+	Lock            Lock        `msgpack:"-"`
+	IntrospectToken bool        `msgpack:"-"`
 }
 
 func (s *SessionState) ObtainLock(ctx context.Context, expiration time.Duration) error {

--- a/pkg/providers/oidc/provider.go
+++ b/pkg/providers/oidc/provider.go
@@ -11,11 +11,15 @@ import (
 
 // providerJSON represents the information we need from an OIDC discovery
 type providerJSON struct {
-	Issuer               string   `json:"issuer"`
-	AuthURL              string   `json:"authorization_endpoint"`
-	TokenURL             string   `json:"token_endpoint"`
-	JWKsURL              string   `json:"jwks_uri"`
-	UserInfoURL          string   `json:"userinfo_endpoint"`
+	AuthURL          string `json:"authorization_endpoint"`
+	EndSessionURL    string `json:"end_session_endpoint"`
+	IntrospectionURL string `json:"introspection_endpoint"`
+	Issuer           string `json:"issuer"`
+	JWKsURL          string `json:"jwks_uri"`
+	RevocationURL    string `json:"revocation_endpoint"`
+	TokenURL         string `json:"token_endpoint"`
+	UserInfoURL      string `json:"userinfo_endpoint"`
+
 	CodeChallengeAlgs    []string `json:"code_challenge_methods_supported"`
 	SupportedSigningAlgs []string `json:"id_token_signing_alg_values_supported"`
 }
@@ -23,10 +27,13 @@ type providerJSON struct {
 // Endpoints represents the endpoints discovered as part of the OIDC discovery process
 // that will be used by the authentication providers.
 type Endpoints struct {
-	AuthURL     string
-	TokenURL    string
-	JWKsURL     string
-	UserInfoURL string
+	AuthURL          string
+	EndSessionURL    string
+	IntrospectionURL string
+	RevocationURL    string
+	TokenURL         string
+	JWKsURL          string
+	UserInfoURL      string
 }
 
 // PKCE holds information relevant to the PKCE (code challenge) support of the
@@ -66,8 +73,11 @@ func NewProvider(ctx context.Context, issuerURL string, skipIssuerVerification b
 
 	return &discoveryProvider{
 		authURL:              p.AuthURL,
-		tokenURL:             p.TokenURL,
+		endSessionURL:        p.EndSessionURL,
+		introspectionURL:     p.IntrospectionURL,
 		jwksURL:              p.JWKsURL,
+		revocationURL:        p.RevocationURL,
+		tokenURL:             p.TokenURL,
 		userInfoURL:          p.UserInfoURL,
 		codeChallengeAlgs:    p.CodeChallengeAlgs,
 		supportedSigningAlgs: p.SupportedSigningAlgs,
@@ -77,6 +87,9 @@ func NewProvider(ctx context.Context, issuerURL string, skipIssuerVerification b
 // discoveryProvider holds the discovered endpoints
 type discoveryProvider struct {
 	authURL              string
+	endSessionURL        string
+	introspectionURL     string
+	revocationURL        string
 	tokenURL             string
 	jwksURL              string
 	userInfoURL          string
@@ -87,10 +100,13 @@ type discoveryProvider struct {
 // Endpoints returns the discovered endpoints needed for an authentication provider.
 func (p *discoveryProvider) Endpoints() Endpoints {
 	return Endpoints{
-		AuthURL:     p.authURL,
-		TokenURL:    p.tokenURL,
-		JWKsURL:     p.jwksURL,
-		UserInfoURL: p.userInfoURL,
+		AuthURL:          p.authURL,
+		EndSessionURL:    p.endSessionURL,
+		IntrospectionURL: p.introspectionURL,
+		RevocationURL:    p.revocationURL,
+		TokenURL:         p.tokenURL,
+		JWKsURL:          p.jwksURL,
+		UserInfoURL:      p.userInfoURL,
 	}
 }
 

--- a/pkg/requests/builder.go
+++ b/pkg/requests/builder.go
@@ -2,6 +2,7 @@ package requests
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"net/http"
@@ -12,6 +13,8 @@ import (
 // Do returns a Result which allows the user to get the body,
 // unmarshal the body into an interface, or into a simplejson.Json.
 type Builder interface {
+	WithAuthorization(string, string) Builder
+	WithAuthorizationBasicBase64(username, password string) Builder
 	WithContext(context.Context) Builder
 	WithBody(io.Reader) Builder
 	WithMethod(string) Builder
@@ -35,6 +38,20 @@ func New(endpoint string) Builder {
 		endpoint: endpoint,
 		method:   "GET",
 	}
+}
+
+// WithAuthorization adds a Authorization header to the request
+func (r *builder) WithAuthorization(auth, value string) Builder {
+	return r.SetHeader("Authorization", fmt.Sprintf("%s %s", auth, value))
+}
+
+// WithAuthorization adds a Authorization Basic header to the request
+// Used for username password
+func (r *builder) WithAuthorizationBasicBase64(username, password string) Builder {
+	str := []byte(fmt.Sprintf("%s:%s", username, password))
+	value := base64.StdEncoding.EncodeToString(str)
+
+	return r.WithAuthorization("Basic", value)
 }
 
 // WithContext adds a context to the request.

--- a/providers/provider_data.go
+++ b/providers/provider_data.go
@@ -28,8 +28,11 @@ const (
 // of OAuth2 providers
 type ProviderData struct {
 	ProviderName      string
+	EndSessionURL     *url.URL
+	IntrospectionURL  *url.URL
 	LoginURL          *url.URL
 	RedeemURL         *url.URL
+	RevocationURL     *url.URL
 	ProfileURL        *url.URL
 	ProtectedResource *url.URL
 	ValidateURL       *url.URL
@@ -179,18 +182,24 @@ func (p *ProviderData) setAllowedGroups(groups []string) {
 }
 
 type providerDefaults struct {
-	name        string
-	loginURL    *url.URL
-	redeemURL   *url.URL
-	profileURL  *url.URL
-	validateURL *url.URL
-	scope       string
+	name             string
+	endSessionURL    *url.URL
+	introspectionURL *url.URL
+	loginURL         *url.URL
+	redeemURL        *url.URL
+	revocationURL    *url.URL
+	profileURL       *url.URL
+	validateURL      *url.URL
+	scope            string
 }
 
 func (p *ProviderData) setProviderDefaults(defaults providerDefaults) {
 	p.ProviderName = defaults.name
+	p.EndSessionURL = defaultURL(p.EndSessionURL, defaults.endSessionURL)
+	p.IntrospectionURL = defaultURL(p.IntrospectionURL, defaults.introspectionURL)
 	p.LoginURL = defaultURL(p.LoginURL, defaults.loginURL)
 	p.RedeemURL = defaultURL(p.RedeemURL, defaults.redeemURL)
+	p.RevocationURL = defaultURL(p.RevocationURL, defaults.revocationURL)
 	p.ProfileURL = defaultURL(p.ProfileURL, defaults.profileURL)
 	p.ValidateURL = defaultURL(p.ValidateURL, defaults.validateURL)
 

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -102,8 +102,11 @@ func newProviderDataFromConfig(providerConfig options.Provider) (*ProviderData, 
 			// Use the discovered values rather than any specified values
 			endpoints := pv.Provider().Endpoints()
 			pkce := pv.Provider().PKCE()
+			providerConfig.EndSessionURL = endpoints.EndSessionURL
+			providerConfig.IntrospectionURL = endpoints.IntrospectionURL
 			providerConfig.LoginURL = endpoints.AuthURL
 			providerConfig.RedeemURL = endpoints.TokenURL
+			providerConfig.RevocationURL = endpoints.RevocationURL
 			providerConfig.ProfileURL = endpoints.UserInfoURL
 			providerConfig.OIDCConfig.JwksURL = endpoints.JWKsURL
 			p.SupportedCodeChallengeMethods = pkce.CodeChallengeAlgs
@@ -115,11 +118,14 @@ func newProviderDataFromConfig(providerConfig options.Provider) (*ProviderData, 
 		dst **url.URL
 		raw string
 	}{
-		"login":    {dst: &p.LoginURL, raw: providerConfig.LoginURL},
-		"redeem":   {dst: &p.RedeemURL, raw: providerConfig.RedeemURL},
-		"profile":  {dst: &p.ProfileURL, raw: providerConfig.ProfileURL},
-		"validate": {dst: &p.ValidateURL, raw: providerConfig.ValidateURL},
-		"resource": {dst: &p.ProtectedResource, raw: providerConfig.ProtectedResource},
+		"end_session": {dst: &p.EndSessionURL, raw: providerConfig.EndSessionURL},
+		"introspect":  {dst: &p.IntrospectionURL, raw: providerConfig.IntrospectionURL},
+		"revoke":      {dst: &p.RevocationURL, raw: providerConfig.RevocationURL},
+		"login":       {dst: &p.LoginURL, raw: providerConfig.LoginURL},
+		"redeem":      {dst: &p.RedeemURL, raw: providerConfig.RedeemURL},
+		"profile":     {dst: &p.ProfileURL, raw: providerConfig.ProfileURL},
+		"validate":    {dst: &p.ValidateURL, raw: providerConfig.ValidateURL},
+		"resource":    {dst: &p.ProtectedResource, raw: providerConfig.ProtectedResource},
 	} {
 		var err error
 		*u.dst, err = url.Parse(u.raw)


### PR DESCRIPTION
Set `X-Oauth2-Proxy-Introspect-Token true' on requests that you want to be introspected. Will affect latency.

## Description

Adding the ability to introspect the token when a specific header is set in the incoming request. From what I have come to understand, it's not possible to use Introspection on PKCE (https://salesforce.stackexchange.com/a/299171).

This uses the introspection url already provided by the OIDC endpoint. 

## Motivation and Context

In e.g. Nginx this makes it possible to make really sure that certain operations validate the token the whole way.

## How Has This Been Tested?

* Logging in
* Invalidating the token centrally
* Trying to access the resource again

## Checklist:

- [X] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
