### PR TITLE
bugfix: move oidc scope logic to oidc provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## Breaking Changes
 
 ## Changes since v7.5.0
+- [#1989](https://github.com/oauth2-proxy/oauth2-proxy/pull/1989) Fix default scope for keycloak-oidc provider
 
 # V7.5.0
 

--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -20,16 +20,24 @@ type OIDCProvider struct {
 	SkipNonce bool
 }
 
+const oidcDefaultScope = "openid email profile"
+
 // NewOIDCProvider initiates a new OIDCProvider
 func NewOIDCProvider(p *ProviderData, opts options.OIDCOptions) *OIDCProvider {
-	p.setProviderDefaults(providerDefaults{
+	oidcProviderDefaults := providerDefaults{
 		name:        "OpenID Connect",
 		loginURL:    nil,
 		redeemURL:   nil,
 		profileURL:  nil,
 		validateURL: nil,
-		scope:       "",
-	})
+		scope:       oidcDefaultScope,
+	}
+
+	if len(p.AllowedGroups) > 0 {
+		oidcProviderDefaults.scope += " groups"
+	}
+
+	p.setProviderDefaults(oidcProviderDefaults)
 	p.getAuthorizationHeaderFunc = makeOIDCHeader
 
 	return &OIDCProvider{

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -156,14 +156,6 @@ func newProviderDataFromConfig(providerConfig options.Provider) (*ProviderData, 
 		p.EmailClaim = providerConfig.OIDCConfig.UserIDClaim
 	}
 
-	if providerConfig.Type == "oidc" && p.Scope == "" {
-		p.Scope = "openid email profile"
-
-		if len(providerConfig.AllowedGroups) > 0 {
-			p.Scope += " groups"
-		}
-	}
-
 	p.setAllowedGroups(providerConfig.AllowedGroups)
 
 	return p, nil


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description and Motivation
The OIDC provider shouldn't be treated as anything specially where as all the other providers have their internal scope logic defined in the specific provider files the scope logic for oidc and in extension the keycloak-oidc provider is located in the providers.go.

To align the OIDC and Keycloak OIDC provider I moved the logic to the oidc.go provider file.

<!--- Describe your changes in detail -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My change requires a change to the documentation or CHANGELOG.
- [X] I have updated the documentation/CHANGELOG accordingly.
- [X] I have created a feature (non-master) branch for my PR.


Replaces PR: #1989 
Fixes:#2222