### PR TITLE
Fix duplicate query parameters

### DIFF
--- a/docs/versioned_docs/version-7.3.x/features/endpoints.md
+++ b/docs/versioned_docs/version-7.3.x/features/endpoints.md
@@ -39,7 +39,7 @@ BEWARE that the domain you want to redirect to (`my-oidc-provider.example.com` i
 
 This endpoint returns 202 Accepted response or a 401 Unauthorized response.
 
-It can be configured using the following query parameters query parameters:
+It can be configured using the following query parameters:
 - `allowed_groups`: comma separated list of allowed groups
 - `allowed_email_domains`: comma separated list of allowed email domains
 - `allowed_emails`: comma separated list of allowed emails

--- a/docs/versioned_docs/version-7.4.x/features/endpoints.md
+++ b/docs/versioned_docs/version-7.4.x/features/endpoints.md
@@ -39,7 +39,7 @@ BEWARE that the domain you want to redirect to (`my-oidc-provider.example.com` i
 
 This endpoint returns 202 Accepted response or a 401 Unauthorized response.
 
-It can be configured using the following query parameters query parameters:
+It can be configured using the following query parameters:
 - `allowed_groups`: comma separated list of allowed groups
 - `allowed_email_domains`: comma separated list of allowed email domains
 - `allowed_emails`: comma separated list of allowed emails

--- a/docs/versioned_docs/version-7.5.x/features/endpoints.md
+++ b/docs/versioned_docs/version-7.5.x/features/endpoints.md
@@ -41,7 +41,7 @@ BEWARE that the domain you want to redirect to (`my-oidc-provider.example.com` i
 
 This endpoint returns 202 Accepted response or a 401 Unauthorized response.
 
-It can be configured using the following query parameters query parameters:
+It can be configured using the following query parameters:
 - `allowed_groups`: comma separated list of allowed groups
 - `allowed_email_domains`: comma separated list of allowed email domains
 - `allowed_emails`: comma separated list of allowed emails


### PR DESCRIPTION
Fix duplicate query parameters in versioned documentation. It is no longer present in "next" documentation.