### PR TITLE
update error middleware definition (for traefik)

### DIFF
--- a/docs/docs/configuration/overview.md
+++ b/docs/docs/configuration/overview.md
@@ -499,7 +499,7 @@ http:
         status:
           - "401-403"
         service: oauth-backend
-        query: "/oauth2/sign_in"
+        query: "/oauth2/sign_in?rd={url}"
 ```
 
 ### ForwardAuth with static upstreams configuration

--- a/docs/versioned_docs/version-7.5.x/configuration/overview.md
+++ b/docs/versioned_docs/version-7.5.x/configuration/overview.md
@@ -499,7 +499,7 @@ http:
         status:
           - "401-403"
         service: oauth-backend
-        query: "/oauth2/sign_in"
+        query: "/oauth2/sign_in?rd={url}"
 ```
 
 ### ForwardAuth with static upstreams configuration


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

After setting up oauth2-proxy + services as per https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/overview#forwardauth-with-401-errors-middleware the post-signin redirects did not include PATH nor GET parameters.

They did however include anchor data but because it is added via JavaScript

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

There are several issues open related to this topic (maybe OPs had different root cause) but none of them resulted in any PR (to code or documentation). And the comments in any I found helped me.

I went ahead and looked at the code to see how `rd` is rendered in the template and understand why it's always `/`

* https://github.com/oauth2-proxy/oauth2-proxy/blob/master/oauthproxy.go#L536
* https://github.com/oauth2-proxy/oauth2-proxy/blob/master/pkg/app/redirect/director.go#L61-L65

So it looks for a `rd` parameter (in original request, not the rendered one) and 3 different headers.
I fire up tcpdump in the oauth2-proxy container and I see that `/oauth2/auth` (the ForwardAuth middleware address) does receive `X-Forwarded-Uri` but then, looking at `/oauth2/sign_in` request that follows, it does **not** get the header.

Checking traefik docs for the [error middleware](https://doc.traefik.io/traefik/middlewares/http/errorpages/#query) shows there's no option to add headers (like in ForwardAuth), but there is however a template variable `url` that can be used in the `query` parameter.

So I added `?rd={url}` to my compose file and there it was, working perfectly.

I thought it'd be worth sharing in the docs.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
