### PR TITLE
oauth2-proxy.service.example: Remove syslog.target

### DIFF
--- a/contrib/oauth2-proxy.service.example
+++ b/contrib/oauth2-proxy.service.example
@@ -5,7 +5,7 @@
 
 [Unit]
 Description=oauth2-proxy daemon service
-After=syslog.target network.target
+After=network.target
 
 [Service]
 # www-data group and user need to be created before using these lines


### PR DESCRIPTION
Remove syslog.target from service file, this target hasn't existed for over a decade.

https://github.com/systemd/systemd/blob/6aa8d43ade72e24c9426e604f7fc4b7582b9db7c/NEWS#L72-L73

