### PR TITLE
Support http.AllowQuerySemicolons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 ## Breaking Changes
 
 ## Changes since v7.5.1
-
 - [#2128](https://github.com/oauth2-proxy/oauth2-proxy/pull/2128) Update dependencies (@vllvll)
 - [#2269](https://github.com/oauth2-proxy/oauth2-proxy/pull/2269) Added Azure China (and other air gaped cloud) support (@mblaschke)
 - [#2237](https://github.com/oauth2-proxy/oauth2-proxy/pull/2237) adds an option to append CA certificates (@emsixteeen)
@@ -19,6 +18,7 @@
 - [#1866](https://github.com/oauth2-proxy/oauth2-proxy/pull/1866) Add support for unix socker as upstream (@babs)
 - [#1949](https://github.com/oauth2-proxy/oauth2-proxy/pull/1949) Allow cookie names with dots in redis sessions (@miguelborges99)
 - [#2297](https://github.com/oauth2-proxy/oauth2-proxy/pull/2297) Add nightly build and push (@tuunit)
+- [#2248](https://github.com/oauth2-proxy/oauth2-proxy/pull/2248) Added support for semicolons in query strings.
 
 # V7.5.1
 
@@ -89,7 +89,6 @@ N/A
 
 ## Release Highlights
 
-- Added support for semicolons in query strings.
 - New Azure groups support for Azure OAuth2 v2.0
 - Option to configure API routes - paths that will not redirect to login when unauthenticated
 - CSRF and session cookies now have different timeouts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ N/A
 
 ## Release Highlights
 
+- Added support for semicolons in query strings.
 - New Azure groups support for Azure OAuth2 v2.0
 - Option to configure API routes - paths that will not redirect to login when unauthenticated
 - CSRF and session cookies now have different timeouts

--- a/docs/docs/configuration/overview.md
+++ b/docs/docs/configuration/overview.md
@@ -67,6 +67,7 @@ An example [oauth2-proxy.cfg](https://github.com/oauth2-proxy/oauth2-proxy/blob/
 | Option | Type | Description | Default |
 | ------ | ---- | ----------- | ------- |
 | `--acr-values` | string | optional, see [docs](https://openid.net/specs/openid-connect-eap-acr-values-1_0.html#acrValues) | `""` |
+| `--allow-query-semicolons` | bool | allow the use of semicolons in query args ([required for some legacy applications](https://github.com/golang/go/issues/25192)) | `false` |
 | `--api-route` | string \| list | return HTTP 401 instead of redirecting to authentication server if token is not valid. Format: path_regex | |
 | `--approval-prompt` | string | OAuth approval_prompt | `"force"` |
 | `--auth-logging` | bool | Log authentication attempts | true |

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -83,22 +83,23 @@ type OAuthProxy struct {
 
 	SignInPath string
 
-	allowedRoutes       []allowedRoute
-	apiRoutes           []apiRoute
-	redirectURL         *url.URL // the url to receive requests at
+	allowedRoutes        []allowedRoute
+	apiRoutes            []apiRoute
+	redirectURL          *url.URL // the url to receive requests at
 	relativeRedirectURL bool
-	whitelistDomains    []string
-	provider            providers.Provider
-	sessionStore        sessionsapi.SessionStore
-	ProxyPrefix         string
-	basicAuthValidator  basic.Validator
-	basicAuthGroups     []string
-	SkipProviderButton  bool
-	skipAuthPreflight   bool
-	skipJwtBearerTokens bool
-	forceJSONErrors     bool
-	realClientIPParser  ipapi.RealClientIPParser
-	trustedIPs          *ip.NetSet
+	whitelistDomains     []string
+	provider             providers.Provider
+	sessionStore         sessionsapi.SessionStore
+	ProxyPrefix          string
+	basicAuthValidator   basic.Validator
+	basicAuthGroups      []string
+	SkipProviderButton   bool
+	skipAuthPreflight    bool
+	skipJwtBearerTokens  bool
+	forceJSONErrors      bool
+	allowQuerySemicolons bool
+	realClientIPParser   ipapi.RealClientIPParser
+	trustedIPs           *ip.NetSet
 
 	sessionChain      alice.Chain
 	headersChain      alice.Chain
@@ -213,20 +214,21 @@ func NewOAuthProxy(opts *options.Options, validator func(string) bool) (*OAuthPr
 
 		SignInPath: fmt.Sprintf("%s/sign_in", opts.ProxyPrefix),
 
-		ProxyPrefix:         opts.ProxyPrefix,
-		provider:            provider,
-		sessionStore:        sessionStore,
-		redirectURL:         redirectURL,
+		ProxyPrefix:          opts.ProxyPrefix,
+		provider:             provider,
+		sessionStore:         sessionStore,
+		redirectURL:          redirectURL,
 		relativeRedirectURL: opts.RelativeRedirectURL,
-		apiRoutes:           apiRoutes,
-		allowedRoutes:       allowedRoutes,
-		whitelistDomains:    opts.WhitelistDomains,
-		skipAuthPreflight:   opts.SkipAuthPreflight,
-		skipJwtBearerTokens: opts.SkipJwtBearerTokens,
-		realClientIPParser:  opts.GetRealClientIPParser(),
-		SkipProviderButton:  opts.SkipProviderButton,
-		forceJSONErrors:     opts.ForceJSONErrors,
-		trustedIPs:          trustedIPs,
+		apiRoutes:            apiRoutes,
+		allowedRoutes:        allowedRoutes,
+		whitelistDomains:     opts.WhitelistDomains,
+		skipAuthPreflight:    opts.SkipAuthPreflight,
+		skipJwtBearerTokens:  opts.SkipJwtBearerTokens,
+		realClientIPParser:   opts.GetRealClientIPParser(),
+		SkipProviderButton:   opts.SkipProviderButton,
+		forceJSONErrors:      opts.ForceJSONErrors,
+		allowQuerySemicolons: opts.AllowQuerySemicolons,
+		trustedIPs:           trustedIPs,
 
 		basicAuthValidator: basicAuthValidator,
 		basicAuthGroups:    opts.HtpasswdUserGroups,
@@ -273,6 +275,11 @@ func (p *OAuthProxy) setupServer(opts *options.Options) error {
 		BindAddress:       opts.Server.BindAddress,
 		SecureBindAddress: opts.Server.SecureBindAddress,
 		TLS:               opts.Server.TLS,
+	}
+
+	// Option: AllowQuerySemicolons
+	if opts.AllowQuerySemicolons {
+		serverOpts.Handler = http.AllowQuerySemicolons(p)
 	}
 
 	appServer, err := proxyhttp.NewServer(serverOpts)

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -86,7 +86,7 @@ type OAuthProxy struct {
 	allowedRoutes        []allowedRoute
 	apiRoutes            []apiRoute
 	redirectURL          *url.URL // the url to receive requests at
-	relativeRedirectURL bool
+	relativeRedirectURL  bool
 	whitelistDomains     []string
 	provider             providers.Provider
 	sessionStore         sessionsapi.SessionStore
@@ -218,7 +218,7 @@ func NewOAuthProxy(opts *options.Options, validator func(string) bool) (*OAuthPr
 		provider:             provider,
 		sessionStore:         sessionStore,
 		redirectURL:          redirectURL,
-		relativeRedirectURL: opts.RelativeRedirectURL,
+		relativeRedirectURL:  opts.RelativeRedirectURL,
 		apiRoutes:            apiRoutes,
 		allowedRoutes:        allowedRoutes,
 		whitelistDomains:     opts.WhitelistDomains,

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -279,7 +279,7 @@ func (p *OAuthProxy) setupServer(opts *options.Options) error {
 
 	// Option: AllowQuerySemicolons
 	if opts.AllowQuerySemicolons {
-		serverOpts.Handler = http.AllowQuerySemicolons(p)
+		serverOpts.Handler = http.AllowQuerySemicolons(serverOpts.Handler)
 	}
 
 	appServer, err := proxyhttp.NewServer(serverOpts)

--- a/pkg/apis/options/options.go
+++ b/pkg/apis/options/options.go
@@ -61,6 +61,7 @@ type Options struct {
 	SSLInsecureSkipVerify bool     `flag:"ssl-insecure-skip-verify" cfg:"ssl_insecure_skip_verify"`
 	SkipAuthPreflight     bool     `flag:"skip-auth-preflight" cfg:"skip_auth_preflight"`
 	ForceJSONErrors       bool     `flag:"force-json-errors" cfg:"force_json_errors"`
+	AllowQuerySemicolons  bool     `flag:"allow-query-semicolons" cfg:"allow_query_semicolons"`
 
 	SignatureKey    string `flag:"signature-key" cfg:"signature_key"`
 	GCPHealthChecks bool   `flag:"gcp-healthchecks" cfg:"gcp_healthchecks"`
@@ -127,6 +128,7 @@ func NewFlagSet() *pflag.FlagSet {
 	flagSet.Bool("ssl-insecure-skip-verify", false, "skip validation of certificates presented when using HTTPS providers")
 	flagSet.Bool("skip-jwt-bearer-tokens", false, "will skip requests that have verified JWT bearer tokens (default false)")
 	flagSet.Bool("force-json-errors", false, "will force JSON errors instead of HTTP error pages or redirects")
+	flagSet.Bool("allow-query-semicolons", false, "allow the use of semicolons in query args")
 	flagSet.StringSlice("extra-jwt-issuers", []string{}, "if skip-jwt-bearer-tokens is set, a list of extra JWT issuer=audience pairs (where the issuer URL has a .well-known/openid-configuration or a .well-known/jwks.json)")
 
 	flagSet.StringSlice("email-domain", []string{}, "authenticate emails with the specified domain (may be given multiple times). Use * to authenticate any email")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Provide support for using semicolons in query strings. This adds a new bool flag --allow-query-semicolons.

Current behavior causes issues with software that uses `;` as a query parameter separator. [golang.org/issue/25192](https://github.com/golang/go/issues/25192) (and some other places online) believe that this is a security issue as proxies and the backend software treat the `;` differently, which can cause strange behaviour or security issues. For this reason, we should only be enabling https://pkg.go.dev/net/http#AllowQuerySemicolons when the backend software requires `;` as a query separator, hence why this should be a flag and not enabled by default.

(Continuation of #2076)

## Motivation and Context

See Issue https://github.com/oauth2-proxy/oauth2-proxy/issues/1841

## How Has This Been Tested?

Tested against OTRS (Znuny), a perl system that still uses `;` as an argument separator.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My change requires a change to the documentation or CHANGELOG.
- [X] I have updated the documentation/CHANGELOG accordingly.
- [X] I have created a feature (non-master) branch for my PR.
