### PR TITLE
Update alpine to 3.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [#2220](https://github.com/oauth2-proxy/oauth2-proxy/pull/2220) Added binary and docker release platforms (@kvanzuijlen)
 - [#2221](https://github.com/oauth2-proxy/oauth2-proxy/pull/2221) Backwards compatible fix for wrong environment variable name (OAUTH2_PROXY_GOOGLE_GROUPS) (@kvanzuijlen)
 - [#1989](https://github.com/oauth2-proxy/oauth2-proxy/pull/1989) Fix default scope for keycloak-oidc provider
+- [#2217](https://github.com/oauth2-proxy/oauth2-proxy/pull/2217) Upgrade alpine to version 3.18 (@polarctos)
 
 # V7.5.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # This ARG has to be at the top, otherwise the docker daemon does not known what to do with FROM ${RUNTIME_IMAGE}
-ARG RUNTIME_IMAGE=docker.io/library/alpine:3.17.2
+ARG RUNTIME_IMAGE=docker.io/library/alpine:3.18
 
 # All builds should be done using the platform native to the build node to allow
 #  cache sharing of the go mod download step.

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ $(BINARY):
 	CGO_ENABLED=0 $(GO) build -a -installsuffix cgo -ldflags="-X main.VERSION=${VERSION}" -o $@ github.com/oauth2-proxy/oauth2-proxy/v7
 
 DOCKER_BUILD_PLATFORM         ?= linux/amd64,linux/arm64,linux/ppc64le,linux/arm/v6,linux/arm/v7
-DOCKER_BUILD_RUNTIME_IMAGE    ?= alpine:3.17.2
+DOCKER_BUILD_RUNTIME_IMAGE    ?= alpine:3.18
 DOCKER_BUILDX_ARGS            ?= --build-arg RUNTIME_IMAGE=${DOCKER_BUILD_RUNTIME_IMAGE}
 DOCKER_BUILDX                 := docker buildx build ${DOCKER_BUILDX_ARGS} --build-arg VERSION=${VERSION}
 DOCKER_BUILDX_X_PLATFORM      := $(DOCKER_BUILDX) --platform ${DOCKER_BUILD_PLATFORM}


### PR DESCRIPTION
## Description

Update to [Alpine 3.18](https://www.alpinelinux.org/releases/) with support until 2025-05-09. 

Only pinning minor version of alpine to automatically receive patches. This is the same approach as before [PR #2013 ](https://github.com/oauth2-proxy/oauth2-proxy/pull/2013/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557).

With this approach at least on the date of a new release the produced image is as up to date as possible.

## Motivation and Context

The release 7.5.0 used the alpine version 3.17.2 instead of 3.17.5 and thus the freshly released container unfortunately still includes CVEs. They are also shown here: https://quay.io/repository/oauth2-proxy/oauth2-proxy?tab=tags

As of today with Trivy:
```
quay.io/oauth2-proxy/oauth2-proxy:v7.5.0 (alpine 3.17.2)
Total: 16 (UNKNOWN: 0, LOW: 0, MEDIUM: 14, HIGH: 2, CRITICAL: 0)
```
Namely in ``libcrypto3`` and ``libssl3`` from the alpine base image.

This also addresses the remaining issues from: https://github.com/oauth2-proxy/oauth2-proxy/issues/2203
The release of 7.5.0 addressed all the other issues, thus a release with this alpine base image would actually result in a container without any current CVEs. 

Fixes https://github.com/oauth2-proxy/oauth2-proxy/issues/2203

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
