### PR TITLE
Fix HTTP 500 error for redirect url being called without 'state' query when `cookie-csrf-per-request=true`

### DIFF
--- a/pkg/cookies/csrf.go
+++ b/pkg/cookies/csrf.go
@@ -219,7 +219,7 @@ func ExtractStateSubstring(req *http.Request) string {
 	stateSubstring := ""
 
 	state := req.URL.Query()["state"]
-	if state[0] != "" {
+	if len(state) > 0 && state[0] != "" {
 		state := state[0]
 		if lastChar <= len(state) {
 			stateSubstring = state[0:lastChar]


### PR DESCRIPTION
I found that in some cases, the `oauth2-proxy` will response HTTP 500 in case of the `redirect-url` was called without any query string, therefore I found the bug in `/pkg/cookies.ExtractStateSubstring()`.

The problem happens only when `cookie-csrf-per-request=true`.

## Description
When the `redirect-url` was called without any query string, following error message will appears in logs and the client will receive HTTP 500 error.
```
2023/08/11 01:25:24 http: panic serving 10.x.x.x:52104: runtime error: index out of range [0] with length 0                                                                       
goroutine 103 [running]:                                                                                                                                                            
net/http.(*conn).serve.func1()                                                                                                                                                      
    /usr/local/go/src/net/http/server.go:1850 +0xb8                                                                                                                                 
panic({0x911720, 0x40001447f8})                                                                                                                                                     
    /usr/local/go/src/runtime/panic.go:890 +0x260                                                                                                                                   
github.com/oauth2-proxy/oauth2-proxy/v7/pkg/cookies.ExtractStateSubstring(0x4000131098?) 
```
## Motivation and Context

I found the line in csrf.go was casuing the issue . The slice `state` was assumed having at least 1 item.
```golang
state := req.URL.Query()["state"]
if state[0] != "" {
```

So I added a simple length check with that, and the problem was gone.

```golang
if len(state) > 0 && state[0] != "" {
```
## How Has This Been Tested?

Here is a step to reproduce the same error with docker image `quay.io/oauth2-proxy/oauth2-proxy:v7.4.0`.

In a container with working OIDC configs, I had definied `--redirect-url` and `--cookie-csrf-per-request` as below.
```
--redirect-url=/oauth2/callback \
--cookie-csrf-per-request=true 
```

And then I get in to the shell of the container, try the `redirect-url` with wget, and I can see the error of "index out of range [0] with length 0" will be raised.
```
$ wget localhost:4180/oauth2/callback
Connecting to localhost:4180 ([::1]:4180)
wget: error getting response: Invalid argument
```

My testing environment was using Gitlab.com as provider, and my platforms to reproduce such error are "linux/amd64" and "linux/arm64".

## Checklist:

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [X] I have created a feature (non-master) branch for my PR.
