### PR TITLE
Add the assignment of user to userinfo at azure provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 ## Breaking Changes
 
 ## Changes since v7.5.1
-
+- [#2535](https://github.com/oauth2-proxy/oauth2-proxy/pull/2307) Add the assignment of user to userinfo at azure provider (@Jozefiel)
 - [#2381](https://github.com/oauth2-proxy/oauth2-proxy/pull/2381) Allow username authentication to Redis cluster (@rossigee)
 - [#2345](https://github.com/oauth2-proxy/oauth2-proxy/pull/2345) Log error details when failed loading CSRF cookie (@charvadzo)
 - [#2128](https://github.com/oauth2-proxy/oauth2-proxy/pull/2128) Update dependencies (@vllvll)

--- a/providers/azure_test.go
+++ b/providers/azure_test.go
@@ -165,6 +165,8 @@ func testAzureBackendWithError(payload string, accessToken, refreshToken string,
 						}
 					]
 				}`))
+			} else if r.URL.Path == path && r.Method == http.MethodGet {
+				w.Write([]byte(payload))
 			} else if (r.URL.Path != path) && r.Method != http.MethodPost {
 				w.WriteHeader(404)
 			} else if r.Method == http.MethodPost && r.Body != nil {
@@ -189,6 +191,7 @@ func TestAzureProviderEnrichSession(t *testing.T) {
 		Description             string
 		Email                   string
 		PayloadFromAzureBackend string
+		ExpectedUser            string
 		ExpectedEmail           string
 		ExpectedError           error
 	}{
@@ -227,6 +230,13 @@ func TestAzureProviderEnrichSession(t *testing.T) {
 			Email:         "user@windows.net",
 			ExpectedEmail: "user@windows.net",
 		},
+		{
+			Description:             "should enrich username from Azure provider",
+			Email:                   "user@windows.net",
+			PayloadFromAzureBackend: `{ "name": "User" }`,
+			ExpectedEmail:           "user@windows.net",
+			ExpectedUser:            "User",
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -248,6 +258,7 @@ func TestAzureProviderEnrichSession(t *testing.T) {
 			err := p.EnrichSession(context.Background(), session)
 			assert.Equal(t, testCase.ExpectedError, err)
 			assert.Equal(t, testCase.ExpectedEmail, session.Email)
+			assert.Equal(t, testCase.ExpectedUser, session.User)
 		})
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix missing username in /oauth2/userinfo for Azure AD 

## Motivation and Context

Applications can provide a Username with an email address. Now only an email address can be used. 

## How Has This Been Tested?

oauth2-proxy configured with azure ad provider.
Then just check <ip_address:port>/oauth2/userinfo where missing name was provided

```
{"user":"Admin2","email":"admin2@email.com","groups":["All.ReadWrite"]}
```

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.
