### PR TITLE
feat: add prefix to secretsource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Changes since v7.15.4
 
+- [#2451](https://github.com/oauth2-proxy/oauth2-proxy/pull/2451) Add support for prefix in SecretSource (@aslafy-z)
+
 # V7.15.4
 
 ## Release Highlights

--- a/docs/docs/configuration/alpha_config.md
+++ b/docs/docs/configuration/alpha_config.md
@@ -354,8 +354,8 @@ ClaimSource allows loading a header value from a claim within the session
 | Field | Type | Description |
 | ----- | ---- | ----------- |
 | `claim` | _string_ | Claim is the name of the claim in the session that the value should be<br/>loaded from. Available claims: `access_token` `id_token` `created_at`<br/>`expires_on` `refresh_token` `email` `user` `groups` `preferred_username`. |
-| `prefix` | _string_ | Prefix is an optional prefix that will be prepended to the value of the<br/>claim if it is non-empty. |
-| `basicAuthPassword` | _[SecretSource](#secretsource)_ | BasicAuthPassword converts this claim into a basic auth header.<br/>Note the value of claim will become the basic auth username and the<br/>basicAuthPassword will be used as the password value. |
+| `prefix` | _string_ | Prefix is an optional prefix that will be prepended to each claim value<br/>if it is non-empty. |
+| `basicAuthPassword` | _[SecretSource](#secretsource)_ | BasicAuthPassword converts this claim into a basic auth header.<br/>Note the value of claim will become the basic auth username and the<br/>basicAuthPassword will be used as the password value.<br/>The Prefix field is disregarded when this option is enabled. |
 
 ### GitHubOptions
 
@@ -424,9 +424,10 @@ make up the header value
 | `value` | _[]byte_ | Value expects a base64 encoded string value. |
 | `fromEnv` | _string_ | FromEnv expects the name of an environment variable. |
 | `fromFile` | _string_ | FromFile expects a path to a file containing the secret value. |
+| `prefix` | _string_ | Prefix is an optional prefix that will be prepended to the secret value<br/>if it is non-empty. |
 | `claim` | _string_ | Claim is the name of the claim in the session that the value should be<br/>loaded from. Available claims: `access_token` `id_token` `created_at`<br/>`expires_on` `refresh_token` `email` `user` `groups` `preferred_username`. |
-| `prefix` | _string_ | Prefix is an optional prefix that will be prepended to the value of the<br/>claim if it is non-empty. |
-| `basicAuthPassword` | _[SecretSource](#secretsource)_ | BasicAuthPassword converts this claim into a basic auth header.<br/>Note the value of claim will become the basic auth username and the<br/>basicAuthPassword will be used as the password value. |
+| `prefix` | _string_ | Prefix is an optional prefix that will be prepended to each claim value<br/>if it is non-empty. |
+| `basicAuthPassword` | _[SecretSource](#secretsource)_ | BasicAuthPassword converts this claim into a basic auth header.<br/>Note the value of claim will become the basic auth username and the<br/>basicAuthPassword will be used as the password value.<br/>The Prefix field is disregarded when this option is enabled. |
 
 ### KeycloakOptions
 
@@ -638,6 +639,7 @@ Only one source within the struct should be defined at any time.
 | `value` | _[]byte_ | Value expects a base64 encoded string value. |
 | `fromEnv` | _string_ | FromEnv expects the name of an environment variable. |
 | `fromFile` | _string_ | FromFile expects a path to a file containing the secret value. |
+| `prefix` | _string_ | Prefix is an optional prefix that will be prepended to the secret value<br/>if it is non-empty. |
 
 ### Server
 

--- a/pkg/apis/options/header.go
+++ b/pkg/apis/options/header.go
@@ -53,13 +53,14 @@ type ClaimSource struct {
 	// `expires_on` `refresh_token` `email` `user` `groups` `preferred_username`.
 	Claim string `yaml:"claim,omitempty"`
 
-	// Prefix is an optional prefix that will be prepended to the value of the
-	// claim if it is non-empty.
+	// Prefix is an optional prefix that will be prepended to each claim value
+	// if it is non-empty.
 	Prefix string `yaml:"prefix,omitempty"`
 
 	// BasicAuthPassword converts this claim into a basic auth header.
 	// Note the value of claim will become the basic auth username and the
 	// basicAuthPassword will be used as the password value.
+	// The Prefix field is disregarded when this option is enabled.
 	BasicAuthPassword *SecretSource `yaml:"basicAuthPassword,omitempty"`
 }
 

--- a/pkg/apis/options/secret_source.go
+++ b/pkg/apis/options/secret_source.go
@@ -11,6 +11,10 @@ type SecretSource struct {
 
 	// FromFile expects a path to a file containing the secret value.
 	FromFile string `yaml:"fromFile,omitempty"`
+
+	// Prefix is an optional prefix that will be prepended to the secret value
+	// if it is non-empty.
+	Prefix string `yaml:"prefix,omitempty"`
 }
 
 // EnsureDefaults sets any default values for SecretSource fields.

--- a/pkg/header/injector.go
+++ b/pkg/header/injector.go
@@ -73,7 +73,7 @@ func newSecretInjector(name string, source *options.SecretSource) (valueInjector
 	}
 
 	return newInjectorFunc(func(header http.Header, _ *sessionsapi.SessionState) {
-		header.Add(name, string(value))
+		header.Add(name, source.Prefix+string(value))
 	}), nil
 }
 
@@ -94,16 +94,6 @@ func newClaimInjector(name string, source *options.ClaimSource) (valueInjector, 
 				header.Add(name, fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(auth))))
 			}
 		}), nil
