### PR TITLE
Update auth.md for Azure v2.0

### DIFF
--- a/docs/versioned_docs/version-7.4.x/configuration/auth.md
+++ b/docs/versioned_docs/version-7.4.x/configuration/auth.md
@@ -97,10 +97,9 @@ in the App registration manifest file.
 
 - for V2 Azure Auth endpoint (Microsoft Identity Platform Endpoints - https://login.microsoftonline.com/common/oauth2/v2.0/authorize)
 ```
-   --provider=azure
+   --provider=oidc
    --client-id=<application ID from step 3>
    --client-secret=<value from step 5>
-   --azure-tenant={tenant-id}
    --oidc-issuer-url=https://login.microsoftonline.com/{tenant-id}/v2.0
 ```
 


### PR DESCRIPTION
Updated documentation example for Azure using v2.0 endpoint
Description

By using provider=oidc, permission problems for Group lookups are resolved
Motivation and Context

Current example doesn't work for v2.0, results in 500 permission denied errors for Group lookups
How Has This Been Tested?

Verified sign-in using oauth2-proxy and Azure IDp
Checklist:

[] My change requires a change to the documentation or CHANGELOG.
[] I have updated the documentation/CHANGELOG accordingly.
[ X] I have created a feature (non-master) branch for my PR.