### PR TITLE
Fix default email/groups/audience claim settings

### DIFF
--- a/pkg/apis/options/providers.go
+++ b/pkg/apis/options/providers.go
@@ -256,10 +256,6 @@ func providerDefaults() Providers {
 				InsecureAllowUnverifiedEmail: false,
 				InsecureSkipNonce:            true,
 				SkipDiscovery:                false,
-				UserIDClaim:                  OIDCEmailClaim, // Deprecated: Use OIDCEmailClaim
-				EmailClaim:                   OIDCEmailClaim,
-				GroupsClaim:                  OIDCGroupsClaim,
-				AudienceClaims:               OIDCAudienceClaims,
 				ExtraAudiences:               []string{},
 			},
 		},

--- a/providers/adfs_test.go
+++ b/providers/adfs_test.go
@@ -62,7 +62,7 @@ func testADFSProvider(hostname string) *ADFSProvider {
 		ValidateURL:  &url.URL{},
 		Scope:        "",
 		Verifier:     o,
-		EmailClaim:   options.OIDCEmailClaim,
+		EmailClaim:   DefaultEmailClaim,
 	}, options.Provider{})
 
 	if hostname != "" {

--- a/providers/nextcloud.go
+++ b/providers/nextcloud.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/sessions"
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/logger"
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/requests"
@@ -26,7 +25,7 @@ func NewNextcloudProvider(p *ProviderData) *NextcloudProvider {
 	})
 
 	p.getAuthorizationHeaderFunc = makeOIDCHeader
-	if p.EmailClaim == options.OIDCEmailClaim {
+	if p.EmailClaim == DefaultEmailClaim {
 		// This implies the email claim has not been overridden, we should set a default
 		// for this provider
 		p.EmailClaim = "ocs.data.email"

--- a/providers/provider_data.go
+++ b/providers/provider_data.go
@@ -265,7 +265,7 @@ func (p *ProviderData) buildSessionFromClaims(rawIDToken, accessToken string) (*
 
 	// `email_verified` must be present and explicitly set to `false` to be
 	// considered unverified.
-	verifyEmail := (p.EmailClaim == options.OIDCEmailClaim) && !p.AllowUnverifiedEmail
+	verifyEmail := (p.EmailClaim == DefaultEmailClaim) && !p.AllowUnverifiedEmail
 
 	if verifyEmail {
 		var verified bool


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

If look at the oauth2-proxy documentation, we'll see the description like below.

|Field | Type | Description |
|-- | -- | --|
|emailClaim | string | EmailClaim indicates which claim contains the user email,default set to `email`|
|groupsClaim | string | GroupsClaim indicates which claim contains the user groups default set to `groups`|
|userIDClaim | string | UserIDClaim indicates which claim contains the user ID default set to `email`|
|audienceClaims | []string | AudienceClaim allows to define any claim that is verified against the client id By default `aud` claim is used for verification.|

I thought that if I didn't declare those values, they would automatically be set to the default values.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

.vscode/launch.json

```json
{
    "version": "0.2.0",
    "configurations": [
        {
            "name": "Launch Server",
            "type": "go",
            "program": ".",
            "request": "launch",
            "args": [
                "--alpha-config=config.yaml",
                "--silence-ping-logging",
                "--email-domain=*",
                "--redirect-url=https://<ngrok>/oauth2/callback",
                "--cookie-secret=<secret>",
                "--reverse-proxy=true",
            ],
            "mode": "debug"
        },
    ]
}
```

config.yaml

```yaml
upstreamConfig:
  upstreams:
    - id: test
      path: /
      uri: http://localhost:3333
injectRequestHeaders:
  - name: x-forwarded-email
    values:
      - claim: email
injectResponseHeaders:
  - name: x-forwarded-email
    values:
      - claim: email
providers:
  - id: keycloak-oidc
    provider: keycloak-oidc
    clientID: test
    clientSecret: <secret>
    scope: openid profile email groups
    allowedGroups:
      - test
    code_challenge_method: S256
    oidcConfig:
      issuerURL: https://<keycloak>/realms/<realm>
server:
  BindAddress: 0.0.0.0:4180
  SecureBindAddress: ""
metricsServer:
  BindAddress: 0.0.0.0:44180
  SecureBindAddress: ""
```

```shell
ngrok http 4180
```

- run an application with port 3333
- use debug mode with vscode
- run ngrok


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
