### PR TITLE
Added possibility to configure an outbound proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [#1988](https://github.com/oauth2-proxy/oauth2-proxy/pull/1988) Ensure sign-in page background is uniform throughout the page
 - [#2013](https://github.com/oauth2-proxy/oauth2-proxy/pull/2013) Upgrade alpine to version 3.17.2 and library dependencies (@miguelborges99)
 - [#2047](https://github.com/oauth2-proxy/oauth2-proxy/pull/2047) CVE-2022-41717: DoS in Go net/http may lead to DoS (@miguelborges99)
+- [#2174](https://github.com/oauth2-proxy/oauth2-proxy/pull/2174) Added Possibility to Configure an outbound proxy for OAuth2 itself (@wahlflo)
 
 # V7.4.0
 

--- a/docs/docs/configuration/overview.md
+++ b/docs/docs/configuration/overview.md
@@ -238,6 +238,10 @@ or the command line.
 For example, the `--cookie-secret` flag becomes `OAUTH2_PROXY_COOKIE_SECRET`,
 and the `--email-domain` flag becomes `OAUTH2_PROXY_EMAIL_DOMAINS`.
 
+### Configuring Outbound Proxy
+If you need to pass a proxy when communicating with the providers, you can set the environment variable 
+`OAUTH2_PROXY_OUTBOUND_PROXY` in the format `<protocol>://(<domain>|<ip>):<port>`.
+
 ## Logging Configuration
 
 By default, OAuth2 Proxy logs all output to stdout. Logging can be configured to output to a rotating log file using the `--logging-filename` command.


### PR DESCRIPTION
## Description

Added the possibility to configure a HTTP proxy for the OAuth2 proxy itself via the environment variable ``OAUTH2_PROXY_OUTBOUND_PROXY``.
If the parameter is not set the default ``http.Client`` is used as before.

## Motivation and Context

closes #2172 

## How Has This Been Tested?

Tested locally

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
