### PR TITLE
Fix oidc-issuer-url in example

### DIFF
--- a/docs/docs/configuration/auth.md
+++ b/docs/docs/configuration/auth.md
@@ -237,7 +237,7 @@ you should define the 'keycloak-group' value to /admin.
     --client-id=<your client's id>
     --client-secret=<your client's secret>
     --redirect-url=https://internal.yourcompany.com/oauth2/callback
-    --oidc-issuer-url=https://<keycloak host>/auth/realms/<your realm>
+    --oidc-issuer-url=https://<keycloak host>/realms/<your realm> // For Keycloak versions <17: --oidc-issuer-url=https://<keycloak host>/auth/realms/<your realm>
     --email-domain=<yourcompany.com> // Validate email domain for users, see option documentation
     --allowed-role=<realm role name> // Optional, required realm role
     --allowed-role=<client id>:<client role name> // Optional, required client role

--- a/docs/versioned_docs/version-7.5.x/configuration/auth.md
+++ b/docs/versioned_docs/version-7.5.x/configuration/auth.md
@@ -218,7 +218,7 @@ you should define the 'keycloak-group' value to /admin.
     --client-id=<your client's id>
     --client-secret=<your client's secret>
     --redirect-url=https://internal.yourcompany.com/oauth2/callback
-    --oidc-issuer-url=https://<keycloak host>/auth/realms/<your realm>
+    --oidc-issuer-url=https://<keycloak host>/realms/<your realm> // For Keycloak versions <17: --oidc-issuer-url=https://<keycloak host>/auth/realms/<your realm>
     --email-domain=<yourcompany.com> // Validate email domain for users, see option documentation
     --allowed-role=<realm role name> // Optional, required realm role
     --allowed-role=<client id>:<client role name> // Optional, required client role


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Updated oidc-issuer-url in example

## Motivation and Context
Current example is broken, `/auth/` part from URL was dropped with the move to Quarkus in Keycloak 17 (see https://www.keycloak.org/migration/migrating-to-quarkus)

## How Has This Been Tested?

Tested by myself (see https://github.com/oauth2-proxy/oauth2-proxy/pull/1758#issuecomment-1577307476)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
