### PR TITLE
fix: regex substitution for $ signs in upstream path handling before running envsubst

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [#2605](https://github.com/oauth2-proxy/oauth2-proxy/pull/2605) fix: show login page on broken cookie (@Primexz)
 - [#2743](https://github.com/oauth2-proxy/oauth2-proxy/pull/2743) feat: allow use more possible google admin-sdk api scopes (@BobDu)
 - [#2359](https://github.com/oauth2-proxy/oauth2-proxy/pull/2359) feat: add SourceHut (sr.ht) provider(@bitfehler)
+-[#2524](https://github.com/oauth2-proxy/oauth2-proxy/pull/2524) fix: regex substitution for $ signs in upstream path handling before running envsubst (@dashkan / @tuunit)
 
 # V7.10.0
 

--- a/pkg/apis/options/load.go
+++ b/pkg/apis/options/load.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"regexp"
 	"strings"
 
 	"github.com/a8m/envsubst"
@@ -166,8 +167,21 @@ func loadAndParseYaml(configFileName string) ([]byte, error) {
 		return nil, fmt.Errorf("unable to load config file: %w", err)
 	}
 
+	// Convert the byte array to a string for regex processing
+	unparsedString := string(unparsedBuffer)
+
+	// Compile the regex pattern
+	regexPattern, err := regexp.Compile(`\$(\d+)`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compile regex pattern: %w", err)
+	}
+
+	substitutedString := regexPattern.ReplaceAllString(unparsedString, `$$$$1`)
+
+	modifiedBuffer := []byte(substitutedString)
+
 	// We now parse over the yaml with env substring, and fill in the ENV's
-	buffer, err := envsubst.Bytes(unparsedBuffer)
+	buffer, err := envsubst.Bytes(modifiedBuffer)
 	if err != nil {
 		return nil, fmt.Errorf("error in substituting env variables : %w", err)
 	}

--- a/pkg/apis/options/load_test.go
+++ b/pkg/apis/options/load_test.go
@@ -487,6 +487,31 @@ sub:
 					StringOption: "Bob",
 				},
 			}),
+			Entry("with a config file containing $ signs for things other than environment variables", loadYAMLTableInput{
+				configFile: []byte(`
+stringOption: /$1
+stringSliceOption:
+- /$1
+- ^/(.*)$
+- api/$1
+- api/(.*)$
+- ^/api/(.*)$
+- /api/$1`),
+				input: &TestOptions{},
+				expectedOutput: &TestOptions{
+					StringOption: "/$1",
+					TestOptionSubStruct: TestOptionSubStruct{
+						StringSliceOption: []string{
+							"/$1",
+							"^/(.*)$",
+							"api/$1",
+							"api/(.*)$",
+							"^/api/(.*)$",
+							"/api/$1",
+						},
+					},
+				},
+			}),
 		)
 	})
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Enhance Environment Variable Substitution in Alpha Config Parsing

## Description

<!--- Describe your changes in detail -->
This PR introduces an enhancement to the environment variable substitution logic within the configuration file parsing process. It implements a regex-based preprocessing step to ensure that $ characters followed by numerals (e.g., $1, $2) are correctly escaped, addressing the issue where envsubst fails to process such patterns appropriately.

## Motivation and Context
The motivation behind this change is to solve the problem identified in issue [#2508](https://github.com/oauth2-proxy/oauth2-proxy/issues/2508), where users experienced difficulties with the substitution of environment variables in their configuration files, particularly in cases involving $ followed by numerals. This fix ensures that the oauth2-proxy can be configured more flexibly and reliably in environments where dynamic configuration through environment variables is a common practice.

Fixes #2508
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
The changes have been tested locally by manually modifying the configuration files to include $ followed by numerals and observing the correct substitution of environment variables. This testing approach ensured that the fix resolves the issue without introducing new problems or affecting other areas of the code.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [X] I have created a feature (non-master) branch for my PR.
- [x] I have written tests for my code changes.
