### PR TITLE
feat: add role based authorization when using Microsoft Entra ID App Registration roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## Changes since v7.6.0
 
 - [#2539](https://github.com/oauth2-proxy/oauth2-proxy/pull/2539) pkg/http: Fix leaky test (@isodude)
+- [#2309](https://github.com/oauth2-proxy/oauth2-proxy/pull/2309) Add role based authorization when using Microsoft Entra ID App Registration roles (@jgmartinez)
 
 # V7.6.0
 

--- a/docs/docs/configuration/overview.md
+++ b/docs/docs/configuration/overview.md
@@ -136,6 +136,7 @@ An example [oauth2-proxy.cfg](https://github.com/oauth2-proxy/oauth2-proxy/blob/
 | `--oidc-jwks-url` | string | OIDC JWKS URI for token verification; required if OIDC discovery is disabled | |
 | `--oidc-email-claim` | string | which OIDC claim contains the user's email | `"email"` |
 | `--oidc-groups-claim` | string | which OIDC claim contains the user groups | `"groups"` |
+| `--oidc-roles-claim` | string | which OIDC claim contains the user roles | `"roles"` |
 | `--oidc-audience-claim` | string | which OIDC claim contains the audience | `"aud"` |
 | `--oidc-extra-audience` | string \| list | additional audiences which are allowed to pass verification | `"[]"` |
 | `--pass-access-token` | bool | pass OAuth access_token to upstream via X-Forwarded-Access-Token header. When used with `--set-xauthrequest` this adds the X-Auth-Request-Access-Token header to the response | false |

--- a/docs/docs/configuration/overview.md
+++ b/docs/docs/configuration/overview.md
@@ -205,7 +205,7 @@ An example [oauth2-proxy.cfg](https://github.com/oauth2-proxy/oauth2-proxy/blob/
 | `--upstream` | string \| list | the http url(s) of the upstream endpoint, file:// paths for static files or `static://<status_code>` for static response. Routing is based on the path | |
 | `--upstream-timeout` | duration | maximum amount of time the server will wait for a response from the upstream | 30s |
 | `--allowed-group` | string \| list | restrict logins to members of this group (may be given multiple times) | |
-| `--allowed-role` | string \| list | restrict logins to users with this role (may be given multiple times). Only works with the keycloak-oidc provider. | |
+| `--allowed-role` | string \| list | restrict logins to users with this role (may be given multiple times). Only works with the keycloak-oidc provider or with Microsoft Entra ID App Registration roles. | |
 | `--validate-url` | string | Access token validation endpoint | |
 | `--version` | n/a | print version string | |
 | `--whitelist-domain` | string \| list | allowed domains for redirection after authentication. Prefix domain with a `.` or a `*.` to allow subdomains (e.g. `.example.com`, `*.example.com`)&nbsp;[^2] | |

--- a/docs/docs/configuration/providers/azure.md
+++ b/docs/docs/configuration/providers/azure.md
@@ -37,6 +37,13 @@ title: Azure
    --oidc-issuer-url=https://login.microsoftonline.com/{tenant-id}/v2.0
 ```
 
+
+***Roles***:
+
+Microsoft Entra ID (Former Azure AD) adds a `roles` claim when App Roles are defined in the App registrations and assigned to the logged in users. Microsoft Entra ID roles can be autorized usign the `--allowed-role=<role name>` option, allowing only users from the defined list of roles (non-exclusive).
+
+To create an App Role in Microsoft Entra ID, go to your **App registration** -> **App Roles** -> **Create App Role**. The value you assign in the `Value` field is the one that will be included in the claim. Then, to assign a role to a user, group or Service Principal, go to the **Enterprise Application** of your **App Registration** -> **Users and Groups** -> **Add User/Group**. From that screen, you can assign the role.
+
 ***Notes***:
 - When using v2.0 Azure Auth endpoint (`https://login.microsoftonline.com/{tenant-id}/v2.0`) as `--oidc_issuer_url`, in conjunction
   with `--resource` flag, be sure to append `/.default` at the end of the resource name. See

--- a/docs/docs/configuration/providers/azure.md
+++ b/docs/docs/configuration/providers/azure.md
@@ -40,7 +40,7 @@ title: Azure
 
 ***Roles***:
 
-Microsoft Entra ID (Former Azure AD) adds a `roles` claim when App Roles are defined in the App registrations and assigned to the logged in users. Microsoft Entra ID roles can be autorized usign the `--allowed-role=<role name>` option, allowing only users from the defined list of roles (non-exclusive).
+Microsoft Entra ID (Former Azure AD) adds a `roles` claim when App Roles are defined in the App registrations and assigned to the logged in users. Microsoft Entra ID roles can be authorized using the `--allowed-role=<role name>` option, allowing only users from the defined list of roles (non-exclusive).
 
 To create an App Role in Microsoft Entra ID, go to your **App registration** -> **App Roles** -> **Create App Role**. The value you assign in the `Value` field is the one that will be included in the claim. Then, to assign a role to a user, group or Service Principal, go to the **Enterprise Application** of your **App Registration** -> **Users and Groups** -> **Add User/Group**. From that screen, you can assign the role.
 

--- a/main_test.go
+++ b/main_test.go
@@ -78,6 +78,7 @@ providers:
     tenant: common
   oidcConfig:
     groupsClaim: groups
+    rolesClaim: roles
     emailClaim: email
     userIDClaim: email
     insecureSkipNonce: true
@@ -158,6 +159,7 @@ redirect_url="http://localhost:4180/oauth2/callback"
 				},
 				OIDCConfig: options.OIDCOptions{
 					GroupsClaim:       "groups",
+					RolesClaim:        "roles",
 					EmailClaim:        "email",
 					UserIDClaim:       "email",
 					AudienceClaims:    []string{"aud"},

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -1138,6 +1138,7 @@ func authOnlyAuthorize(req *http.Request, s *sessionsapi.SessionState) bool {
 
 	constraints := []func(*http.Request, *sessionsapi.SessionState) bool{
 		checkAllowedGroups,
+		checkAllowedRoles,
 		checkAllowedEmailDomains,
 		checkAllowedEmails,
 	}
@@ -1208,6 +1209,23 @@ func checkAllowedGroups(req *http.Request, s *sessionsapi.SessionState) bool {
 	}
 
 	return false
+}
+
+// checkAllowedRoles allow secondary role restrictions based on the `allowed_roles`
+// querystring parameter
+func checkAllowedRoles(req *http.Request, s *sessionsapi.SessionState) bool {
+	allowedRoles := extractAllowedEntities(req, "allowed_roles")
+	if len(allowedRoles) == 0 {
+		return true
+	}
+	for _, role := range s.Roles {
+		if _, ok := allowedRoles[role]; ok {
+			return true
+		}
+	}
+
+	return false
+
 }
 
 // checkAllowedEmails allow email restrictions based on the `allowed_emails`

--- a/pkg/apis/middleware/session.go
+++ b/pkg/apis/middleware/session.go
@@ -25,6 +25,7 @@ func CreateTokenToSessionFunc(verify VerifyFunc) TokenToSessionFunc {
 			Verified          *bool    `json:"email_verified"`
 			PreferredUsername string   `json:"preferred_username"`
 			Groups            []string `json:"groups"`
+			Roles             []string `json:"roles"`
 		}
 
 		idToken, err := verify(ctx, token)
@@ -48,13 +49,13 @@ func CreateTokenToSessionFunc(verify VerifyFunc) TokenToSessionFunc {
 			Email:             claims.Email,
 			User:              claims.Subject,
 			Groups:            claims.Groups,
+			Roles:             claims.Roles,
 			PreferredUsername: claims.PreferredUsername,
 			AccessToken:       token,
 			IDToken:           token,
 			RefreshToken:      "",
 			ExpiresOn:         &idToken.Expiry,
 		}
-
 		return newSession, nil
 	}
 }

--- a/pkg/apis/middleware/session.go
+++ b/pkg/apis/middleware/session.go
@@ -56,6 +56,7 @@ func CreateTokenToSessionFunc(verify VerifyFunc) TokenToSessionFunc {
 			RefreshToken:      "",
 			ExpiresOn:         &idToken.Expiry,
 		}
+
 		return newSession, nil
 	}
 }

