### PR TITLE
Fixed name for GoogleGroups env variable + unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## Breaking Changes
 
 ## Changes since v7.5.0
+- [#2221](https://github.com/oauth2-proxy/oauth2-proxy/pull/2221) Backwards compatible fix for wrong environment variable name (OAUTH2_PROXY_GOOGLE_GROUPS) (@kvanzuijlen)
 
 # V7.5.0
 

--- a/pkg/apis/options/legacy_options.go
+++ b/pkg/apis/options/legacy_options.go
@@ -3,6 +3,7 @@ package options
 import (
 	"fmt"
 	"net/url"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -494,7 +495,8 @@ type LegacyProvider struct {
 	GitHubUsers                            []string `flag:"github-user" cfg:"github_users"`
 	GitLabGroup                            []string `flag:"gitlab-group" cfg:"gitlab_groups"`
 	GitLabProjects                         []string `flag:"gitlab-project" cfg:"gitlab_projects"`
-	GoogleGroups                           []string `flag:"google-group" cfg:"google_group"`
+	GoogleGroupsLegacy                     []string `flag:"google-group" cfg:"google_group"`
+	GoogleGroups                           []string `flag:"google-group" cfg:"google_groups"`
 	GoogleAdminEmail                       string   `flag:"google-admin-email" cfg:"google_admin_email"`
 	GoogleServiceAccountJSON               string   `flag:"google-service-account-json" cfg:"google_service_account_json"`
 	GoogleUseApplicationDefaultCredentials bool     `flag:"google-use-application-default-credentials" cfg:"google_use_application_default_credentials"`
@@ -727,6 +729,13 @@ func (l *LegacyProvider) convert() (Providers, error) {
 			Repository: l.BitbucketRepository,
 		}
 	case "google":
+		if len(l.GoogleGroupsLegacy) != 0 && !reflect.DeepEqual(l.GoogleGroupsLegacy, l.GoogleGroups) {
+			// Log the deprecation notice
+			logger.Error(
+				"WARNING: The 'OAUTH2_PROXY_GOOGLE_GROUP' environment variable is deprecated and will likely be removed in the next major release. Use 'OAUTH2_PROXY_GOOGLE_GROUPS' instead.",
+			)
+			l.GoogleGroups = l.GoogleGroupsLegacy
+		}
 		provider.GoogleConfig = GoogleOptions{
 			Groups:                           l.GoogleGroups,
 			AdminEmail:                       l.GoogleAdminEmail,

--- a/pkg/apis/options/legacy_options_test.go
+++ b/pkg/apis/options/legacy_options_test.go
@@ -991,6 +991,14 @@ var _ = Describe("Legacy Options", func() {
 			GoogleServiceAccountJSON: "test.json",
 			GoogleGroups:             []string{"1", "2"},
 		}
+
+		legacyConfigLegacyProvider := LegacyProvider{
+			ClientID:                 clientID,
+			ProviderType:             "google",
+			GoogleAdminEmail:         "email@email.com",
+			GoogleServiceAccountJSON: "test.json",
+			GoogleGroupsLegacy:       []string{"1", "2"},
+		}
 		DescribeTable("convertLegacyProviders",
 			func(in *convertProvidersTableInput) {
 				providers, err := in.legacyProvider.convert()
@@ -1021,6 +1029,11 @@ var _ = Describe("Legacy Options", func() {
 			}),
 			Entry("with internal provider config", &convertProvidersTableInput{
 				legacyProvider:    internalConfigLegacyProvider,
+				expectedProviders: Providers{internalConfigProvider},
+				errMsg:            "",
+			}),
+			Entry("with legacy provider config", &convertProvidersTableInput{
+				legacyProvider:    legacyConfigLegacyProvider,
 				expectedProviders: Providers{internalConfigProvider},
 				errMsg:            "",
 			}),

--- a/pkg/apis/options/load.go
+++ b/pkg/apis/options/load.go
@@ -43,8 +43,8 @@ func Load(configFileName string, flagSet *pflag.FlagSet, into interface{}) error
 		return fmt.Errorf("unable to register flags: %w", err)
 	}
 
-	// UnmarhsalExact will return an error if the config includes options that are
-	// not mapped to felds of the into struct
+	// UnmarshalExact will return an error if the config includes options that are
+	// not mapped to fields of the into struct
 	err = v.UnmarshalExact(into, decodeFromCfgTag)
 	if err != nil {
 		return fmt.Errorf("error unmarshalling config: %w", err)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes the name of the GoogleGroups env variable (from OAUTH2_PROXY_GOOGLE_GROUP to OAUTH2_PROXY_GOOGLE_GROUPS)
<!--- Describe your changes in detail -->

## Motivation and Context
Closes #2201
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Ran the application using the debugger with all 3 settings (--google-group, OAUTH2_PROXY_GOOGLE_GROUP, and OAUTH2_PROXY_GOOGLE_GROUPS), as well as added tests to proof reading the old env variable still results in the same outcome
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
