### PR TITLE
add grouping and scheduling

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,12 +1,21 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   semanticCommits: "auto",
+  schedule: [
+    "after 8am on sunday"
+  ],
   enabledManagers: [
     "dockerfile",
     "gomod",
     "github-actions",
     "npm",
     "regex",
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["dockerfile", "gomod", "github-actions", "npm", "regex"],
+      "groupName": "{{manager}}"
+    }
   ],
   customManagers: [
     {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Reduce the chattyness of renovate by grouping the PRs based on the dependency manager on only running it on sundays.

https://docs.renovatebot.com/configuration-options/#schedule

https://docs.renovatebot.com/noise-reduction/#package-grouping

https://github.com/renovatebot/renovate/discussions/16419