### PR TITLE
Update traefik docu and configs

### DIFF
--- a/contrib/local-environment/docker-compose-traefik.yaml
+++ b/contrib/local-environment/docker-compose-traefik.yaml
@@ -33,7 +33,7 @@ services:
   # Reverse proxy
   gateway:
     container_name: traefik
-    image: traefik:2.4.2
+    image: traefik:2.10.7
     volumes:
       - "./traefik:/etc/traefik"
     ports:

--- a/contrib/local-environment/oauth2-proxy-traefik.cfg
+++ b/contrib/local-environment/oauth2-proxy-traefik.cfg
@@ -2,7 +2,7 @@ http_address="0.0.0.0:4180"
 cookie_secret="OQINaROshtE9TcZkNAm-5Zs2Pv3xaWytBmc5W7sPX7w="
 provider="oidc"
 email_domains=["example.com"]
-oidc_issuer_url="http://dex.localhost:4190/dex"
+oidc_issuer_url="http://dex.localtest.me:4190/dex"
 client_secret="b2F1dGgyLXByb3h5LWNsaWVudC1zZWNyZXQK"
 client_id="oauth2-proxy"
 cookie_secure="false"

--- a/docs/docs/configuration/overview.md
+++ b/docs/docs/configuration/overview.md
@@ -514,7 +514,7 @@ Redirect to sign_in functionality provided without the use of `errors` middlewar
 http:
   routers:
     a-service-route-1:
-      rule: "Host(`a-service.example.com`, `b-service.example.com`) && PathPrefix(`/`)"
+      rule: "Host(`a-service.example.com`)"
       service: a-service-backend
       middlewares:
         - oauth-auth-redirect # redirects all unauthenticated to oauth2 signin
@@ -536,7 +536,7 @@ http:
             sans:
               - "*.example.com"
     services-oauth2-route:
-      rule: "Host(`a-service.example.com`, `b-service.example.com`) && PathPrefix(`/oauth2/`)"
+      rule: "Host(`a-service.example.com`) && PathPrefix(`/oauth2/`)"
       middlewares:
         - auth-headers
       service: oauth-backend
@@ -563,10 +563,6 @@ http:
       loadBalancer:
         servers:
           - url: http://172.16.0.2:7555
-    b-service-backend:
-      loadBalancer:
-        servers:
-          - url: http://172.16.0.3:7555
     oauth-backend:
       loadBalancer:
         servers:
@@ -586,14 +582,14 @@ http:
         frameDeny: true
     oauth-auth-redirect:
       forwardAuth:
-        address: https://oauth.example.com/
+        address: http://172.16.0.1:4180
         trustForwardHeader: true
         authResponseHeaders:
           - X-Auth-Request-Access-Token
           - Authorization
     oauth-auth-wo-redirect:
       forwardAuth:
-        address: https://oauth.example.com/oauth2/auth
+        address: http://172.16.0.1:4180/oauth2/auth
         trustForwardHeader: true
         authResponseHeaders:
           - X-Auth-Request-Access-Token

--- a/docs/versioned_docs/version-7.5.x/configuration/overview.md
+++ b/docs/versioned_docs/version-7.5.x/configuration/overview.md
@@ -514,7 +514,7 @@ Redirect to sign_in functionality provided without the use of `errors` middlewar
 http:
   routers:
     a-service-route-1:
-      rule: "Host(`a-service.example.com`, `b-service.example.com`) && PathPrefix(`/`)"
+      rule: "Host(`a-service.example.com`)"
       service: a-service-backend
       middlewares:
         - oauth-auth-redirect # redirects all unauthenticated to oauth2 signin
@@ -536,7 +536,7 @@ http:
             sans:
               - "*.example.com"
     services-oauth2-route:
-      rule: "Host(`a-service.example.com`, `b-service.example.com`) && PathPrefix(`/oauth2/`)"
+      rule: "Host(`a-service.example.com`) && PathPrefix(`/oauth2/`)"
       middlewares:
         - auth-headers
       service: oauth-backend
@@ -563,10 +563,6 @@ http:
       loadBalancer:
         servers:
           - url: http://172.16.0.2:7555
-    b-service-backend:
-      loadBalancer:
-        servers:
-          - url: http://172.16.0.3:7555
     oauth-backend:
       loadBalancer:
         servers:
@@ -586,14 +582,14 @@ http:
         frameDeny: true
     oauth-auth-redirect:
       forwardAuth:
-        address: https://oauth.example.com/
+        address: http://172.16.0.1:4180
         trustForwardHeader: true
         authResponseHeaders:
           - X-Auth-Request-Access-Token
           - Authorization
     oauth-auth-wo-redirect:
       forwardAuth:
-        address: https://oauth.example.com/oauth2/auth
+        address: http://172.16.0.1:4180/oauth2/auth
         trustForwardHeader: true
         authResponseHeaders:
           - X-Auth-Request-Access-Token


### PR DESCRIPTION
## Description

The example config is not working anymore and the documantion is a little bit confusion, because you use different urls for the oauth-backend and forwardAuth.address.

## Motivation and Context

`make local-env-traefik-up` is not working anymore

## How Has This Been Tested?

I tested it localy

## Checklist:

- [x] I have created a feature (non-master) branch for my PR.
