### PR TITLE
Allow unverified email also in default implementation

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -387,7 +387,7 @@ func buildSessionChain(opts *options.Options, provider providers.Provider, sessi
 
 		for _, verifier := range opts.GetJWTBearerVerifiers() {
 			sessionLoaders = append(sessionLoaders,
-				middlewareapi.CreateTokenToSessionFunc(verifier.Verify))
+				middlewareapi.CreateTokenToSessionFunc(verifier.Verify, provider.Data().AllowUnverifiedEmail))
 		}
 
 		chain = chain.Append(middleware.NewJwtSessionLoader(sessionLoaders))

--- a/pkg/apis/middleware/session.go
+++ b/pkg/apis/middleware/session.go
@@ -17,7 +17,7 @@ type VerifyFunc func(ctx context.Context, token string) (*oidc.IDToken, error)
 
 // CreateTokenToSessionFunc provides a handler that is a default implementation
 // for converting a JWT into a session.
-func CreateTokenToSessionFunc(verify VerifyFunc) TokenToSessionFunc {
+func CreateTokenToSessionFunc(verify VerifyFunc, allowUnverifiedEmail bool) TokenToSessionFunc {
 	return func(ctx context.Context, token string) (*sessionsapi.SessionState, error) {
 		var claims struct {
 			Subject           string   `json:"sub"`
@@ -40,7 +40,7 @@ func CreateTokenToSessionFunc(verify VerifyFunc) TokenToSessionFunc {
 			claims.Email = claims.Subject
 		}
 
-		if claims.Verified != nil && !*claims.Verified {
+		if claims.Verified != nil && !*claims.Verified && !allowUnverifiedEmail {
 			return nil, fmt.Errorf("email in id_token (%s) isn't verified", claims.Email)
 		}
 

--- a/providers/provider_default.go
+++ b/providers/provider_default.go
@@ -142,7 +142,7 @@ func (p *ProviderData) RefreshSession(_ context.Context, _ *sessions.SessionStat
 // CreateSessionFromToken converts Bearer IDTokens into sessions
 func (p *ProviderData) CreateSessionFromToken(ctx context.Context, token string) (*sessions.SessionState, error) {
 	if p.Verifier != nil {
-		return middleware.CreateTokenToSessionFunc(p.Verifier.Verify)(ctx, token)
+		return middleware.CreateTokenToSessionFunc(p.Verifier.Verify, p.AllowUnverifiedEmail)(ctx, token)
 	}
 	return nil, ErrNotImplemented
 }


### PR DESCRIPTION
Hey folks, this is my first PR in this great project.

## Description
The original issue about "Ability to ignore unverified email" #117 is from 2019-05-31. It was solved by #159. 

Later (2021-04-12) another issue #1152 was opened regarding this topic. This time the issue is, that tokens with `"email_verified": false` in the token are getting rejected, when a client is coming from audience which is allowed in `extra_jwt_issuers` and `insecure_oidc_allow_unverified_email` was set to `true`.

@NickMeves commented
> Any extra OIDC bearer verifiers added with extra-jwt-issuers don't use those and use a generic implementation. Long term, when we roll out structured configs, we want to make the bearer verifier list a list of full providers that can take in full options.

I also have this issue for the same reason and decided to dive a bit deeper into this issue. My solution fixes the issue for `extra-jwt-issuers` as well by using the same property `insecure_oidc_allow_unverified_email`. I just put an additional parameter to middleware session function (`session.go:20`):

```CreateTokenToSessionFunc(verify VerifyFunc, allowUnverifiedEmail bool)``` 

Afterwards the flag is used in line 43 (like #159 added it in `providers/oidc.go:123`).

`CreateTokenToSessionFunc` is called from `oauthproxy.go:390` and `providers/provider_default.go:145`
- `oauthproxy.go:390`:  It was possible to get the provider data and the flag by using `provider.Data().AllowUnverifiedEmail`.
- `providers/provider_default.go:145`: The provider data was already available so it was possible to get the flag by using `p.AllowUnverifiedEmail`

## Motivation and Context
By the documentation of `insecure-oidc-allow-unverified-email` which says
> don't fail if an email address in an id_token is not verified

I assumed that allowing unverified emails also works for client which are allowed by the `extra-jwt-issuers` property. But this was not the case. With this PR the issue is solved for `extra-jwt-issuers` as well - we don not even have to change the documentation or like @NickMeves said "Our documentation admittedly needs some love 😅"

## How Has This Been Tested?
1. Unit tests: Additional tests in `pkg/middleware/jwt_session_test.go` 
2. Local environment
I set up a local environment (with keycloak). I created a `userA` with `"email_verified": false` and `audience-a` and another `userB` with `"email_verified": false` and `audience-b`. I also configured a client for `audience-a`.
a) In the configuration I did not put `extra_jwt_issuers` or `insecure_oidc_allow_unverified_email`
userA: denied, userB: denied
b) I added `insecure_oidc_allow_unverified_email=true`
userA: allowed, userB: denied
c) I added `audience-b` as an `extra_jwt_issuers`
userA: allowed, userB: allowed
d) I set `insecure_oidc_allow_unverified_email=false`
userA: denied, userB: denied

## Checklist:
- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
- [x] I have written tests for my code changes.

@NickMeves I would really appreciate your feedback.

Have a great day.