-	case source.Prefix != "":
-		return newInjectorFunc(func(header http.Header, session *sessionsapi.SessionState) {
-			claimValues := session.GetClaim(source.Claim)
-			for _, claim := range claimValues {
-				if claim == "" {
-					continue
-				}
-				header.Add(name, source.Prefix+claim)
-			}
-		}), nil
 	default:
 		return newInjectorFunc(func(header http.Header, session *sessionsapi.SessionState) {
 			claimValues := session.GetClaim(source.Claim)
@@ -111,7 +101,7 @@ func newClaimInjector(name string, source *options.ClaimSource) (valueInjector, 
 				if claim == "" {
 					continue
 				}
-				header.Add(name, claim)
+				header.Add(name, source.Prefix+claim)
 			}
 		}), nil
 	}

--- a/pkg/header/injector_test.go
+++ b/pkg/header/injector_test.go
@@ -94,6 +94,30 @@ var _ = Describe("Injector Suite", func() {
 				},
 				expectedErr: nil,
 			}),
+			Entry("with a prefixed static valued header from env", newInjectorTableInput{
+				headers: []options.Header{
+					{
+						Name: "Secret",
+						Values: []options.HeaderValue{
+							{
+								SecretSource: &options.SecretSource{
+									FromEnv: "SECRET_ENV",
+									Prefix:  "Bearer ",
+								},
+							},
+						},
+					},
+				},
+				initialHeaders: http.Header{
+					"foo": []string{"bar", "baz"},
+				},
+				session: &sessionsapi.SessionState{},
+				expectedHeaders: http.Header{
+					"foo":    []string{"bar", "baz"},
+					"Secret": []string{"Bearer super-secret-env"},
+				},
+				expectedErr: nil,
+			}),
 			Entry("with a claim valued header", newInjectorTableInput{
 				headers: []options.Header{
 					{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Add `Prefix` field in `SecretSource`.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I want to load a service account token into the `Authorization` header, with the `Bearer ` prefix.

## How Has This Been Tested?

- Unit tests.
- Tested in real world conditions
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
- [x] I have written tests for my code changes.
