### PR TITLE
NGINX return 403 for sign_in (#2322)

### DIFF
--- a/contrib/local-environment/nginx.conf
+++ b/contrib/local-environment/nginx.conf
@@ -20,7 +20,7 @@ server {
 
   # If the auth_request denies the request (401), redirect to the sign_in page
   # and include the final rd URL back to the user's original request.
-  error_page 401 = http://oauth2-proxy.oauth2-proxy.localhost/oauth2/sign_in?rd=$scheme://$host$request_uri;
+  error_page 401 =403 http://oauth2-proxy.oauth2-proxy.localhost/oauth2/sign_in?rd=$scheme://$host$request_uri;
 
   # Alternatively send the request to `start` to skip the provider button
   # error_page 401 = http://oauth2-proxy.oauth2-proxy.localhost/oauth2/start?rd=$scheme://$host$request_uri;
@@ -54,7 +54,7 @@ server {
 
     # If the auth_request denies the request (401), redirect to the sign_in page
     # and include the final rd URL back to the user's original request.
-    error_page 401 = http://oauth2-proxy.oauth2-proxy.localhost/oauth2/sign_in?rd=$scheme://$host$request_uri;
+    error_page 401 =403 http://oauth2-proxy.oauth2-proxy.localhost/oauth2/sign_in?rd=$scheme://$host$request_uri;
 
     # Alternatively send the request to `start` to skip the provider button
     # error_page 401 = http://oauth2-proxy.oauth2-proxy.localhost/oauth2/start?rd=$scheme://$host$request_uri;

--- a/docs/docs/configuration/overview.md
+++ b/docs/docs/configuration/overview.md
@@ -369,7 +369,7 @@ server {
 
   location / {
     auth_request /oauth2/auth;
-    error_page 401 = /oauth2/sign_in;
+    error_page 401 =403 /oauth2/sign_in;
 
     # pass information via X-User and X-Email headers to backend,
     # requires running with --set-xauthrequest flag

--- a/docs/versioned_docs/version-7.5.x/configuration/overview.md
+++ b/docs/versioned_docs/version-7.5.x/configuration/overview.md
@@ -370,7 +370,7 @@ server {
 
   location / {
     auth_request /oauth2/auth;
-    error_page 401 = /oauth2/sign_in;
+    error_page 401 =403 /oauth2/sign_in;
 
     # pass information via X-User and X-Email headers to backend,
     # requires running with --set-xauthrequest flag


### PR DESCRIPTION
Return 403 for sign_in when running behind a NGINX reverse proxy.

## Description

fixes #2322

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.
