### PR TITLE
fix: use X-Forwarded-Uri if it exists for pathRegex match

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -554,7 +554,7 @@ func isAllowedMethod(req *http.Request, route allowedRoute) bool {
 }
 
 func isAllowedPath(req *http.Request, route allowedRoute) bool {
-	matches := route.pathRegex.MatchString(req.URL.Path)
+	matches := route.pathRegex.MatchString(requestutil.GetRequestURI(req))
 
 	if route.negate {
 		return !matches
@@ -575,7 +575,7 @@ func (p *OAuthProxy) isAllowedRoute(req *http.Request) bool {
 
 func (p *OAuthProxy) isAPIPath(req *http.Request) bool {
 	for _, route := range p.apiRoutes {
-		if route.pathRegex.MatchString(req.URL.Path) {
+		if route.pathRegex.MatchString(requestutil.GetRequestURI(req)) {
 			return true
 		}
 	}


### PR DESCRIPTION
## Description
The functions `isApiPath` and `isAllowedPath` use the `req.URL.Path` property which leads to faulty behavior when behind a reverse proxy. The correct path can be inferred from the `X-Forwarded-Uri` header by making use of the already provided `requestutil.GetRequestURI` function.

<!--- Describe your changes in detail -->

## Motivation and Context
The functions `isApiPath` and `isAllowedPath` use the `req.URL.Path` property, which is always `/` **when used behind a proxy**. Using the `requestutil.GetRequestURI` helper, we get the optional (and correct) `X-Forwarded-Uri` header, while falling back to original URI path.

Possibly related to:
https://github.com/oauth2-proxy/oauth2-proxy/issues/2029#issuecomment-1545438281
and
https://github.com/oauth2-proxy/oauth2-proxy/issues/2029#issuecomment-1546706288

## How Has This Been Tested?
This has been tested inside a `golang` docker container with docker compose, using the traefik forward-auth middleware in a reverse proxy setup. 

All tests are running exactly as before the changes were made. The changes made should not have any side effects, since the function used falls back to the behavior as it was before the change.
```console
root@d1293379e417:/go/oauth2-proxy# go test
Running Suite: Main Suite
=========================
Random Seed: 1686759490
Will run 5 of 5 specs

•••••
Ran 5 of 5 Specs in 0.006 seconds
SUCCESS! -- 5 Passed | 0 Failed | 0 Pending | 0 Skipped
```

## Checklist:
- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
