### PR TITLE
fix linter version for publish workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -49,11 +49,11 @@ jobs:
 
     - name: Get dependencies
       run: |
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.50.0
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2
         curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
         chmod +x ./cc-test-reporter
 
-        # Install go depedencies
+        # Install go dependencies
         go mod download
 
     - name: Build Artifacts


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Upgrading the linter installed in the release publishing workflow to be compatible with go 1.21


## How Has This Been Tested?
Locally executed the linter using the Makefile

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- ~My change requires a change to the documentation or CHANGELOG.~
- ~I have updated the documentation/CHANGELOG accordingly.~
- [x] I have created a feature (non-master) branch for my PR.
- ~I have written tests for my code changes.~
