### PR TITLE
Issue 2153: Can not specific other usernames rather than default when using Redis Cluster or Redis Sentinel as session storage

### DIFF
--- a/pkg/sessions/redis/redis_store.go
+++ b/pkg/sessions/redis/redis_store.go
@@ -104,11 +104,16 @@ func buildSentinelClient(opts options.RedisStoreOptions) (Client, error) {
 		return nil, err
 	}
 
+	if opts.Password != "" {
+		opt.Password = opts.Password
+	}
+
 	client := redis.NewFailoverClient(&redis.FailoverOptions{
 		MasterName:       opts.SentinelMasterName,
 		SentinelAddrs:    addrs,
 		SentinelPassword: opts.SentinelPassword,
-		Password:         opts.Password,
+		Username:         opt.Username,
+		Password:         opt.Password,
 		TLSConfig:        opt.TLSConfig,
 		ConnMaxIdleTime:  time.Duration(opts.IdleTimeout) * time.Second,
 	})

--- a/pkg/sessions/redis/redis_store.go
+++ b/pkg/sessions/redis/redis_store.go
@@ -126,9 +126,14 @@ func buildClusterClient(opts options.RedisStoreOptions) (Client, error) {
 		return nil, err
 	}
 
+	if opts.Password != "" {
+		opt.Password = opts.Password
+	}
+
 	client := redis.NewClusterClient(&redis.ClusterOptions{
 		Addrs:           addrs,
-		Password:        opts.Password,
+		Username:        opt.Username,
+		Password:        opt.Password,
 		TLSConfig:       opt.TLSConfig,
 		ConnMaxIdleTime: time.Duration(opts.IdleTimeout) * time.Second,
 	})


### PR DESCRIPTION
## Description

When using Redis Cluster or Redis Sentinel as session storage, pass the username to the opts.

## Motivation and Context

Can not specific other usernames rather than default when using Redis Cluster or Redis Sentinel as session storage.
For more detail, please check this issue:
https://github.com/oauth2-proxy/oauth2-proxy/issues/2153

## How Has This Been Tested?

Prepared a redis cluster and tested with the following configs:
```
redis_use_cluster=true
redis_cluster_connection_urls="redis://user:secret@redis-cluster"
```

## Checklist:

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
