### PR TITLE
Updated linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,19 +3,15 @@ run:
 linters:
   enable:
     - govet
-    - golint
     - ineffassign
     - goconst
-    - deadcode
     - gofmt
     - goimports
     - gosec
     - gosimple
     - staticcheck
-    - structcheck
     - typecheck
     - unused
-    - varcheck
     - bodyclose
     - dogsled
     - goprintffuncname
@@ -25,6 +21,7 @@ linters:
     - stylecheck
     - unconvert
     - gocritic
+    - revive
   disable-all: true
 issues:
   exclude-rules:
@@ -38,6 +35,6 @@ issues:
     # If we have tests in shared test folders, these can be less strictly linted
     - path: tests/.*_tests\.go
       linters:
-        - golint
+        - revive
         - bodyclose
         - stylecheck

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -448,9 +448,8 @@ func (patTest *PassAccessTokenTest) getEndpointWithCookie(cookie string, endpoin
 		value = strings.TrimPrefix(field, keyPrefix)
 		if value != field {
 			break
-		} else {
-			value = ""
 		}
+		value = ""
 	}
 	if value == "" {
 		return 0, ""
@@ -612,7 +611,7 @@ func (sipTest *SignInPageTest) GetEndpoint(endpoint string) (int, string) {
 type AlwaysSuccessfulValidator struct {
 }
 
-func (AlwaysSuccessfulValidator) Validate(user, password string) bool {
+func (AlwaysSuccessfulValidator) Validate(_, _ string) bool {
 	return true
 }
 

--- a/pkg/apis/sessions/lock.go
+++ b/pkg/apis/sessions/lock.go
@@ -7,18 +7,18 @@ import (
 
 type NoOpLock struct{}
 
-func (l *NoOpLock) Obtain(ctx context.Context, expiration time.Duration) error {
+func (l *NoOpLock) Obtain(_ context.Context, _ time.Duration) error {
 	return nil
 }
 
-func (l *NoOpLock) Peek(ctx context.Context) (bool, error) {
+func (l *NoOpLock) Peek(_ context.Context) (bool, error) {
 	return false, nil
 }
 
-func (l *NoOpLock) Refresh(ctx context.Context, expiration time.Duration) error {
+func (l *NoOpLock) Refresh(_ context.Context, _ time.Duration) error {
 	return nil
 }
 
-func (l *NoOpLock) Release(ctx context.Context) error {
+func (l *NoOpLock) Release(_ context.Context) error {
 	return nil
 }

--- a/pkg/providers/oidc/verifier_test.go
+++ b/pkg/providers/oidc/verifier_test.go
@@ -199,7 +199,7 @@ type testVerifier struct {
 	jwk jose.JSONWebKey
 }
 
-func (t *testVerifier) VerifySignature(ctx context.Context, jwt string) ([]byte, error) {
+func (t *testVerifier) VerifySignature(_ context.Context, jwt string) ([]byte, error) {
 	jws, err := jose.ParseSigned(jwt)
 	if err != nil {
 		return nil, fmt.Errorf("oidc: malformed jwt: %v", err)

--- a/pkg/sessions/tests/mock_lock.go
+++ b/pkg/sessions/tests/mock_lock.go
@@ -12,19 +12,19 @@ type MockLock struct {
 	elapsed    time.Duration
 }
 
-func (l *MockLock) Obtain(ctx context.Context, expiration time.Duration) error {
+func (l *MockLock) Obtain(_ context.Context, expiration time.Duration) error {
 	l.expiration = expiration
 	return nil
 }
 
-func (l *MockLock) Peek(ctx context.Context) (bool, error) {
+func (l *MockLock) Peek(_ context.Context) (bool, error) {
 	if l.elapsed < l.expiration {
 		return true, nil
 	}
 	return false, nil
 }
 
-func (l *MockLock) Refresh(ctx context.Context, expiration time.Duration) error {
+func (l *MockLock) Refresh(_ context.Context, expiration time.Duration) error {
 	if l.expiration <= l.elapsed {
 		return sessions.ErrNotLocked
 	}
@@ -33,7 +33,7 @@ func (l *MockLock) Refresh(ctx context.Context, expiration time.Duration) error 
 	return nil
 }
 
-func (l *MockLock) Release(ctx context.Context) error {
+func (l *MockLock) Release(_ context.Context) error {
 	if l.expiration <= l.elapsed {
 		return sessions.ErrNotLocked
 	}

--- a/pkg/validation/header.go
+++ b/pkg/validation/header.go
@@ -38,7 +38,7 @@ func validateHeader(header options.Header, names map[string]struct{}) []string {
 	return msgs
 }
 
-func validateHeaderValue(name string, value options.HeaderValue) []string {
+func validateHeaderValue(_ string, value options.HeaderValue) []string {
 	switch {
 	case value.SecretSource != nil && value.ClaimSource == nil:
 		return []string{validateSecretSource(*value.SecretSource)}

--- a/providers/adfs.go
+++ b/providers/adfs.go
@@ -93,7 +93,7 @@ func (p *ADFSProvider) RefreshSession(ctx context.Context, s *sessions.SessionSt
 	return refreshed, err
 }
 
-func (p *ADFSProvider) fallbackUPN(ctx context.Context, s *sessions.SessionState) error {
+func (p *ADFSProvider) fallbackUPN(_ context.Context, s *sessions.SessionState) error {
 	claims, err := p.getClaimExtractor(s.IDToken, s.AccessToken)
 	if err != nil {
 		return fmt.Errorf("could not extract claims: %v", err)

--- a/providers/internal_util_test.go
+++ b/providers/internal_util_test.go
@@ -26,13 +26,13 @@ type ValidateSessionTestProvider struct {
 
 var _ Provider = (*ValidateSessionTestProvider)(nil)
 
-func (tp *ValidateSessionTestProvider) GetEmailAddress(ctx context.Context, s *sessions.SessionState) (string, error) {
+func (tp *ValidateSessionTestProvider) GetEmailAddress(_ context.Context, _ *sessions.SessionState) (string, error) {
 	return "", errors.New("not implemented")
 }
 
 // Note that we're testing the internal validateToken() used to implement
 // several Provider's ValidateSession() implementations
-func (tp *ValidateSessionTestProvider) ValidateSession(ctx context.Context, s *sessions.SessionState) bool {
+func (tp *ValidateSessionTestProvider) ValidateSession(_ context.Context, _ *sessions.SessionState) bool {
 	return false
 }
 

--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -93,7 +93,7 @@ func (p *OIDCProvider) Redeem(ctx context.Context, redirectURL, code, codeVerifi
 
 // EnrichSession is called after Redeem to allow providers to enrich session fields
 // such as User, Email, Groups with provider specific API calls.
-func (p *OIDCProvider) EnrichSession(ctx context.Context, s *sessions.SessionState) error {
+func (p *OIDCProvider) EnrichSession(_ context.Context, s *sessions.SessionState) error {
 	// If a mandatory email wasn't set, error at this point.
 	if s.Email == "" {
 		return errors.New("neither the id_token nor the profileURL set an email")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Updated the linters as `golint` was deprecated and replaced by `revive` and `deadcode`, `structcheck`, and `varcheck` were deprecated and replaced by `unused`. `revive` had some additional feedback which I also applied.
<!--- Describe your changes in detail -->

## Motivation and Context
Everytime `make lint` ran, the output showed that some linters were deprecated. By updating the linters we can make sure that the code stays clean.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Ran make lint until it no longer exited with error code 1.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
