### PR TITLE
Allow setting unix socket file mode when declaring listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Changes since v7.6.0
 
+- [#2537](https://github.com/oauth2-proxy/oauth2-proxy/pull/2537) Allow setting unix socket file mode when declaring listener (@Tristan971)
+
 # V7.6.0
 
 ## Release Highlights

--- a/docs/docs/configuration/overview.md
+++ b/docs/docs/configuration/overview.md
@@ -118,7 +118,7 @@ An example [oauth2-proxy.cfg](https://github.com/oauth2-proxy/oauth2-proxy/blob/
 | `--google-target-principal` | bool | the target principal to impersonate when using ADC | defaults to the service account configured for ADC |
 | `--htpasswd-file` | string | additionally authenticate against a htpasswd file. Entries must be created with `htpasswd -B` for bcrypt encryption | |
 | `--htpasswd-user-group` | string \| list | the groups to be set on sessions for htpasswd users | |
-| `--http-address` | string | `[http://]<addr>:<port>` or `unix://<path>` to listen on for HTTP clients. Square brackets are required for ipv6 address, e.g. `http://[::1]:4180` | `"127.0.0.1:4180"` |
+| `--http-address` | string | `[http://]<addr>:<port>` or `unix://<path>` to listen on for HTTP clients. Square brackets are required for ipv6 address, e.g. `http://[::1]:4180` | `"127.0.0.1:4180"`. Unix sockets are created with file mode 0644 by default, which can be overriden with e.g. `unix://<path>,mode=<mode>`. |
 | `--https-address` | string | `[https://]<addr>:<port>` to listen on for HTTPS clients. Square brackets are required for ipv6 address, e.g. `https://[::1]:443` | `":443"` |
 | `--logging-compress` | bool | Should rotated log files be compressed using gzip | false |
 | `--logging-filename` | string | File to log requests to, empty for `stdout` | `""` (stdout) |

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
@@ -97,7 +98,12 @@ func setupUnixSocketListener(networkType string, address string) (net.Listener, 
 	}
 
 	socketPath := socketOpts[0]
-	socketMode := os.FileMode(0o644)
+
+	// must set umask to find out the previous value, so we set-store-reset it
+	currentUmask := syscall.Umask(0o777)
+	syscall.Umask(currentUmask)
+	socketMode := os.FileMode(currentUmask)
+
 	for _, socketOpt := range socketOpts[1:] {
 		socketOpt := strings.SplitN(socketOpt, "=", 2)
 		if len(socketOpt) != 2 {

--- a/pkg/http/server_test.go
+++ b/pkg/http/server_test.go
@@ -545,6 +545,46 @@ var _ = Describe("Server", func() {
 				expectTLSListener:  true,
 				ipv6:               true,
 			}),
+			Entry("with a valid unix socket path", &newServerTableInput{
+				opts: Opts{
+					Handler:     handler,
+					BindAddress: "unix:///tmp/oauth2-proxy.sock",
+				},
+				expectedErr:        nil,
+				expectHTTPListener: true,
+				expectTLSListener:  false,
+				ipv6:               false,
+			}),
+			Entry("with a valid unix socket path and a valid socket file mode", &newServerTableInput{
+				opts: Opts{
+					Handler:     handler,
+					BindAddress: "unix:///tmp/oauth2-proxy.sock,mode=0777",
+				},
+				expectedErr:        nil,
+				expectHTTPListener: true,
+				expectTLSListener:  false,
+				ipv6:               false,
+			}),
+			Entry("with a valid unix socket path and a value-less socket file mode argument", &newServerTableInput{
+				opts: Opts{
+					Handler:     handler,
+					BindAddress: "unix:///tmp/oauth2-proxy.sock,mode",
+				},
+				expectedErr:        errors.New("error setting up listener: listen (unix, /tmp/oauth2-proxy.sock,mode) failed: unix socket option mode expects a value"),
+				expectHTTPListener: false,
+				expectTLSListener:  false,
+				ipv6:               false,
+			}),
+			Entry("with a valid unix socket path and an invalid socket file mode value", &newServerTableInput{
+				opts: Opts{
+					Handler:     handler,
+					BindAddress: "unix:///tmp/oauth2-proxy.sock,mode=-1",
+				},
+				expectedErr:        errors.New("error setting up listener: listen (unix, /tmp/oauth2-proxy.sock,mode=-1) failed: unix socket file mode has invalid value -1"),
+				expectHTTPListener: false,
+				expectTLSListener:  false,
+				ipv6:               false,
+			}),
 		)
 	})
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Support setting the socket file mode when binding a unix socket.

Defined using the optional suffix `mode=<mode>` in unix (listener) socket paths, e.g.: `unix://<path>,mode=<mode>`

## Motivation and Context

Fixes #2536 

## How Has This Been Tested?

Added relevant test cases, and checked the permissions of the created unix socket file on my computer.

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
- [x] I have written tests for my code changes.
