### PR TITLE
feat: add SetDefaultIfNil partially

### DIFF
--- a/main.go
+++ b/main.go
@@ -113,6 +113,7 @@ func loadAlphaOptions(config, alphaConfig string, extraFlags *pflag.FlagSet, arg
 	if err := options.LoadYAML(alphaConfig, alphaOpts); err != nil {
 		return nil, fmt.Errorf("failed to load alpha options: %v", err)
 	}
+	alphaOpts.SetDefaultIfNil()
 
 	alphaOpts.MergeInto(opts)
 	return opts, nil

--- a/pkg/apis/options/alpha_options.go
+++ b/pkg/apis/options/alpha_options.go
@@ -45,6 +45,10 @@ type AlphaOptions struct {
 	Providers Providers `json:"providers,omitempty"`
 }
 
+func (a *AlphaOptions) SetDefaultIfNil() {
+	a.Providers.SetDefaultIfNil()
+}
+
 // MergeInto replaces alpha options in the Options struct with the values
 // from the AlphaOptions
 func (a *AlphaOptions) MergeInto(opts *Options) {

--- a/pkg/apis/options/providers.go
+++ b/pkg/apis/options/providers.go
@@ -14,6 +14,16 @@ var OIDCAudienceClaims = []string{"aud"}
 // Providers is a collection of definitions for providers.
 type Providers []Provider
 
+func (p *Providers) SetDefaultIfNil() {
+	if len(*p) == 0 {
+		*p = providerDefaults()
+	}
+	for i, provider := range *p {
+		provider.SetDefaultIfNil()
+		(*p)[i] = provider
+	}
+}
+
 // Provider holds all configuration for a single provider
 type Provider struct {
 	// ClientID is the OAuth Client ID that is defined in the provider
@@ -78,6 +88,10 @@ type Provider struct {
 	AllowedGroups []string `json:"allowedGroups,omitempty"`
 	// The code challenge method
 	CodeChallengeMethod string `json:"code_challenge_method,omitempty"`
+}
+
+func (p *Provider) SetDefaultIfNil() {
+	p.OIDCConfig.SetDefaultIfNil()
 }
 
 // ProviderType is used to enumerate the different provider type options
@@ -228,6 +242,21 @@ type OIDCOptions struct {
 	// ExtraAudiences is a list of additional audiences that are allowed
 	// to pass verification in addition to the client id.
 	ExtraAudiences []string `json:"extraAudiences,omitempty"`
+}
+
+func (o *OIDCOptions) SetDefaultIfNil() {
+	if o.EmailClaim == "" {
+		o.EmailClaim = OIDCEmailClaim
+	}
+	if o.UserIDClaim == "" {
+		o.UserIDClaim = OIDCEmailClaim
+	}
+	if o.GroupsClaim == "" {
+		o.GroupsClaim = OIDCGroupsClaim
+	}
+	if len(o.AudienceClaims) == 0 {
+		o.AudienceClaims = OIDCAudienceClaims
+	}
 }
 
 type LoginGovOptions struct {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

If look at the oauth2-proxy documentation, we'll see the description like below.

|Field | Type | Description |
|-- | -- | --|
|emailClaim | string | EmailClaim indicates which claim contains the user email,default set to `email`|
|groupsClaim | string | GroupsClaim indicates which claim contains the user groups default set to `groups`|
|userIDClaim | string | UserIDClaim indicates which claim contains the user ID default set to `email`|
|audienceClaims | []string | AudienceClaim allows to define any claim that is verified against the client id By default `aud` claim is used for verification.|

I thought that if I didn't declare those values, they would automatically be set to the default values. It would be nice to be able to declare default values in yaml tags, but if not, check out what this PR suggests.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
