### PR TITLE
Improve the Nginx `auth_request` example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [#2237](https://github.com/oauth2-proxy/oauth2-proxy/pull/2237) adds an option to append CA certificates (@emsixteeen)
 - [#2128](https://github.com/oauth2-proxy/oauth2-proxy/pull/2128) Update dependencies (@vllvll)
 - [#2274](https://github.com/oauth2-proxy/oauth2-proxy/pull/2274) Upgrade golang.org/x/net to v0.17.0 (@pierluigilenoci)
+- [#2278](https://github.com/oauth2-proxy/oauth2-proxy/pull/2278) Improve the Nginx auth_request example (@akunzai)
 - [#2282](https://github.com/oauth2-proxy/oauth2-proxy/pull/2282) Fixed checking Google Groups membership using Google Application Credentials (@kvanzuijlen)
 - [#2183](https://github.com/oauth2-proxy/oauth2-proxy/pull/2183) Allowing relative redirect url though an option
 - [#1866](https://github.com/oauth2-proxy/oauth2-proxy/pull/1866) Add support for unix socker as upstream (@babs)

--- a/contrib/local-environment/docker-compose-nginx.yaml
+++ b/contrib/local-environment/docker-compose-nginx.yaml
@@ -31,6 +31,7 @@ services:
   nginx:
     container_name: nginx
     image: nginx:1.18
+    restart: unless-stopped
     ports:
       - 80:80/tcp
     hostname: nginx

--- a/contrib/local-environment/nginx.conf
+++ b/contrib/local-environment/nginx.conf
@@ -38,6 +38,7 @@ server {
     # Make sure the OAuth2 Proxy knows where the original request came from.
     proxy_set_header Host       $host;
     proxy_set_header X-Real-IP  $remote_addr;
+    proxy_set_header X-Forwarded-Uri $request_uri;
 
     proxy_pass http://oauth2-proxy:4180/;
   }
@@ -78,6 +79,7 @@ server {
     # Make sure the OAuth2 Proxy knows where the original request came from.
     proxy_set_header Host       $host;
     proxy_set_header X-Real-IP  $remote_addr;
+    proxy_set_header X-Forwarded-Uri $request_uri;
 
     proxy_pass http://oauth2-proxy:4180/;
   }

--- a/contrib/local-environment/oauth2-proxy-nginx.cfg
+++ b/contrib/local-environment/oauth2-proxy-nginx.cfg
@@ -10,3 +10,5 @@ cookie_secure="false"
 redirect_url="http://oauth2-proxy.oauth2-proxy.localhost/oauth2/callback"
 cookie_domains=".oauth2-proxy.localhost" # Required so cookie can be read on all subdomains.
 whitelist_domains=".oauth2-proxy.localhost" # Required to allow redirection back to original requested target.
+# Enables the use of `X-Forwarded-*` headers to determine request correctly
+reverse_proxy="true"

--- a/docs/docs/configuration/overview.md
+++ b/docs/docs/configuration/overview.md
@@ -361,6 +361,7 @@ server {
     proxy_set_header Host             $host;
     proxy_set_header X-Real-IP        $remote_addr;
     proxy_set_header X-Scheme         $scheme;
+    proxy_set_header X-Forwarded-Uri  $request_uri;
     # nginx auth_request includes headers but not body
     proxy_set_header Content-Length   "";
     proxy_pass_request_body           off;

--- a/docs/docs/configuration/overview.md
+++ b/docs/docs/configuration/overview.md
@@ -353,7 +353,6 @@ server {
     proxy_pass       http://127.0.0.1:4180;
     proxy_set_header Host                    $host;
     proxy_set_header X-Real-IP               $remote_addr;
-    proxy_set_header X-Scheme                $scheme;
     proxy_set_header X-Auth-Request-Redirect $request_uri;
     # or, if you are handling multiple domains:
     # proxy_set_header X-Auth-Request-Redirect $scheme://$host$request_uri;
@@ -362,7 +361,6 @@ server {
     proxy_pass       http://127.0.0.1:4180;
     proxy_set_header Host             $host;
     proxy_set_header X-Real-IP        $remote_addr;
-    proxy_set_header X-Scheme         $scheme;
     proxy_set_header X-Forwarded-Uri  $request_uri;
     # nginx auth_request includes headers but not body
     proxy_set_header Content-Length   "";

--- a/docs/docs/configuration/overview.md
+++ b/docs/docs/configuration/overview.md
@@ -339,6 +339,8 @@ Available variables for standard logging:
 
 ## Configuring for use with the Nginx `auth_request` directive
 
+**This option requires `--reverse-proxy` option to be set.**
+
 The [Nginx `auth_request` directive](http://nginx.org/en/docs/http/ngx_http_auth_request_module.html) allows Nginx to authenticate requests via the oauth2-proxy's `/auth` endpoint, which only returns a 202 Accepted response or a 401 Unauthorized response without proxying the request through. For example:
 
 ```nginx

--- a/docs/docs/configuration/tls.md
+++ b/docs/docs/configuration/tls.md
@@ -63,7 +63,6 @@ There are two recommended configurations:
             proxy_pass http://127.0.0.1:4180;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Scheme $scheme;
             proxy_connect_timeout 1;
             proxy_send_timeout 30;
             proxy_read_timeout 30;

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -2714,7 +2714,7 @@ func TestAllowedRequestWithForwardedUriHeader(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			req, err := http.NewRequest(tc.method, opts.ProxyPrefix+"/auth", nil)
+			req, err := http.NewRequest(tc.method, opts.ProxyPrefix+authOnlyPath, nil)
 			req.Header.Set("X-Forwarded-Uri", tc.url)
 			assert.NoError(t, err)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

- Fix the `skip_auth_routes` option not working in Nginx

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #2277

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Add tests for allowed requests with proxied `X-Forwarded-Uri` header

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
