### PR TITLE
fix: websocket path rewrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#2800](https://github.com/oauth2-proxy/oauth2-proxy/pull/2800) Add some opencontainer labels to docker image (@halkeye)
 - [#2755](https://github.com/oauth2-proxy/oauth2-proxy/pull/2755) feat: add X-Envoy-External-Address as supported header (@bjencks)
 - [#1985](https://github.com/oauth2-proxy/oauth2-proxy/pull/1985) Add support for systemd socket (@isodude)
+- [#2300](https://github.com/oauth2-proxy/oauth2-proxy/pull/2300) Add fix for websocket path rewrite (@rekup)
 
 # V7.7.1
 
@@ -58,7 +59,6 @@
 - [#2589](https://github.com/oauth2-proxy/oauth2-proxy/pull/2589) Added support for regex path matching and rewriting when using a static `file:` upstream (@ianroberts)
 - [#2790](https://github.com/oauth2-proxy/oauth2-proxy/pull/2790) chore(deps): update all golang dependencies (@tuunit)
 - [#2607](https://github.com/oauth2-proxy/oauth2-proxy/pull/2607) fix(csrf): fix possible infinite loop (@Primexz)
-
 
 # V7.6.0
 

--- a/pkg/upstream/proxy_test.go
+++ b/pkg/upstream/proxy_test.go
@@ -253,7 +253,7 @@ var _ = Describe("Proxy Suite", func() {
 						URL:    "http://example.localhost/different/backend/path/1234",
 						Header: map[string][]string{
 							"Gap-Auth":      {""},
-							"Gap-Signature": {"sha256 jeAeM7wHSj2ab/l9YPvtTJ9l/8q1tpY2V/iwXF48bgw="},
+							"Gap-Signature": {"sha256 Pzy0fSFhzbhY0R9rj8vl5LCiIQaKVB0s6h9BADgIT4I="},
 						},
 						Body:       []byte{},
 						Host:       "example.localhost",
@@ -274,7 +274,7 @@ var _ = Describe("Proxy Suite", func() {
 						URL:    "http://example.localhost/different/backend/path/1234/abc",
 						Header: map[string][]string{
 							"Gap-Auth":      {""},
-							"Gap-Signature": {"sha256 rAkAc9gp7EndoOppJuvbuPnYuBcqrTkBnQx6iPS8xTA="},
+							"Gap-Signature": {"sha256 uqIAxSgz+onqHDMMl/EAZWbwSw56PzM90iCocNUEqmw="},
 						},
 						Body:       []byte{},
 						Host:       "example.localhost",
@@ -324,7 +324,7 @@ var _ = Describe("Proxy Suite", func() {
 						URL:    "http://example.localhost/double-match/rewrite/foo",
 						Header: map[string][]string{
 							"Gap-Auth":      {""},
-							"Gap-Signature": {"sha256 eYyUNdsrTmnvFpavpP8AdHGUGzqJ39QEjqn0/3fQPHA="},
+							"Gap-Signature": {"sha256 Ii7wKYBkRkJH556gRUsVUwGPgF7IG7V7X4vhkiyzfQ0="},
 						},
 						Body:       []byte{},
 						Host:       "example.localhost",

--- a/pkg/upstream/rewrite.go
+++ b/pkg/upstream/rewrite.go
@@ -50,6 +50,7 @@ func rewritePath(rewriteRegExp *regexp.Regexp, rewriteTarget string, writer page
 		}
 
 		req.RequestURI = reqURL.String()
+		req.URL.Path = reqURL.String() // set path for websocket connections
 		next.ServeHTTP(rw, req)
 	})
 }

--- a/pkg/upstream/rewrite.go
+++ b/pkg/upstream/rewrite.go
@@ -50,7 +50,7 @@ func rewritePath(rewriteRegExp *regexp.Regexp, rewriteTarget string, writer page
 		}
 
 		req.RequestURI = reqURL.String()
-		req.URL.Path = reqURL.String() // set path for websocket connections
+		req.URL.Path = reqURL.Path // set path for websocket connections
 		next.ServeHTTP(rw, req)
 	})
 }

--- a/pkg/upstream/rewrite_test.go
+++ b/pkg/upstream/rewrite_test.go
@@ -16,6 +16,7 @@ var _ = Describe("Rewrite", func() {
 		rewriteTarget      string
 		requestTarget      string
 		expectedRequestURI string
+		expectedURLPath    string
 	}
 
 	DescribeTable("should rewrite the request path",
@@ -24,36 +25,43 @@ var _ = Describe("Rewrite", func() {
 			rw := httptest.NewRecorder()
 
 			var gotRequestURI string
+			var gotRequestURLPath string
 			handler := newRewritePath(in.rewriteRegex, in.rewriteTarget, &pagewriter.WriterFuncs{})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				gotRequestURI = r.RequestURI
+				gotRequestURLPath = r.URL.Path
 			}))
 			handler.ServeHTTP(rw, req)
 
 			Expect(gotRequestURI).To(Equal(in.expectedRequestURI))
+			Expect(gotRequestURLPath).To(Equal(in.expectedURLPath))
 		},
 		Entry("when the path matches the regexp", rewritePathTableInput{
 			rewriteRegex:       regexp.MustCompile("^/http/(.*)"),
 			rewriteTarget:      "/$1",
 			requestTarget:      "http://example.com/http/foo/bar",
 			expectedRequestURI: "http://example.com/foo/bar",
+			expectedURLPath:    "/foo/bar",
 		}),
 		Entry("when the path does not match the regexp", rewritePathTableInput{
 			rewriteRegex:       regexp.MustCompile("^/http/(.*)"),
 			rewriteTarget:      "/$1",
 			requestTarget:      "https://example.com/https/foo/bar",
 			expectedRequestURI: "https://example.com/https/foo/bar",
+			expectedURLPath:    "/https/foo/bar",
 		}),
 		Entry("when the regexp is not anchored", rewritePathTableInput{
 			rewriteRegex:       regexp.MustCompile("/http/(.*)"),
 			rewriteTarget:      "/$1",
 			requestTarget:      "http://example.com/bar/http/foo/bar",
 			expectedRequestURI: "http://example.com/bar/foo/bar",
+			expectedURLPath:    "/bar/foo/bar",
 		}),
 		Entry("when the regexp is rewriting to a query", rewritePathTableInput{
 			rewriteRegex:       regexp.MustCompile(`/articles/([a-z0-9\-]*)`),
 			rewriteTarget:      "/article?id=$1",
 			requestTarget:      "http://example.com/articles/blog-2021-01-01",
 			expectedRequestURI: "http://example.com/article?id=blog-2021-01-01",
+			expectedURLPath:    "/article",
 		}),
 	)
 })


### PR DESCRIPTION
~~This PR is still work in progress... I need to do some further tests~~

## Description

Add a fix for https://github.com/oauth2-proxy/oauth2-proxy/issues/1601

## Motivation and Context

This fix is required because currently paths for websockets are not rewritten even if `rewriteTarget` is configured

## How Has This Been Tested?

I've tested this fix using the setup described in the issue https://github.com/oauth2-proxy/oauth2-proxy/issues/1601

## Checklist:


- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
