### PR TITLE
Don't run the nightly build and push job in forked repositories

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # only run this build in the main repository, not in forks
+    if: github.repository == 'oauth2-proxy/oauth2-proxy'
     steps:
     - name: Check out code
       uses: actions/checkout@v3


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The new nightly build-and-push job introduced by #2297 will currently attempt to run in forks of the oauth2-proxy repo as well as in the main repository, but will fail in such cases as the fork does not have access to the secrets containing the `quay.io` credentials.  This PR adds a check to the workflow file to only run the job within the main `oauth2-ptoxy` repository.


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
- (N/A) I have written tests for my code changes.
