### PR TITLE
Update setup-buildx-action to supported version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,12 +57,12 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v3
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+    
     - name: Set up Docker Buildx
       id: buildx
-      uses: crazy-max/ghaction-docker-buildx@v3
-      with:
-        buildx-version: latest
-        qemu-version: latest
+      uses: docker/setup-buildx-action@v2
 
     - name: Docker Build
       run: |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The [crazy-max github action](https://github.com/crazy-max/ghaction-docker-buildx) which sets up buildx and qemu was archived by its owner.  This PR replaces it with the [setup-buildx](https://github.com/docker/setup-buildx-action) and [setup-qemu](https://github.com/docker/setup-qemu-action) actions which are now owned by the docker organization.

## Motivation and Context

I ran across the out of date action while building this in my environment and wanted to give something back.

## How Has This Been Tested?

The workflows ran successfully in [my forked repository](https://github.com/MarkIannucci/oauth2-proxy/actions/runs/5947901275/job/16130693530).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
