### PR TITLE
[REQUEST FOR COMMENT] Add client assertions auth to the default oidc provider

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -11,10 +11,16 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
 	"github.com/spf13/pflag"
 )
 
 var _ = Describe("Configuration Loading Suite", func() {
+
+	// we are comparing very large objects and we want to see the differences
+	format.MaxLength = 50000
+	format.MaxDepth = 10
+
 	const testLegacyConfig = `
 http_address="127.0.0.1:4180"
 upstreams="http://httpbin"
@@ -66,8 +72,10 @@ server:
 providers:
 - provider: google
   ID: google=oauth2-proxy
-  clientSecret: b2F1dGgyLXByb3h5LWNsaWVudC1zZWNyZXQK
   clientID: oauth2-proxy
+  authentication:
+    method: client_secret
+    clientSecret: b2F1dGgyLXByb3h5LWNsaWVudC1zZWNyZXQK
   azureConfig:
     tenant: common
   oidcConfig:
@@ -143,10 +151,13 @@ redirect_url="http://localhost:4180/oauth2/callback"
 
 		opts.Providers = options.Providers{
 			options.Provider{
-				ID:           "google=oauth2-proxy",
-				Type:         "google",
-				ClientSecret: "b2F1dGgyLXByb3h5LWNsaWVudC1zZWNyZXQK",
-				ClientID:     "oauth2-proxy",
+				ID:   "google=oauth2-proxy",
+				Type: "google",
+				AuthenticationConfig: options.AuthenticationOptions{
+					Method:       options.ClientSecret,
+					ClientSecret: "b2F1dGgyLXByb3h5LWNsaWVudC1zZWNyZXQK",
+				},
+				ClientID: "oauth2-proxy",
 				AzureConfig: options.AzureOptions{
 					Tenant: "common",
 				},

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -2029,7 +2029,7 @@ func baseTestOptions() *options.Options {
 	opts.Cookie.Secret = rawCookieSecret
 	opts.Providers[0].ID = "providerID"
 	opts.Providers[0].ClientID = clientID
-	opts.Providers[0].ClientSecret = clientSecret
+	opts.Providers[0].AuthenticationConfig.ClientSecret = clientSecret
 	opts.EmailDomains = []string{"*"}
 
 	// Default injected headers for legacy configuration

--- a/pkg/apis/options/authentication.go
+++ b/pkg/apis/options/authentication.go
@@ -1,0 +1,62 @@
+package options
+
+import "time"
+
+type AuthenticationMethod string
+
+const (
+	// ClientSecret is the authentication method for client secret
+	// (default) https://oauth.net/2/client-authentication/
+	ClientSecret AuthenticationMethod = "client_secret"
+
+	// MutualTLS is the authentication method for mutual TLS
+	// https://oauth.net/2/mtls/
+	MutualTLS AuthenticationMethod = "mtls"
+
+	// PrivateKeyJWT is the authentication method for private key JWT
+	// https://oauth.net/private-key-jwt/
+	PrivateKeyJWT AuthenticationMethod = "private_key_jwt"
+)
+
+type AuthenticationOptions struct {
+	// AuthenticationMethod defines how we should authenticate with the provider
+	// possible values are: 'client_secret', 'mtls', 'private_key_jwt'
+	AuthenticationMethod AuthenticationMethod `json:"authenticationMethod,omitempty"`
+
+	// ClientSecret is the OAuth Client Secret that is defined in the provider
+	// This value is required when AuthenticationMethod is set to 'client_secret'
+	ClientSecret string `json:"clientSecret,omitempty"`
+	// ClientSecretFile is the name of the file
+	// containing the OAuth Client Secret, it will be used if ClientSecret is not set.
+	ClientSecretFile string `json:"clientSecretFile,omitempty"`
+
+	// JWTKey is the private key used to sign the assertion
+	// this is required when UseAssertionAuthentication is set to 'true'
+	// only ecdsa keys are supported for now
+	// it is required when AuthenticationMethod is set to 'private_key_jwt'
+	// JWTKey is a private key in PEM format used to sign JWT,
+	JWTKey string `json:"jwtKey,omitempty"`
+	// JWTKeyFile is a path to the private key file in PEM format used to sign the JWT
+	// it is required when AuthenticationMethod is set to 'private_key_jwt'
+	JWTKeyFile string `json:"jwtKeyFile,omitempty"`
+	// JWTAlgorithm is the algorithm used to sign the assertion
+	// this defaults to 'ES256'
+	// it is required when AuthenticationMethod is set to 'private_key_jwt'
+	JWTAlgorithm string `json:"jwtAlgorithm,omitempty"`
+	// JWTKeyId is the key id used to sign the assertion
+	// it is used as the "kid" jwt token header in the assertion
+	// if not provided, the "kid" header is not set
+	// it is required when AuthenticationMethod is set to 'private_key_jwt'
+	JWTKeyId string `json:"jwtKeyId,omitempty"`
+	// JWTExpire is the duration for which the assertion is valid
+	// this defaults to '5m'
+	// it is required when AuthenticationMethod is set to 'private_key_jwt'
+	JWTExpire time.Duration `json:"jwtExpire,omitempty"`
+
+	// TLSCertFile Path to the PEM encoded X.509 certificate to use when connecting to the provider
+	// it is required when AuthenticationMethod is set to 'mtls'
+	TLSCertFile string `json:"tlsCertFile,omitempty"`
+	// TLSKeyFile Path to the PEM encoded X.509 key to use when connecting to the provider
+	// it is required when AuthenticationMethod is set to 'mtls'
+	TLSKeyFile string `json:"tlsKeyFile,omitempty"`
+}

--- a/pkg/apis/options/authentication.go
+++ b/pkg/apis/options/authentication.go
@@ -19,9 +19,9 @@ const (
 )
 
 type AuthenticationOptions struct {
-	// AuthenticationMethod defines how we should authenticate with the provider
+	// Method defines how we should authenticate with the provider
 	// possible values are: 'client_secret', 'mtls', 'private_key_jwt'
-	AuthenticationMethod AuthenticationMethod `json:"authenticationMethod,omitempty"`
+	Method AuthenticationMethod `json:"method,omitempty"`
 
 	// ClientSecret is the OAuth Client Secret that is defined in the provider
 	// This value is required when AuthenticationMethod is set to 'client_secret'

--- a/pkg/apis/options/legacy_options.go
+++ b/pkg/apis/options/legacy_options.go
@@ -50,6 +50,7 @@ func NewLegacyOptions() *LegacyOptions {
 
 		LegacyProvider: LegacyProvider{
 			ProviderType:          "google",
+			AuthenticationMethod:  "client_secret",
 			AzureTenant:           "common",
 			ApprovalPrompt:        "force",
 			UserIDClaim:           "email",
@@ -599,16 +600,16 @@ func legacyProviderFlagSet() *pflag.FlagSet {
 	flagSet.StringSlice("allowed-group", []string{}, "restrict logins to members of this group (may be given multiple times)")
 	flagSet.StringSlice("allowed-role", []string{}, "(keycloak-oidc) restrict logins to members of these roles (may be given multiple times)")
 
-	flagSet.String("authentication-method", "", "Authentication method to use; can be \"client_secret\", \"mtls\" or \"private_key_jwt\"")
+	flagSet.String("authentication-method", "client_secret", "Authentication method to use; can be \"client_secret\", \"mtls\" or \"private_key_jwt\"")
 	flagSet.String("client-secret", "", "the OAuth Client Secret")
 	flagSet.String("client-secret-file", "", "the file with OAuth Client Secret")
 	flagSet.String("tls-cert-file", "", "path to certificate file")
 	flagSet.String("tls-key-file", "", "path to private key file")
 	flagSet.String("jwt-key", "", "private key in PEM format used to sign JWT, so that you can say something like -jwt-key=\"${OAUTH2_PROXY_JWT_KEY}\": required by login.gov and when authenticating with JWT")
 	flagSet.String("jwt-key-file", "", "path to the private key file in PEM format used to sign the JWT so that you can say something like -jwt-key-file=/etc/ssl/private/jwt_signing_key.pem: required by login.gov and when authenticating with JWT")
-	flagSet.String("jwt-algorithm", "RS256", "the algorithm to use when signing the JWT")
+	flagSet.String("jwt-algorithm", "", "the algorithm to use when signing the JWT")
 	flagSet.String("jwt-key-id", "", "the key id to use in the JWT header")
-	flagSet.String("jwt-expire", "1h", "the duration that the generated JWT will be valid")
+	flagSet.Duration("jwt-expire", time.Duration(0), "the duration that the generated JWT will be valid")
 
 	return flagSet
 }
@@ -673,9 +674,9 @@ func (l *LegacyProvider) convert() (Providers, error) {
 	providers := Providers{}
 
 	providerAuthentication := AuthenticationOptions{
-		AuthenticationMethod: AuthenticationMethod(l.AuthenticationMethod),
-		ClientSecret:         l.ClientSecret,
-		ClientSecretFile:     l.ClientSecretFile,
+		Method:           AuthenticationMethod(l.AuthenticationMethod),
+		ClientSecret:     l.ClientSecret,
+		ClientSecretFile: l.ClientSecretFile,
 
 		TLSCertFile: l.TLSCertFile,
 		TLSKeyFile:  l.TLSKeyFile,

--- a/pkg/apis/options/legacy_options.go
+++ b/pkg/apis/options/legacy_options.go
@@ -481,9 +481,7 @@ func legacyServerFlagset() *pflag.FlagSet {
 }
 
 type LegacyProvider struct {
-	ClientID         string `flag:"client-id" cfg:"client_id"`
-	ClientSecret     string `flag:"client-secret" cfg:"client_secret"`
-	ClientSecretFile string `flag:"client-secret-file" cfg:"client_secret_file"`
+	ClientID string `flag:"client-id" cfg:"client_id"`
 
 	KeycloakGroups                         []string `flag:"keycloak-group" cfg:"keycloak_groups"`
 	AzureTenant                            string   `flag:"azure-tenant" cfg:"azure_tenant"`
@@ -532,14 +530,24 @@ type LegacyProvider struct {
 	AllowedGroups                      []string `flag:"allowed-group" cfg:"allowed_groups"`
 	AllowedRoles                       []string `flag:"allowed-role" cfg:"allowed_roles"`
 
-	AcrValues  string `flag:"acr-values" cfg:"acr_values"`
-	JWTKey     string `flag:"jwt-key" cfg:"jwt_key"`
-	JWTKeyFile string `flag:"jwt-key-file" cfg:"jwt_key_file"`
-	PubJWKURL  string `flag:"pubjwk-url" cfg:"pubjwk_url"`
+	AcrValues string `flag:"acr-values" cfg:"acr_values"`
+	PubJWKURL string `flag:"pubjwk-url" cfg:"pubjwk_url"`
 	// PKCE Code Challenge method to use (either S256 or plain)
 	CodeChallengeMethod string `flag:"code-challenge-method" cfg:"code_challenge_method"`
 	// Provided for legacy reasons, to be dropped in newer version see #1667
 	ForceCodeChallengeMethod string `flag:"force-code-challenge-method" cfg:"force_code_challenge_method"`
+
+	// authentication options
+	AuthenticationMethod string        `flag:"authentication-method" cfg:"authentication_method"`
+	ClientSecret         string        `flag:"client-secret" cfg:"client_secret"`
+	ClientSecretFile     string        `flag:"client-secret-file" cfg:"client_secret_file"`
+	TLSCertFile          string        `flag:"tls-cert-file" cfg:"tls_cert_file"`
+	TLSKeyFile           string        `flag:"tls-key-file" cfg:"tls_key_file"`
+	JWTKey               string        `flag:"jwt-key" cfg:"jwt_key"`
+	JWTKeyFile           string        `flag:"jwt-key-file" cfg:"jwt_key_file"`
+	JWTAlgorithm         string        `flag:"jwt-algorithm" cfg:"jwt_algorithm"`
+	JWTKeyId             string        `flag:"jwt-key-id" cfg:"jwt_key_id"`
+	JWTExpire            time.Duration `flag:"jwt-expire" cfg:"jwt_expire"`
 }
 
 func legacyProviderFlagSet() *pflag.FlagSet {
@@ -558,8 +566,6 @@ func legacyProviderFlagSet() *pflag.FlagSet {
 	flagSet.StringSlice("gitlab-group", []string{}, "restrict logins to members of this group (may be given multiple times)")
 	flagSet.StringSlice("gitlab-project", []string{}, "restrict logins to members of this project (may be given multiple times) (eg `group/project=accesslevel`). Access level should be a value matching Gitlab access levels (see https://docs.gitlab.com/ee/api/members.html#valid-access-levels), defaulted to 20 if absent")
 	flagSet.String("client-id", "", "the OAuth Client ID: ie: \"123456.apps.googleusercontent.com\"")
-	flagSet.String("client-secret", "", "the OAuth Client Secret")
-	flagSet.String("client-secret-file", "", "the file with OAuth Client Secret")
 
 	flagSet.String("provider", "google", "OAuth provider")
 	flagSet.String("provider-display-name", "", "Provider display name")
@@ -587,13 +593,22 @@ func legacyProviderFlagSet() *pflag.FlagSet {
 	flagSet.String("force-code-challenge-method", "", "Deprecated - use --code-challenge-method")
 
 	flagSet.String("acr-values", "", "acr values string:  optional")
-	flagSet.String("jwt-key", "", "private key in PEM format used to sign JWT, so that you can say something like -jwt-key=\"${OAUTH2_PROXY_JWT_KEY}\": required by login.gov")
-	flagSet.String("jwt-key-file", "", "path to the private key file in PEM format used to sign the JWT so that you can say something like -jwt-key-file=/etc/ssl/private/jwt_signing_key.pem: required by login.gov")
 	flagSet.String("pubjwk-url", "", "JWK pubkey access endpoint: required by login.gov")
 
 	flagSet.String("user-id-claim", OIDCEmailClaim, "(DEPRECATED for `oidc-email-claim`) which claim contains the user ID")
 	flagSet.StringSlice("allowed-group", []string{}, "restrict logins to members of this group (may be given multiple times)")
 	flagSet.StringSlice("allowed-role", []string{}, "(keycloak-oidc) restrict logins to members of these roles (may be given multiple times)")
+
+	flagSet.String("authentication-method", "", "Authentication method to use; can be \"client_secret\", \"mtls\" or \"private_key_jwt\"")
+	flagSet.String("client-secret", "", "the OAuth Client Secret")
+	flagSet.String("client-secret-file", "", "the file with OAuth Client Secret")
+	flagSet.String("tls-cert-file", "", "path to certificate file")
+	flagSet.String("tls-key-file", "", "path to private key file")
+	flagSet.String("jwt-key", "", "private key in PEM format used to sign JWT, so that you can say something like -jwt-key=\"${OAUTH2_PROXY_JWT_KEY}\": required by login.gov and when authenticating with JWT")
+	flagSet.String("jwt-key-file", "", "path to the private key file in PEM format used to sign the JWT so that you can say something like -jwt-key-file=/etc/ssl/private/jwt_signing_key.pem: required by login.gov and when authenticating with JWT")
+	flagSet.String("jwt-algorithm", "RS256", "the algorithm to use when signing the JWT")
+	flagSet.String("jwt-key-id", "", "the key id to use in the JWT header")
+	flagSet.String("jwt-expire", "1h", "the duration that the generated JWT will be valid")
 
 	return flagSet
 }
@@ -657,21 +672,35 @@ func (l LegacyServer) convert() (Server, Server) {
 func (l *LegacyProvider) convert() (Providers, error) {
 	providers := Providers{}
 
+	providerAuthentication := AuthenticationOptions{
+		AuthenticationMethod: AuthenticationMethod(l.AuthenticationMethod),
+		ClientSecret:         l.ClientSecret,
+		ClientSecretFile:     l.ClientSecretFile,
+
+		TLSCertFile: l.TLSCertFile,
+		TLSKeyFile:  l.TLSKeyFile,
+
+		JWTKey:       l.JWTKey,
+		JWTKeyFile:   l.JWTKeyFile,
+		JWTAlgorithm: l.JWTAlgorithm,
+		JWTKeyId:     l.JWTKeyId,
+		JWTExpire:    l.JWTExpire,
+	}
+
 	provider := Provider{
-		ClientID:            l.ClientID,
-		ClientSecret:        l.ClientSecret,
-		ClientSecretFile:    l.ClientSecretFile,
-		Type:                ProviderType(l.ProviderType),
-		CAFiles:             l.ProviderCAFiles,
-		UseSystemTrustStore: l.UseSystemTrustStore,
-		LoginURL:            l.LoginURL,
-		RedeemURL:           l.RedeemURL,
-		ProfileURL:          l.ProfileURL,
-		ProtectedResource:   l.ProtectedResource,
-		ValidateURL:         l.ValidateURL,
-		Scope:               l.Scope,
-		AllowedGroups:       l.AllowedGroups,
-		CodeChallengeMethod: l.CodeChallengeMethod,
+		ClientID:             l.ClientID,
+		AuthenticationConfig: providerAuthentication,
+		Type:                 ProviderType(l.ProviderType),
+		CAFiles:              l.ProviderCAFiles,
+		UseSystemTrustStore:  l.UseSystemTrustStore,
+		LoginURL:             l.LoginURL,
+		RedeemURL:            l.RedeemURL,
+		ProfileURL:           l.ProfileURL,
+		ProtectedResource:    l.ProtectedResource,
+		ValidateURL:          l.ValidateURL,
+		Scope:                l.Scope,
+		AllowedGroups:        l.AllowedGroups,
+		CodeChallengeMethod:  l.CodeChallengeMethod,
 	}
 
 	// This part is out of the switch section for all providers that support OIDC
@@ -726,9 +755,7 @@ func (l *LegacyProvider) convert() (Providers, error) {
 		}
 	case "login.gov":
 		provider.LoginGovConfig = LoginGovOptions{
-			JWTKey:     l.JWTKey,
-			JWTKeyFile: l.JWTKeyFile,
-			PubJWKURL:  l.PubJWKURL,
+			PubJWKURL: l.PubJWKURL,
 		}
 	case "bitbucket":
 		provider.BitbucketConfig = BitbucketOptions{

--- a/pkg/apis/options/load_test.go
+++ b/pkg/apis/options/load_test.go
@@ -9,10 +9,16 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
 	"github.com/spf13/pflag"
 )
 
 var _ = Describe("Load", func() {
+
+	// we are comparing very large objects and we want to see the differences
+	format.MaxLength = 50000
+	format.MaxDepth = 10
+
 	optionsWithNilProvider := NewOptions()
 	optionsWithNilProvider.Providers = nil
 
@@ -37,6 +43,7 @@ var _ = Describe("Load", func() {
 
 		LegacyProvider: LegacyProvider{
 			ProviderType:          "google",
+			AuthenticationMethod:  "client_secret",
 			AzureTenant:           "common",
 			ApprovalPrompt:        "force",
 			UserIDClaim:           "email",

--- a/pkg/apis/options/providers.go
+++ b/pkg/apis/options/providers.go
@@ -1,9 +1,5 @@
 package options
 
-import (
-	"time"
-)
-
 const (
 	// OIDCEmailClaim is the generic email claim used by the OIDC provider.
 	OIDCEmailClaim = "email"
@@ -23,12 +19,10 @@ type Provider struct {
 	// ClientID is the OAuth Client ID that is defined in the provider
 	// This value is required for all providers.
 	ClientID string `json:"clientID,omitempty"`
-	// ClientSecret is the OAuth Client Secret that is defined in the provider
+
+	// AuthenticationConfig holds all configurations for the authentication method.
 	// This value is required for all providers.
-	ClientSecret string `json:"clientSecret,omitempty"`
-	// ClientSecretFile is the name of the file
-	// containing the OAuth Client Secret, it will be used if ClientSecret is not set.
-	ClientSecretFile string `json:"clientSecretFile,omitempty"`
+	AuthenticationConfig AuthenticationOptions `json:"authenticationConfig,omitempty"`
 
 	// KeycloakConfig holds all configurations for Keycloak provider.
 	KeycloakConfig KeycloakOptions `json:"keycloakConfig,omitempty"`
@@ -238,34 +232,9 @@ type OIDCOptions struct {
 	// ExtraAudiences is a list of additional audiences that are allowed
 	// to pass verification in addition to the client id.
 	ExtraAudiences []string `json:"extraAudiences,omitempty"`
-
-	// UseAssertionAuthentication enables the use of assertion authentication
-	// instead of the default client secret authentication, this defaults to 'false'
-	UseAssertionAuthentication bool `json:"useAssertionAuthentication,omitempty"`
-	// AssertionAuthPrivateKey is the private key used to sign the assertion
-	// this is required when UseAssertionAuthentication is set to 'true'
-	// only ecdsa keys are supported for now
-	// JWTKey is a private key in PEM format used to sign JWT,
-	AssertionAuthJWTKey string `json:"assertionAuthJwtKey,omitempty"`
-	// JWTKeyFile is a path to the private key file in PEM format used to sign the JWT
-	AssertionAuthJWTKeyFile string `json:"assertionAuthJwtKeyFile,omitempty"`
-	// AssertionAuthAlgorithm is the algorithm used to sign the assertion
-	// this defaults to 'ES256'
-	AssertionAuthAlgorithm string `json:"assertionAuthAlgorithm,omitempty"`
-	// AssertionAuthKeyId is the key id used to sign the assertion
-	// it is used as the "kid" jwt token header in the assertion
-	// if not provided, the "kid" header is not set
-	AssertionAuthKeyId string `json:"assertionAuthKeyId,omitempty"`
-	// AssertionAuthExpire is the duration for which the assertion is valid
-	// this defaults to '5m'
-	AssertionAuthExpire time.Duration `json:"assertionAuthDuration,omitempty"`
 }
 
 type LoginGovOptions struct {
-	// JWTKey is a private key in PEM format used to sign JWT,
-	JWTKey string `json:"jwtKey,omitempty"`
-	// JWTKeyFile is a path to the private key file in PEM format used to sign the JWT
-	JWTKeyFile string `json:"jwtKeyFile,omitempty"`
 	// PubJWKURL is the JWK pubkey access endpoint
 	PubJWKURL string `json:"pubjwkURL,omitempty"`
 }

--- a/pkg/apis/options/providers.go
+++ b/pkg/apis/options/providers.go
@@ -22,7 +22,7 @@ type Provider struct {
 
 	// AuthenticationConfig holds all configurations for the authentication method.
 	// This value is required for all providers.
-	AuthenticationConfig AuthenticationOptions `json:"authenticationConfig,omitempty"`
+	AuthenticationConfig AuthenticationOptions `json:"authentication,omitempty"`
 
 	// KeycloakConfig holds all configurations for Keycloak provider.
 	KeycloakConfig KeycloakOptions `json:"keycloakConfig,omitempty"`
@@ -243,6 +243,9 @@ func providerDefaults() Providers {
 	providers := Providers{
 		{
 			Type: "google",
+			AuthenticationConfig: AuthenticationOptions{
+				Method: ClientSecret,
+			},
 			AzureConfig: AzureOptions{
 				Tenant: "common",
 			},

--- a/pkg/apis/options/providers.go
+++ b/pkg/apis/options/providers.go
@@ -1,5 +1,9 @@
 package options
 
+import (
+	"time"
+)
+
 const (
 	// OIDCEmailClaim is the generic email claim used by the OIDC provider.
 	OIDCEmailClaim = "email"
@@ -234,6 +238,27 @@ type OIDCOptions struct {
 	// ExtraAudiences is a list of additional audiences that are allowed
 	// to pass verification in addition to the client id.
 	ExtraAudiences []string `json:"extraAudiences,omitempty"`
+
+	// UseAssertionAuthentication enables the use of assertion authentication
+	// instead of the default client secret authentication, this defaults to 'false'
+	UseAssertionAuthentication bool `json:"useAssertionAuthentication,omitempty"`
+	// AssertionAuthPrivateKey is the private key used to sign the assertion
+	// this is required when UseAssertionAuthentication is set to 'true'
+	// only ecdsa keys are supported for now
+	// JWTKey is a private key in PEM format used to sign JWT,
+	AssertionAuthJWTKey string `json:"assertionAuthJwtKey,omitempty"`
+	// JWTKeyFile is a path to the private key file in PEM format used to sign the JWT
+	AssertionAuthJWTKeyFile string `json:"assertionAuthJwtKeyFile,omitempty"`
+	// AssertionAuthAlgorithm is the algorithm used to sign the assertion
+	// this defaults to 'ES256'
+	AssertionAuthAlgorithm string `json:"assertionAuthAlgorithm,omitempty"`
+	// AssertionAuthKeyId is the key id used to sign the assertion
+	// it is used as the "kid" jwt token header in the assertion
+	// if not provided, the "kid" header is not set
+	AssertionAuthKeyId string `json:"assertionAuthKeyId,omitempty"`
+	// AssertionAuthExpire is the duration for which the assertion is valid
+	// this defaults to '5m'
+	AssertionAuthExpire time.Duration `json:"assertionAuthDuration,omitempty"`
 }
 
 type LoginGovOptions struct {

--- a/pkg/validation/authentication.go
+++ b/pkg/validation/authentication.go
@@ -10,7 +10,7 @@ import (
 func validateAuthenticationConfig(authConfig options.AuthenticationOptions) []string {
 	msgs := []string{}
 
-	switch authConfig.AuthenticationMethod {
+	switch authConfig.Method {
 	case options.ClientSecret:
 		msgs = append(msgs, validateClientSecretAuthenticationConfig(authConfig)...)
 	case options.MutualTLS:
@@ -20,6 +20,7 @@ func validateAuthenticationConfig(authConfig options.AuthenticationOptions) []st
 	default:
 		msgs = append(msgs, "invalid setting: authentication-method")
 	}
+
 	return msgs
 }
 

--- a/pkg/validation/authentication.go
+++ b/pkg/validation/authentication.go
@@ -66,6 +66,9 @@ func validateMutualTLSAuthenticationConfig(authConfig options.AuthenticationOpti
 func validatePrivateKeyJWTAuthenticationConfig(authConfig options.AuthenticationOptions) []string {
 	msgs := []string{}
 
+	if authConfig.JWTKey != "" && authConfig.JWTKeyFile != "" {
+		msgs = append(msgs, "cannot set both jwt-key and jwt-key-file")
+	}
 	if authConfig.JWTKey == "" && authConfig.JWTKeyFile == "" {
 		msgs = append(msgs, "missing setting: jwt-key or jwt-key-file")
 	}

--- a/pkg/validation/authentication.go
+++ b/pkg/validation/authentication.go
@@ -1,0 +1,101 @@
+package validation
+
+import (
+	"os"
+
+	"github.com/golang-jwt/jwt"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
+)
+
+func validateAuthenticationConfig(authConfig options.AuthenticationOptions) []string {
+	msgs := []string{}
+
+	switch authConfig.AuthenticationMethod {
+	case options.ClientSecret:
+		msgs = append(msgs, validateClientSecretAuthenticationConfig(authConfig)...)
+	case options.MutualTLS:
+		msgs = append(msgs, validateMutualTLSAuthenticationConfig(authConfig)...)
+	case options.PrivateKeyJWT:
+		msgs = append(msgs, validatePrivateKeyJWTAuthenticationConfig(authConfig)...)
+	default:
+		msgs = append(msgs, "invalid setting: authentication-method")
+	}
+	return msgs
+}
+
+func validateClientSecretAuthenticationConfig(authConfig options.AuthenticationOptions) []string {
+	msgs := []string{}
+
+	if authConfig.ClientSecret == "" && authConfig.ClientSecretFile == "" {
+		msgs = append(msgs, "missing setting: client-secret or client-secret-file")
+	}
+	if authConfig.ClientSecret == "" && authConfig.ClientSecretFile != "" {
+		_, err := os.ReadFile(authConfig.ClientSecretFile)
+		if err != nil {
+			msgs = append(msgs, "could not read client secret file: "+authConfig.ClientSecretFile)
+		}
+	}
+
+	return msgs
+}
+
+func validateMutualTLSAuthenticationConfig(authConfig options.AuthenticationOptions) []string {
+	msgs := []string{}
+
+	if authConfig.TLSCertFile == "" {
+		msgs = append(msgs, "missing setting: tls-cert-file")
+	} else {
+		_, err := os.ReadFile(authConfig.TLSCertFile)
+		if err != nil {
+			msgs = append(msgs, "could not read tls cert file: "+authConfig.TLSCertFile)
+		}
+	}
+	if authConfig.TLSKeyFile == "" {
+		msgs = append(msgs, "missing setting: tls-key-file")
+	} else {
+		_, err := os.ReadFile(authConfig.TLSKeyFile)
+		if err != nil {
+			msgs = append(msgs, "could not read tls cert file: "+authConfig.TLSCertFile)
+		}
+	}
+
+	return msgs
+}
+
+func validatePrivateKeyJWTAuthenticationConfig(authConfig options.AuthenticationOptions) []string {
+	msgs := []string{}
+
+	if authConfig.JWTKey == "" && authConfig.JWTKeyFile == "" {
+		msgs = append(msgs, "missing setting: jwt-key or jwt-key-file")
+	}
+	if authConfig.JWTKey == "" && authConfig.JWTKeyFile != "" {
+		_, err := os.ReadFile(authConfig.JWTKeyFile)
+		if err != nil {
+			msgs = append(msgs, "could not read jwt key file: "+authConfig.JWTKeyFile)
+		}
+	}
+
+	// validate the key type is compatible with the provided key
+	keyContent := authConfig.JWTKey
+	if authConfig.JWTKeyFile != "" {
+		fileContent, err := os.ReadFile(authConfig.JWTKeyFile)
+		if err == nil {
+			keyContent = string(fileContent)
+		}
+	}
+
+	switch authConfig.JWTAlgorithm {
+	case "ES256", "ES384", "ES512":
+		_, err := jwt.ParseECPrivateKeyFromPEM([]byte(keyContent))
+		if err != nil {
+			msgs = append(msgs, "provided key failed to parse as an EC key: "+err.Error())
+		}
+	case "RS256", "RS384", "RS512":
+		_, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(keyContent))
+		if err != nil {
+			msgs = append(msgs, "provided key failed to parse as an RSA key: "+err.Error())
+		}
+	}
+
+	return msgs
+}

--- a/pkg/validation/options_test.go
+++ b/pkg/validation/options_test.go
@@ -15,7 +15,7 @@ import (
 const (
 	cookieSecret = "secretthirtytwobytes+abcdefghijk"
 	clientID     = "bazquux"
-	clientSecret = "xyzzyplugh"
+	clientSecret = "foobar"
 	providerID   = "providerID"
 )
 
@@ -29,7 +29,7 @@ func testOptions() *options.Options {
 	o.Cookie.Secret = cookieSecret
 	o.Providers[0].ID = providerID
 	o.Providers[0].ClientID = clientID
-	o.Providers[0].ClientSecret = clientSecret
+	o.Providers[0].AuthenticationConfig.ClientSecret = clientSecret
 	o.EmailDomains = []string{"*"}
 	return o
 }
@@ -63,7 +63,8 @@ func TestGoogleGroupOptions(t *testing.T) {
 
 	expected := errorMsg([]string{
 		"missing setting: google-admin-email",
-		"missing setting: google-service-account-json or google-use-application-default-credentials"})
+		"missing setting: google-service-account-json or google-use-application-default-credentials",
+	})
 	assert.Equal(t, expected, err.Error())
 }
 

--- a/pkg/validation/providers.go
+++ b/pkg/validation/providers.go
@@ -47,8 +47,8 @@ func validateProvider(provider options.Provider, providerIDs map[string]struct{}
 	}
 
 	msgs = append(msgs, validateAuthenticationConfig(provider.AuthenticationConfig)...)
-
 	msgs = append(msgs, validateGoogleConfig(provider)...)
+	msgs = append(msgs, validateGovLoginConfig(provider)...)
 
 	return msgs
 }
@@ -81,6 +81,16 @@ func validateGoogleConfig(provider options.Provider) []string {
 		}
 	} else if hasSAJSON {
 		msgs = append(msgs, "invalid setting: can't use both google-service-account-json and google-use-application-default-credentials")
+	}
+
+	return msgs
+}
+
+func validateGovLoginConfig(provider options.Provider) []string {
+	msgs := []string{}
+
+	if provider.Type == "login.gov" && provider.AuthenticationConfig.Method != options.PrivateKeyJWT {
+		msgs = append(msgs, "login.gov configuration not using private key jwt")
 	}
 
 	return msgs

--- a/pkg/validation/providers.go
+++ b/pkg/validation/providers.go
@@ -46,18 +46,7 @@ func validateProvider(provider options.Provider, providerIDs map[string]struct{}
 		msgs = append(msgs, "provider missing setting: client-id")
 	}
 
-	// login.gov uses a signed JWT to authenticate, not a client-secret
-	if provider.Type != "login.gov" {
-		if provider.ClientSecret == "" && provider.ClientSecretFile == "" {
-			msgs = append(msgs, "missing setting: client-secret or client-secret-file")
-		}
-		if provider.ClientSecret == "" && provider.ClientSecretFile != "" {
-			_, err := os.ReadFile(provider.ClientSecretFile)
-			if err != nil {
-				msgs = append(msgs, "could not read client secret file: "+provider.ClientSecretFile)
-			}
-		}
-	}
+	msgs = append(msgs, validateAuthenticationConfig(provider.AuthenticationConfig)...)
 
 	msgs = append(msgs, validateGoogleConfig(provider)...)
 

--- a/pkg/validation/providers_test.go
+++ b/pkg/validation/providers_test.go
@@ -1,11 +1,41 @@
 package validation
 
 import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"time"
+
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 )
+
+func newPrivateKeyBytes() ([]byte, error) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, err
+	}
+
+	keyBytes, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		return nil, err
+	}
+
+	privateKeyBlock := &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: keyBytes,
+	}
+	b := &bytes.Buffer{}
+	if err := pem.Encode(b, privateKeyBlock); err != nil {
+		return nil, err
+	}
+
+	return b.Bytes(), nil
+}
 
 var _ = Describe("Providers", func() {
 	type validateProvidersTableInput struct {
@@ -13,28 +43,52 @@ var _ = Describe("Providers", func() {
 		errStrings []string
 	}
 
-	validProvider := options.Provider{
-		ID:           "ProviderID",
-		ClientID:     "ClientID",
+	privateKeyBytes, err := newPrivateKeyBytes()
+	Expect(err).ToNot(HaveOccurred())
+
+	validClientSecretConfig := options.AuthenticationOptions{
+		Method:       options.ClientSecret,
 		ClientSecret: "ClientSecret",
+	}
+
+	validPrivateKeyConfig := options.AuthenticationOptions{
+		Method:       options.PrivateKeyJWT,
+		JWTAlgorithm: "RS256",
+		JWTKey:       string(privateKeyBytes),
+		JWTExpire:    1 * time.Hour,
+		JWTKeyId:     "JWTKeyId",
+	}
+
+	validProvider := options.Provider{
+		ID:                   "ProviderID",
+		ClientID:             "ClientID",
+		AuthenticationConfig: validClientSecretConfig,
 	}
 
 	validLoginGovProvider := options.Provider{
-		Type:         "login.gov",
-		ID:           "ProviderIDLoginGov",
-		ClientID:     "ClientID",
-		ClientSecret: "ClientSecret",
+		Type:                 "login.gov",
+		ID:                   "ProviderIDLoginGov",
+		ClientID:             "ClientID",
+		AuthenticationConfig: validPrivateKeyConfig,
 	}
 
 	missingIDProvider := options.Provider{
-		ClientID:     "ClientID",
-		ClientSecret: "ClientSecret",
+		ClientID:             "ClientID",
+		AuthenticationConfig: validClientSecretConfig,
+	}
+
+	loginGovProviderWithInvalidAuthentication := options.Provider{
+		Type:                 "login.gov",
+		ID:                   "ProviderIDLoginGov",
+		ClientID:             "ClientID",
+		AuthenticationConfig: validClientSecretConfig,
 	}
 
 	missingProvider := "at least one provider has to be defined"
 	emptyIDMsg := "provider has empty id: ids are required for all providers"
 	duplicateProviderIDMsg := "multiple providers found with id ProviderID: provider ids must be unique"
 	skipButtonAndMultipleProvidersMsg := "SkipProviderButton and multiple providers are mutually exclusive"
+	invalidLoginGovAuthentication := "login.gov configuration not using private key jwt"
 
 	DescribeTable("validateProviders",
 		func(o *validateProvidersTableInput) {
@@ -79,6 +133,14 @@ var _ = Describe("Providers", func() {
 				},
 			},
 			errStrings: []string{skipButtonAndMultipleProvidersMsg},
+		}),
+		Entry("login.gov configuration not using private key jwt", &validateProvidersTableInput{
+			options: &options.Options{
+				Providers: options.Providers{
+					loginGovProviderWithInvalidAuthentication,
+				},
+			},
+			errStrings: []string{invalidLoginGovAuthentication},
 		}),
 	)
 })

--- a/providers/adfs.go
+++ b/providers/adfs.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/sessions"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/logger"
 )
 
 // ADFSProvider represents an ADFS based Identity Provider
@@ -46,8 +47,11 @@ func NewADFSProvider(p *ProviderData, opts options.ADFSOptions) *ADFSProvider {
 		}
 	}
 
-	oidcProvider := NewOIDCProvider(p, options.OIDCOptions{InsecureSkipNonce: false})
-
+	oidcProvider, err := NewOIDCProvider(p, options.OIDCOptions{InsecureSkipNonce: false})
+	if err != nil {
+		logger.Errorf("could not create oidc provider: %v", err)
+		return nil
+	}
 	return &ADFSProvider{
 		OIDCProvider:    oidcProvider,
 		skipScope:       opts.SkipScope,

--- a/providers/authentication.go
+++ b/providers/authentication.go
@@ -1,0 +1,182 @@
+package providers
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/golang-jwt/jwt"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/logger"
+)
+
+type AuthenticationMethod int64
+
+const (
+	// (default) https://oauth.net/2/client-authentication/
+	ClientSecret AuthenticationMethod = iota
+	// https://oauth.net/2/mtls/
+	MutualTLS
+	// https://oauth.net/private-key-jwt/
+	PrivateKeyJWT
+)
+
+type ClientSecretAuthenticationData struct {
+	// the OAuth Client Secret, either as a string or a file path
+	ClientSecret     string
+	ClientSecretFile string
+}
+
+type MutalTLSAuthenticationData struct {
+	// Path to the PEM encoded X.509 certificate to use when connecting to the provider
+	TLSCertFile string
+	// Path to the PEM encoded X.509 key to use when connecting to the provider
+	TLSKeyFile string
+}
+
+type PrivateKeyJWTAuthenticationData struct {
+	// only one of the following should be set
+	// can be one of the following: ecdsa.PrivateKey, rsa.PrivateKey
+	JWTKey interface{}
+
+	Algorithm     string
+	SigningMethod jwt.SigningMethod
+	KeyId         string
+	Expire        time.Duration
+}
+
+type AuthenticationConfig struct {
+	// The authentication method to use when connecting to the provider
+	AuthenticationMethod AuthenticationMethod
+	// The authentication details to use when connecting to the provider
+	// only one of the following should be set, according to the authentication method
+	ClientSecretData  ClientSecretAuthenticationData
+	MutalTLSData      MutalTLSAuthenticationData
+	PrivateKeyJWTData PrivateKeyJWTAuthenticationData
+}
+
+func NewAuthenticationConfig(opts options.AuthenticationOptions) (*AuthenticationConfig, error) {
+	switch opts.AuthenticationMethod {
+	case options.ClientSecret:
+		return &AuthenticationConfig{
+			AuthenticationMethod: ClientSecret,
+			ClientSecretData: ClientSecretAuthenticationData{
+				ClientSecret:     opts.ClientSecret,
+				ClientSecretFile: opts.ClientSecretFile,
+			},
+		}, nil
+	case options.MutualTLS:
+		return &AuthenticationConfig{
+			AuthenticationMethod: MutualTLS,
+			MutalTLSData: MutalTLSAuthenticationData{
+				TLSCertFile: opts.TLSCertFile,
+				TLSKeyFile:  opts.TLSKeyFile,
+			},
+		}, nil
+	case options.PrivateKeyJWT:
+		var signingMethod jwt.SigningMethod
+		var signingAlgorithmType string
+		switch opts.JWTAlgorithm {
+		case "ES256":
+			signingMethod = jwt.SigningMethodES256
+			signingAlgorithmType = "ECDSA"
+		case "ES384":
+			signingMethod = jwt.SigningMethodES384
+			signingAlgorithmType = "ECDSA"
+		case "ES512":
+			signingMethod = jwt.SigningMethodES512
+			signingAlgorithmType = "ECDSA"
+		case "RS256":
+			signingMethod = jwt.SigningMethodRS256
+			signingAlgorithmType = "RSA"
+		case "RS384":
+			signingMethod = jwt.SigningMethodRS384
+			signingAlgorithmType = "RSA"
+		case "RS512":
+			signingMethod = jwt.SigningMethodRS512
+			signingAlgorithmType = "RSA"
+		}
+
+		// JWT key can be supplied via env variable or file in the filesystem, but not both.
+		var JWTKey interface{}
+		switch {
+		case opts.JWTKey != "" && opts.JWTKeyFile != "":
+			return nil, errors.New("cannot set both jwt-key and jwt-key-file options")
+		case opts.JWTKey == "" && opts.JWTKeyFile == "":
+			return nil, errors.New("provider requires a private key for signing JWTs")
+		case opts.JWTKey != "" && signingAlgorithmType == "RSA":
+			// The JWT Key is in the commandline argument
+			signKey, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(opts.JWTKey))
+			if err != nil {
+				return nil, fmt.Errorf("could not parse ECDSA Private Key PEM: %v", err)
+			}
+			JWTKey = signKey
+		case opts.JWTKeyFile != "" && signingAlgorithmType == "RSA":
+			// The JWT key is in the filesystem
+			keyData, err := os.ReadFile(opts.JWTKeyFile)
+			if err != nil {
+				return nil, fmt.Errorf("could not read key file: %v", opts.JWTKeyFile)
+			}
+			signKey, err := jwt.ParseRSAPrivateKeyFromPEM(keyData)
+			if err != nil {
+				return nil, fmt.Errorf("could not parse ECDSA private key from PEM file: %v", opts.JWTKeyFile)
+			}
+			JWTKey = signKey
+		case opts.JWTKey != "" && signingAlgorithmType == "ECDSA":
+			// The JWT Key is in the commandline argument
+			signKey, err := jwt.ParseECPrivateKeyFromPEM([]byte(opts.JWTKey))
+			if err != nil {
+				return nil, fmt.Errorf("could not parse ECDSA Private Key PEM: %v", err)
+			}
+			JWTKey = signKey
+		case opts.JWTKeyFile != "" && signingAlgorithmType == "ECDSA":
+			// The JWT key is in the filesystem
+			keyData, err := os.ReadFile(opts.JWTKeyFile)
+			if err != nil {
+				return nil, fmt.Errorf("could not read key file: %v", opts.JWTKeyFile)
+			}
+			signKey, err := jwt.ParseECPrivateKeyFromPEM(keyData)
+			if err != nil {
+				return nil, fmt.Errorf("could not parse ECDSA private key from PEM file: %v", opts.JWTKeyFile)
+			}
+			JWTKey = signKey
+		}
+
+		return &AuthenticationConfig{
+			AuthenticationMethod: PrivateKeyJWT,
+			PrivateKeyJWTData: PrivateKeyJWTAuthenticationData{
+				JWTKey:        JWTKey,
+				Algorithm:     opts.JWTAlgorithm,
+				SigningMethod: signingMethod,
+				KeyId:         opts.JWTKeyId,
+				Expire:        opts.JWTExpire,
+			},
+		}, nil
+	default:
+		return nil, fmt.Errorf("unsupported authentication method: %v", opts.AuthenticationMethod)
+	}
+}
+
+func (a *AuthenticationConfig) GetClientSecret() (clientSecret string, err error) {
+	switch a.AuthenticationMethod {
+	case ClientSecret:
+		return a.ClientSecretData.GetClientSecret()
+	default:
+		return "", errors.New("ClientSecret is not configured")
+	}
+}
+
+func (a *ClientSecretAuthenticationData) GetClientSecret() (clientSecret string, err error) {
+	if a.ClientSecret != "" || a.ClientSecretFile == "" {
+		return a.ClientSecret, nil
+	}
+
+	// Getting ClientSecret can fail in runtime so we need to report it without returning the file name to the user
+	fileClientSecret, err := os.ReadFile(a.ClientSecretFile)
+	if err != nil {
+		logger.Errorf("error reading client secret file %s: %s", a.ClientSecretFile, err)
+		return "", errors.New("could not read client secret file")
+	}
+	return string(fileClientSecret), nil
+}

--- a/providers/authentication.go
+++ b/providers/authentication.go
@@ -1,6 +1,7 @@
 package providers
 
 import (
+	"crypto"
 	"errors"
 	"fmt"
 	"os"
@@ -38,9 +39,8 @@ type MutalTLSAuthenticationData struct {
 type PrivateKeyJWTAuthenticationData struct {
 	// only one of the following should be set
 	// can be one of the following: ecdsa.PrivateKey, rsa.PrivateKey
-	JWTKey interface{}
+	JWTKey crypto.PrivateKey
 
-	Algorithm     string
 	SigningMethod jwt.SigningMethod
 	KeyId         string
 	Expire        time.Duration
@@ -57,7 +57,7 @@ type AuthenticationConfig struct {
 }
 
 func NewAuthenticationConfig(opts options.AuthenticationOptions) (*AuthenticationConfig, error) {
-	switch opts.AuthenticationMethod {
+	switch opts.Method {
 	case options.ClientSecret:
 		return &AuthenticationConfig{
 			AuthenticationMethod: ClientSecret,
@@ -99,7 +99,7 @@ func NewAuthenticationConfig(opts options.AuthenticationOptions) (*Authenticatio
 		}
 
 		// JWT key can be supplied via env variable or file in the filesystem, but not both.
-		var JWTKey interface{}
+		var JWTKey crypto.PrivateKey
 		switch {
 		case opts.JWTKey != "" && opts.JWTKeyFile != "":
 			return nil, errors.New("cannot set both jwt-key and jwt-key-file options")
@@ -147,14 +147,13 @@ func NewAuthenticationConfig(opts options.AuthenticationOptions) (*Authenticatio
 			AuthenticationMethod: PrivateKeyJWT,
 			PrivateKeyJWTData: PrivateKeyJWTAuthenticationData{
 				JWTKey:        JWTKey,
-				Algorithm:     opts.JWTAlgorithm,
 				SigningMethod: signingMethod,
 				KeyId:         opts.JWTKeyId,
 				Expire:        opts.JWTExpire,
 			},
 		}, nil
 	default:
-		return nil, fmt.Errorf("unsupported authentication method: %v", opts.AuthenticationMethod)
+		return nil, fmt.Errorf("unsupported authentication method: %v", opts.Method)
 	}
 }
 

--- a/providers/authentication.go
+++ b/providers/authentication.go
@@ -132,14 +132,6 @@ func getJWTPrivateKeySigninMethod(opts options.AuthenticationOptions) (jwt.Signi
 }
 
 func getJWTPrivateKeyObject(opts options.AuthenticationOptions) (crypto.PrivateKey, error) {
-	// JWT key can be supplied via env variable or file in the filesystem, but not both.
-	var JWTKey crypto.PrivateKey
-	if opts.JWTKey != "" && opts.JWTKeyFile != "" {
-		return nil, errors.New("cannot set both jwt-key and jwt-key-file options")
-	} else if opts.JWTKey == "" && opts.JWTKeyFile == "" {
-		return nil, errors.New("provider requires a private key for signing JWTs")
-	}
-
 	var keyBytes []byte
 	if opts.JWTKey != "" {
 		keyBytes = []byte(opts.JWTKey)
@@ -151,6 +143,7 @@ func getJWTPrivateKeyObject(opts options.AuthenticationOptions) (crypto.PrivateK
 		keyBytes = keyData
 	}
 
+	var JWTKey crypto.PrivateKey
 	switch opts.JWTAlgorithm {
 	case "ES256", "ES384", "ES512":
 		signKey, err := jwt.ParseECPrivateKeyFromPEM(keyBytes)

--- a/providers/gitlab.go
+++ b/providers/gitlab.go
@@ -40,7 +40,10 @@ func NewGitLabProvider(p *ProviderData, opts options.GitLabOptions) (*GitLabProv
 		p.Scope = gitlabDefaultScope
 	}
 
-	oidcProvider := NewOIDCProvider(p, options.OIDCOptions{InsecureSkipNonce: false})
+	oidcProvider, err := NewOIDCProvider(p, options.OIDCOptions{InsecureSkipNonce: false})
+	if err != nil {
+		return nil, err
+	}
 
 	provider := &GitLabProvider{
 		OIDCProvider:    oidcProvider,

--- a/providers/google_test.go
+++ b/providers/google_test.go
@@ -186,7 +186,7 @@ func TestGoogleProviderGetEmailAddressInvalidEncoding(t *testing.T) {
 
 func TestGoogleProviderRedeemFailsNoCLientSecret(t *testing.T) {
 	p := newGoogleProvider(t)
-	p.ProviderData.ClientSecretFile = "srvnoerre"
+	p.ProviderData.AuthenticationConfig.ClientSecretData.ClientSecretFile = "srvnoerre"
 
 	session, err := p.Redeem(context.Background(), "http://redirect/", "code1234", "123")
 	assert.NotEqual(t, nil, err)

--- a/providers/keycloak_oidc.go
+++ b/providers/keycloak_oidc.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/sessions"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/logger"
 )
 
 const keycloakOIDCProviderName = "Keycloak OIDC"
@@ -21,8 +22,14 @@ func NewKeycloakOIDCProvider(p *ProviderData, opts options.KeycloakOptions) *Key
 		name: keycloakOIDCProviderName,
 	})
 
+	oidcProvider, err := NewOIDCProvider(p, options.OIDCOptions{InsecureSkipNonce: false})
+	if err != nil {
+		logger.Errorf("could not create oidc provider: %v", err)
+		return nil
+	}
+
 	provider := &KeycloakOIDCProvider{
-		OIDCProvider: NewOIDCProvider(p, options.OIDCOptions{InsecureSkipNonce: false}),
+		OIDCProvider: oidcProvider,
 	}
 
 	provider.addAllowedRoles(opts.Roles)

--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -120,7 +120,7 @@ func (p *OIDCProvider) RedeemAssertion(ctx context.Context, redirectURL, code, c
 
 	authToken := &jwt.Token{
 		Header: map[string]interface{}{
-			"alg": jwtConfig.Algorithm,
+			"alg": jwtConfig.SigningMethod.Alg(),
 			"typ": "JWT",
 			"kid": jwtConfig.KeyId,
 		},

--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -379,12 +379,18 @@ func (p *OIDCProvider) fetchTokenUsingAssertionsAuth(ctx context.Context, params
 	if err != nil {
 		return nil, err
 	}
+	logger.Errorln("jsonResponse", jsonResponse)
 
 	token := oauth2.Token{
 		AccessToken:  jsonResponse.AccessToken,
 		RefreshToken: jsonResponse.RefreshToken,
 		TokenType:    jsonResponse.TokenType,
-		Expiry:       time.Now().Add(time.Duration(jsonResponse.ExpiresIn) * time.Second),
+
+		Expiry: time.Now().Add(time.Duration(jsonResponse.ExpiresIn) * time.Second),
 	}
+	token = *token.WithExtra(map[string]interface{}{
+		"id_token": jsonResponse.IDToken,
+		"scope":    jsonResponse.Scope,
+	})
 	return &token, nil
 }

--- a/providers/oidc_test.go
+++ b/providers/oidc_test.go
@@ -34,7 +34,12 @@ func newOIDCProvider(serverURL *url.URL, skipNonce bool) *OIDCProvider {
 	providerData := &ProviderData{
 		ProviderName: "oidc",
 		ClientID:     oidcClientID,
-		ClientSecret: oidcSecret,
+		AuthenticationConfig: AuthenticationConfig{
+			AuthenticationMethod: ClientSecret,
+			ClientSecretData: ClientSecretAuthenticationData{
+				ClientSecret: oidcSecret,
+			},
+		},
 		LoginURL: &url.URL{
 			Scheme: serverURL.Scheme,
 			Host:   serverURL.Host,

--- a/providers/oidc_test.go
+++ b/providers/oidc_test.go
@@ -62,7 +62,7 @@ func newOIDCProvider(serverURL *url.URL, skipNonce bool) *OIDCProvider {
 		), verificationOptions),
 	}
 
-	p := NewOIDCProvider(providerData, options.OIDCOptions{
+	p, _ := NewOIDCProvider(providerData, options.OIDCOptions{
 		InsecureSkipNonce: skipNonce,
 	})
 

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -64,7 +64,7 @@ func NewProvider(providerConfig options.Provider) (Provider, error) {
 	case options.NextCloudProvider:
 		return NewNextcloudProvider(providerData), nil
 	case options.OIDCProvider:
-		return NewOIDCProvider(providerData, providerConfig.OIDCConfig), nil
+		return NewOIDCProvider(providerData, providerConfig.OIDCConfig)
 	default:
 		return nil, fmt.Errorf("unknown provider type %q", providerConfig.Type)
 	}

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -71,11 +71,16 @@ func NewProvider(providerConfig options.Provider) (Provider, error) {
 }
 
 func newProviderDataFromConfig(providerConfig options.Provider) (*ProviderData, error) {
+
+	authConfig, err := NewAuthenticationConfig(providerConfig.AuthenticationConfig)
+	if err != nil {
+		return nil, err
+	}
+
 	p := &ProviderData{
-		Scope:            providerConfig.Scope,
-		ClientID:         providerConfig.ClientID,
-		ClientSecret:     providerConfig.ClientSecret,
-		ClientSecretFile: providerConfig.ClientSecretFile,
+		Scope:                providerConfig.Scope,
+		ClientID:             providerConfig.ClientID,
+		AuthenticationConfig: *authConfig,
 	}
 
 	needsVerifier, err := providerRequiresOIDCProviderVerifier(providerConfig.Type)

--- a/providers/providers_test.go
+++ b/providers/providers_test.go
@@ -23,16 +23,20 @@ func TestClientSecretFileOptionFails(t *testing.T) {
 	g := NewWithT(t)
 
 	providerConfig := options.Provider{
-		ID:               providerID,
-		Type:             "google",
-		ClientID:         clientID,
-		ClientSecretFile: clientSecret,
+		ID:       providerID,
+		Type:     "google",
+		ClientID: clientID,
+		AuthenticationConfig: options.AuthenticationOptions{
+			Method:           options.ClientSecret,
+			ClientSecretFile: clientSecret,
+		},
 	}
 
 	p, err := newProviderDataFromConfig(providerConfig)
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(p.ClientSecretFile).To(Equal(clientSecret))
-	g.Expect(p.ClientSecret).To(BeEmpty())
+	g.Expect(p.AuthenticationConfig.AuthenticationMethod).To(Equal(ClientSecret))
+	g.Expect(p.AuthenticationConfig.ClientSecretData.ClientSecretFile).To(Equal(clientSecret))
+	g.Expect(p.AuthenticationConfig.ClientSecretData.ClientSecret).To(BeEmpty())
 
 	s, err := p.GetClientSecret()
 	g.Expect(err).To(HaveOccurred())
@@ -56,16 +60,20 @@ func TestClientSecretFileOption(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 
 	providerConfig := options.Provider{
-		ID:               providerID,
-		Type:             "google",
-		ClientID:         clientID,
-		ClientSecretFile: clientSecretFileName,
+		ID:       providerID,
+		Type:     "google",
+		ClientID: clientID,
+		AuthenticationConfig: options.AuthenticationOptions{
+			Method:           options.ClientSecret,
+			ClientSecretFile: clientSecretFileName,
+		},
 	}
 
 	p, err := newProviderDataFromConfig(providerConfig)
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(p.ClientSecretFile).To(Equal(clientSecretFileName))
-	g.Expect(p.ClientSecret).To(BeEmpty())
+	g.Expect(p.AuthenticationConfig.AuthenticationMethod).To(Equal(ClientSecret))
+	g.Expect(p.AuthenticationConfig.ClientSecretData.ClientSecretFile).To(Equal(clientSecretFileName))
+	g.Expect(p.AuthenticationConfig.ClientSecretData.ClientSecret).To(BeEmpty())
 
 	s, err := p.GetClientSecret()
 	g.Expect(err).ToNot(HaveOccurred())
@@ -75,10 +83,13 @@ func TestClientSecretFileOption(t *testing.T) {
 func TestSkipOIDCDiscovery(t *testing.T) {
 	g := NewWithT(t)
 	providerConfig := options.Provider{
-		ID:               providerID,
-		Type:             "oidc",
-		ClientID:         clientID,
-		ClientSecretFile: clientSecret,
+		ID:       providerID,
+		Type:     "oidc",
+		ClientID: clientID,
+		AuthenticationConfig: options.AuthenticationOptions{
+			Method:           options.ClientSecret,
+			ClientSecretFile: clientSecret,
+		},
 		OIDCConfig: options.OIDCOptions{
 			IssuerURL:     msIssuerURL,
 			SkipDiscovery: true,
@@ -100,12 +111,15 @@ func TestURLsCorrectlyParsed(t *testing.T) {
 	g := NewWithT(t)
 
 	providerConfig := options.Provider{
-		ID:               providerID,
-		Type:             "oidc",
-		ClientID:         clientID,
-		ClientSecretFile: clientSecret,
-		LoginURL:         msAuthURL,
-		RedeemURL:        msTokenURL,
+		ID:       providerID,
+		Type:     "oidc",
+		ClientID: clientID,
+		AuthenticationConfig: options.AuthenticationOptions{
+			Method:           options.ClientSecret,
+			ClientSecretFile: clientSecret,
+		},
+		LoginURL:  msAuthURL,
+		RedeemURL: msTokenURL,
 		OIDCConfig: options.OIDCOptions{
 			IssuerURL:     msIssuerURL,
 			SkipDiscovery: true,
@@ -165,14 +179,17 @@ func TestScope(t *testing.T) {
 
 	for _, tc := range testCases {
 		providerConfig := options.Provider{
-			ID:               providerID,
-			Type:             tc.configuredType,
-			ClientID:         clientID,
-			ClientSecretFile: clientSecret,
-			LoginURL:         msAuthURL,
-			RedeemURL:        msTokenURL,
-			Scope:            tc.configuredScope,
-			AllowedGroups:    tc.allowedGroups,
+			ID:       providerID,
+			Type:     tc.configuredType,
+			ClientID: clientID,
+			AuthenticationConfig: options.AuthenticationOptions{
+				Method:           options.ClientSecret,
+				ClientSecretFile: clientSecret,
+			},
+			LoginURL:      msAuthURL,
+			RedeemURL:     msTokenURL,
+			Scope:         tc.configuredScope,
+			AllowedGroups: tc.allowedGroups,
 			OIDCConfig: options.OIDCOptions{
 				IssuerURL:     msIssuerURL,
 				SkipDiscovery: true,
@@ -248,12 +265,15 @@ func TestEmailClaimCorrectlySet(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			providerConfig := options.Provider{
-				ID:               providerID,
-				Type:             "oidc",
-				ClientID:         clientID,
-				ClientSecretFile: clientSecret,
-				LoginURL:         msAuthURL,
-				RedeemURL:        msTokenURL,
+				ID:       providerID,
+				Type:     "oidc",
+				ClientID: clientID,
+				AuthenticationConfig: options.AuthenticationOptions{
+					Method:           options.ClientSecret,
+					ClientSecretFile: clientSecret,
+				},
+				LoginURL:  msAuthURL,
+				RedeemURL: msTokenURL,
 				OIDCConfig: options.OIDCOptions{
 					IssuerURL:     msIssuerURL,
 					SkipDiscovery: true,


### PR DESCRIPTION
## Description

Support client_assertion in generic OIDC provider

## Motivation and Context

Enterprise oidc often prefers client assertions instead of clientid/clientsecret auth on redeem and refresh
Also: #1834 

## How Has This Been Tested?

Untested for now
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.
