### PR TITLE
oidc provider: do not set `groups` scope when allowed group is set

### DIFF
--- a/docs/docs/configuration/overview.md
+++ b/docs/docs/configuration/overview.md
@@ -175,7 +175,7 @@ An example [oauth2-proxy.cfg](https://github.com/oauth2-proxy/oauth2-proxy/blob/
 | `--request-logging-format` | string | Template for request log lines | see [Logging Configuration](#logging-configuration) |
 | `--resource` | string | The resource that is protected (Azure AD only) | |
 | `--reverse-proxy` | bool | are we running behind a reverse proxy, controls whether headers like X-Real-IP are accepted and allows X-Forwarded-{Proto,Host,Uri} headers to be used on redirect selection | false |
-| `--scope` | string | OAuth scope specification | |
+| `--scope` | string | OAuth scope specification | `openid email profile` |
 | `--session-cookie-minimal` | bool | strip OAuth tokens from cookie session stores if they aren't needed (cookie session store only) | false |
 | `--session-store-type` | string | [Session data storage backend](sessions.md); redis or cookie | cookie |
 | `--set-xauthrequest` | bool | set X-Auth-Request-User, X-Auth-Request-Groups, X-Auth-Request-Email and X-Auth-Request-Preferred-Username response headers (useful in Nginx auth_request mode). When used with `--pass-access-token`, X-Auth-Request-Access-Token is added to response headers. | false |

--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -39,10 +39,6 @@ func NewOIDCProvider(p *ProviderData, opts options.OIDCOptions) *OIDCProvider {
 		scope:       oidcDefaultScope,
 	}
 
-	if len(p.AllowedGroups) > 0 {
-		oidcProviderDefaults.scope += " groups"
-	}
-
 	p.setProviderDefaults(oidcProviderDefaults)
 	p.getAuthorizationHeaderFunc = makeOIDCHeader
 

--- a/providers/providers_test.go
+++ b/providers/providers_test.go
@@ -137,13 +137,6 @@ func TestScope(t *testing.T) {
 			expectedScope:   "openid email profile",
 		},
 		{
-			name:            "oidc: with no scope provided and groups",
-			configuredType:  "oidc",
-			configuredScope: "",
-			expectedScope:   "openid email profile groups",
-			allowedGroups:   []string{"foo"},
-		},
-		{
 			name:            "oidc: with a configured scope provided",
 			configuredType:  "oidc",
 			configuredScope: "openid",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently, generic `oidc` provider includes `groups` scope when `allowed-group` is specified. This field is not compliant with OIDC specification, which allow only `profile`, `email`, `address`, `phone`:
https://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims

Resolves https://github.com/oauth2-proxy/oauth2-proxy/issues/1604

<!--- Describe your changes in detail -->

## Motivation and Context
This change will allow OIDC-complaint providers to consume appropriate defaults.

## How Has This Been Tested?
This has been tested with generic OIDC provider that targets Azure App Registration with default scope and `allowed-group` set. Azure doesn't support `groups` and fails on defaults on current master branch.
```
  - --provider=oidc
  - --client-id=<client-id>
  - --client-secret=<client-secret>
  - --oidc-issuer-url=https://login.microsoftonline.com/<tenant-id>/v2.0 
  - --allowed-group=<group-id>
```
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