--- a/pkg/apis/options/legacy_options.go
+++ b/pkg/apis/options/legacy_options.go
@@ -676,6 +676,7 @@ func (l *LegacyProvider) convert() (Providers, error) {
 		ValidateURL:              l.ValidateURL,
 		Scope:                    l.Scope,
 		AllowedGroups:            l.AllowedGroups,
+		AllowedRoles:             l.AllowedRoles,
 		CodeChallengeMethod:      l.CodeChallengeMethod,
 		BackendLogoutURL:         l.BackendLogoutURL,
 	}

--- a/pkg/apis/options/legacy_options.go
+++ b/pkg/apis/options/legacy_options.go
@@ -55,6 +55,7 @@ func NewLegacyOptions() *LegacyOptions {
 			UserIDClaim:           "email",
 			OIDCEmailClaim:        "email",
 			OIDCGroupsClaim:       "groups",
+			OIDCRolesClaim:        "roles",
 			OIDCAudienceClaims:    []string{"aud"},
 			OIDCExtraAudiences:    []string{},
 			InsecureOIDCSkipNonce: true,
@@ -518,6 +519,7 @@ type LegacyProvider struct {
 	OIDCJwksURL                        string   `flag:"oidc-jwks-url" cfg:"oidc_jwks_url"`
 	OIDCEmailClaim                     string   `flag:"oidc-email-claim" cfg:"oidc_email_claim"`
 	OIDCGroupsClaim                    string   `flag:"oidc-groups-claim" cfg:"oidc_groups_claim"`
+	OIDCRolesClaim                     string   `flag:"oidc-roles-claim" cfg:"oidc_roles_claim"`
 	OIDCAudienceClaims                 []string `flag:"oidc-audience-claim" cfg:"oidc_audience_claims"`
 	OIDCExtraAudiences                 []string `flag:"oidc-extra-audience" cfg:"oidc_extra_audiences"`
 	LoginURL                           string   `flag:"login-url" cfg:"login_url"`
@@ -574,6 +576,7 @@ func legacyProviderFlagSet() *pflag.FlagSet {
 	flagSet.Bool("skip-oidc-discovery", false, "Skip OIDC discovery and use manually supplied Endpoints")
 	flagSet.String("oidc-jwks-url", "", "OpenID Connect JWKS URL (ie: https://www.googleapis.com/oauth2/v3/certs)")
 	flagSet.String("oidc-groups-claim", OIDCGroupsClaim, "which OIDC claim contains the user groups")
+	flagSet.String("oidc-roles-claim", OIDCRolesClaim, "which OIDC claim contains the user roles")
 	flagSet.String("oidc-email-claim", OIDCEmailClaim, "which OIDC claim contains the user's email")
 	flagSet.StringSlice("oidc-audience-claim", OIDCAudienceClaims, "which OIDC claims are used as audience to verify against client id")
 	flagSet.StringSlice("oidc-extra-audience", []string{}, "additional audiences allowed to pass audience verification")
@@ -692,6 +695,7 @@ func (l *LegacyProvider) convert() (Providers, error) {
 		UserIDClaim:                    l.UserIDClaim,
 		EmailClaim:                     l.OIDCEmailClaim,
 		GroupsClaim:                    l.OIDCGroupsClaim,
+		RolesClaim:                     l.OIDCRolesClaim,
 		AudienceClaims:                 l.OIDCAudienceClaims,
 		ExtraAudiences:                 l.OIDCExtraAudiences,
 	}

--- a/pkg/apis/options/load_test.go
+++ b/pkg/apis/options/load_test.go
@@ -43,6 +43,7 @@ var _ = Describe("Load", func() {
 			UserIDClaim:           "email",
 			OIDCEmailClaim:        "email",
 			OIDCGroupsClaim:       "groups",
+			OIDCRolesClaim:        "roles",
 			OIDCAudienceClaims:    []string{"aud"},
 			InsecureOIDCSkipNonce: true,
 		},

--- a/pkg/apis/options/providers.go
+++ b/pkg/apis/options/providers.go
@@ -6,6 +6,9 @@ const (
 
 	// OIDCGroupsClaim is the generic groups claim used by the OIDC provider.
 	OIDCGroupsClaim = "groups"
+
+	// OIDCRolesClaim is the generic roles claim used by the OIDC provider.
+	OIDCRolesClaim = "roles"
 )
 
 // OIDCAudienceClaims is the generic audience claim list used by the OIDC provider.
@@ -233,6 +236,9 @@ type OIDCOptions struct {
 	// GroupsClaim indicates which claim contains the user groups
 	// default set to 'groups'
 	GroupsClaim string `json:"groupsClaim,omitempty"`
+	// RolesClaim indicates which claim contains the user roles
+	// default set to 'roles'
+	RolesClaim string `json:"rolesClaim,omitempty"`
 	// UserIDClaim indicates which claim contains the user ID
 	// default set to 'email'
 	UserIDClaim string `json:"userIDClaim,omitempty"`
@@ -267,6 +273,7 @@ func providerDefaults() Providers {
 				UserIDClaim:                  OIDCEmailClaim, // Deprecated: Use OIDCEmailClaim
 				EmailClaim:                   OIDCEmailClaim,
 				GroupsClaim:                  OIDCGroupsClaim,
+				RolesClaim:                   OIDCRolesClaim,
 				AudienceClaims:               OIDCAudienceClaims,
 				ExtraAudiences:               []string{},
 			},

--- a/pkg/apis/options/providers.go
+++ b/pkg/apis/options/providers.go
@@ -81,6 +81,8 @@ type Provider struct {
 	Scope string `json:"scope,omitempty"`
 	// AllowedGroups is a list of restrict logins to members of this group
 	AllowedGroups []string `json:"allowedGroups,omitempty"`
+	// AllowedRoles is a list of restrict logins to users with role
+	AllowedRoles []string `json:"allowedRoles,omitempty"`
 	// The code challenge method
 	CodeChallengeMethod string `json:"code_challenge_method,omitempty"`
 

--- a/pkg/apis/sessions/session_state.go
+++ b/pkg/apis/sessions/session_state.go
@@ -27,6 +27,7 @@ type SessionState struct {
 	Email             string   `msgpack:"e,omitempty"`
 	User              string   `msgpack:"u,omitempty"`
 	Groups            []string `msgpack:"g,omitempty"`
+	Roles             []string `msgpack:"r,omitempty"`
 	PreferredUsername string   `msgpack:"pu,omitempty"`
 
 	// Internal helpers, not serialized
@@ -120,6 +121,9 @@ func (s *SessionState) String() string {
 	if len(s.Groups) > 0 {
 		o += fmt.Sprintf(" groups:%v", s.Groups)
 	}
+	if len(s.Roles) > 0 {
+		o += fmt.Sprintf(" roles:%v", s.Roles)
+	}
 	return o + "}"
 }
 
@@ -146,6 +150,10 @@ func (s *SessionState) GetClaim(claim string) []string {
 		groups := make([]string, len(s.Groups))
 		copy(groups, s.Groups)
 		return groups
+	case "roles":
+		roles := make([]string, len(s.Roles))
+		copy(roles, s.Roles)
+		return roles
 	case "preferred_username":
 		return []string{s.PreferredUsername}
 	default:

--- a/providers/azure.go
+++ b/providers/azure.go
@@ -277,6 +277,10 @@ func (p *AzureProvider) extractClaimsIntoSession(ctx context.Context, session *s
 		session.Groups = s.Groups
 	}
 
+	if s.Roles != nil {
+		session.Roles = s.Roles
+	}
+
 	return nil
 }
 

--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -43,6 +43,10 @@ func NewOIDCProvider(p *ProviderData, opts options.OIDCOptions) *OIDCProvider {
 		oidcProviderDefaults.scope += " groups"
 	}
 
+	if len(p.AllowedRoles) > 0 {
+		oidcProviderDefaults.scope += " roles"
+	}
+
 	p.setProviderDefaults(oidcProviderDefaults)
 	p.getAuthorizationHeaderFunc = makeOIDCHeader
 

--- a/providers/provider_data.go
+++ b/providers/provider_data.go
@@ -47,12 +47,17 @@ type ProviderData struct {
 	UserClaim                string
 	EmailClaim               string
 	GroupsClaim              string
+	RolesClaim               string
 	Verifier                 internaloidc.IDTokenVerifier
 	SkipClaimsFromProfileURL bool
 
 	// Universal Group authorization data structure
 	// any provider can set to consume
 	AllowedGroups map[string]struct{}
+
+	// Universal Role authorization data structure
+	// any provider can set to consume
+	AllowedRoles map[string]struct{}
 
 	getAuthorizationHeaderFunc func(string) http.Header
 	loginURLParameterDefaults  url.Values
@@ -181,6 +186,15 @@ func (p *ProviderData) setAllowedGroups(groups []string) {
 	}
 }
 
+// setAllowedRoles organizes a role list into the AllowedRoles map
+// to be consumed by Authorize implementations
+func (p *ProviderData) setAllowedRoles(roles []string) {
+	p.AllowedRoles = make(map[string]struct{}, len(roles))
+	for _, role := range roles {
+		p.AllowedRoles[role] = struct{}{}
+	}
+}
+
 type providerDefaults struct {
 	name        string
 	loginURL    *url.URL
@@ -258,6 +272,7 @@ func (p *ProviderData) buildSessionFromClaims(rawIDToken, accessToken string) (*
 		{p.UserClaim, &ss.User},
 		{p.EmailClaim, &ss.Email},
 		{p.GroupsClaim, &ss.Groups},
+		{p.RolesClaim, &ss.Roles},
 		// TODO (@NickMeves) Deprecate for dynamic claim to session mapping
 		{"preferred_username", &ss.PreferredUsername},
 	} {

--- a/providers/provider_default.go
+++ b/providers/provider_default.go
@@ -116,12 +116,18 @@ func (p *ProviderData) EnrichSession(_ context.Context, _ *sessions.SessionState
 // Authorize performs global authorization on an authenticated session.
 // This is not used for fine-grained per route authorization rules.
 func (p *ProviderData) Authorize(_ context.Context, s *sessions.SessionState) (bool, error) {
-	if len(p.AllowedGroups) == 0 {
+	if len(p.AllowedGroups) == 0 && len(p.AllowedRoles) == 0 {
 		return true, nil
 	}
 
 	for _, group := range s.Groups {
 		if _, ok := p.AllowedGroups[group]; ok {
+			return true, nil
+		}
+	}
+
+	for _, role := range s.Roles {
+		if _, ok := p.AllowedRoles[role]; ok {
 			return true, nil
 		}
 	}

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -158,6 +158,7 @@ func newProviderDataFromConfig(providerConfig options.Provider) (*ProviderData, 
 	}
 
 	p.setAllowedGroups(providerConfig.AllowedGroups)
+	p.setAllowedRoles(providerConfig.AllowedRoles)
 
 	p.BackendLogoutURL = providerConfig.BackendLogoutURL
 

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -138,6 +138,7 @@ func newProviderDataFromConfig(providerConfig options.Provider) (*ProviderData, 
 	p.AllowUnverifiedEmail = providerConfig.OIDCConfig.InsecureAllowUnverifiedEmail
 	p.EmailClaim = providerConfig.OIDCConfig.EmailClaim
 	p.GroupsClaim = providerConfig.OIDCConfig.GroupsClaim
+	p.RolesClaim = providerConfig.OIDCConfig.RolesClaim
 	p.SkipClaimsFromProfileURL = providerConfig.SkipClaimsFromProfileURL
 
 	// Set PKCE enabled or disabled based on discovery and force options


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Microsoft Entra ID allows you to assign roles scoped for specific applications. This features enables role based authentication via the `--allowed-roles` flag when using App Registration roles in Azure.

<!--- Describe your changes in detail -->

We have a complex organizational setup that requires us to assign roles to the consumers of our applications. In a similar fashion as done with Groups, this change also takes the roles claim from the IDToken sent by Azure, and sets them up in the user session. 

If allowed roles is set, only users with the correct `role` in the `roles`claim (or whatever is setup in OIDCRolesClaim option) will be allowed to authenticate. This can be combined with the groups option or used standalone, depending on the user requirements.

Roles are application specific, so they are mapped with the ClientID used by the proxy. 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Role based auth was only available for the Keycloak provider. This change also enables leveraging the roles claim set by Microsoft Entra ID when App Roles are assigned to users.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

There are tests written, the same way as Group tests, and we are also using it in our production setup, with a diverse range of consumers.

There are four new tests in the `provider_tests.go` file and we have tested it in a Kubernetes setup, using Oauth2 Proxy as an authentication proxy for our NGINX ingresses.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My change requires a change to the documentation or CHANGELOG.
- [X] I have updated the documentation/CHANGELOG accordingly.
- [X] I have created a feature (non-master) branch for my PR.
- [X] I have written tests for my code changes.
