### PR TITLE
pkg/http: Fix leaky test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Changes since v7.6.0
 
+- [#2539](https://github.com/oauth2-proxy/oauth2-proxy/pull/2539) pkg/http: Fix leaky test (@isodude)
+
 # V7.6.0
 
 ## Release Highlights

--- a/pkg/http/http_suite_test.go
+++ b/pkg/http/http_suite_test.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
@@ -18,7 +19,7 @@ import (
 var ipv4CertData, ipv6CertData []byte
 var ipv4CertDataSource, ipv4KeyDataSource options.SecretSource
 var ipv6CertDataSource, ipv6KeyDataSource options.SecretSource
-var client *http.Client
+var transport *http.Transport
 
 func TestHTTPSuite(t *testing.T) {
 	logger.SetOutput(GinkgoWriter)
@@ -26,6 +27,17 @@ func TestHTTPSuite(t *testing.T) {
 
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "HTTP")
+}
+
+func httpGet(ctx context.Context, url string) (*http.Response, error) {
+	c := &http.Client{
+		Transport: transport.Clone(),
+	}
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	return c.Do(req)
 }
 
 var _ = BeforeSuite(func() {
@@ -70,11 +82,7 @@ var _ = BeforeSuite(func() {
 		certpool.AddCert(ipv4certificate)
 		certpool.AddCert(ipv6certificate)
 
-		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport = http.DefaultTransport.(*http.Transport).Clone()
 		transport.TLSClientConfig.RootCAs = certpool
-
-		client = &http.Client{
-			Transport: transport,
-		}
 	})
 })

--- a/pkg/http/server_test.go
+++ b/pkg/http/server_test.go
@@ -587,7 +587,7 @@ var _ = Describe("Server", func() {
 					Expect(srv.Start(ctx)).To(Succeed())
 				}()
 
-				resp, err := client.Get(listenAddr)
+				resp, err := httpGet(ctx, listenAddr)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
@@ -602,13 +602,13 @@ var _ = Describe("Server", func() {
 					Expect(srv.Start(ctx)).To(Succeed())
 				}()
 
-				_, err := client.Get(listenAddr)
+				_, err := httpGet(ctx, listenAddr)
 				Expect(err).ToNot(HaveOccurred())
 
 				cancel()
 
 				Eventually(func() error {
-					_, err := client.Get(listenAddr)
+					_, err := httpGet(ctx, listenAddr)
 					return err
 				}).Should(HaveOccurred())
 			})
@@ -641,7 +641,7 @@ var _ = Describe("Server", func() {
 					Expect(srv.Start(ctx)).To(Succeed())
 				}()
 
-				resp, err := client.Get(secureListenAddr)
+				resp, err := httpGet(ctx, secureListenAddr)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
@@ -656,13 +656,13 @@ var _ = Describe("Server", func() {
 					Expect(srv.Start(ctx)).To(Succeed())
 				}()
 
-				_, err := client.Get(secureListenAddr)
+				_, err := httpGet(ctx, secureListenAddr)
 				Expect(err).ToNot(HaveOccurred())
 
 				cancel()
 
 				Eventually(func() error {
-					_, err := client.Get(secureListenAddr)
+					_, err := httpGet(ctx, secureListenAddr)
 					return err
 				}).Should(HaveOccurred())
 			})
@@ -673,7 +673,7 @@ var _ = Describe("Server", func() {
 					Expect(srv.Start(ctx)).To(Succeed())
 				}()
 
-				resp, err := client.Get(secureListenAddr)
+				resp, err := httpGet(ctx, secureListenAddr)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
@@ -712,7 +712,7 @@ var _ = Describe("Server", func() {
 					Expect(srv.Start(ctx)).To(Succeed())
 				}()
 
-				resp, err := client.Get(listenAddr)
+				resp, err := httpGet(ctx, listenAddr)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
@@ -727,7 +727,7 @@ var _ = Describe("Server", func() {
 					Expect(srv.Start(ctx)).To(Succeed())
 				}()
 
-				resp, err := client.Get(secureListenAddr)
+				resp, err := httpGet(ctx, secureListenAddr)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
@@ -742,19 +742,19 @@ var _ = Describe("Server", func() {
 					Expect(srv.Start(ctx)).To(Succeed())
 				}()
 
-				_, err := client.Get(listenAddr)
+				_, err := httpGet(ctx, listenAddr)
 				Expect(err).ToNot(HaveOccurred())
-				_, err = client.Get(secureListenAddr)
+				_, err = httpGet(ctx, secureListenAddr)
 				Expect(err).ToNot(HaveOccurred())
 
 				cancel()
 
 				Eventually(func() error {
-					_, err := client.Get(listenAddr)
+					_, err := httpGet(ctx, listenAddr)
 					return err
 				}).Should(HaveOccurred())
 				Eventually(func() error {
-					_, err := client.Get(secureListenAddr)
+					_, err := httpGet(ctx, secureListenAddr)
 					return err
 				}).Should(HaveOccurred())
 			})
@@ -784,7 +784,7 @@ var _ = Describe("Server", func() {
 					Expect(srv.Start(ctx)).To(Succeed())
 				}()
 
-				resp, err := client.Get(listenAddr)
+				resp, err := httpGet(ctx, listenAddr)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
@@ -799,13 +799,13 @@ var _ = Describe("Server", func() {
 					Expect(srv.Start(ctx)).To(Succeed())
 				}()
 
-				_, err := client.Get(listenAddr)
+				_, err := httpGet(ctx, listenAddr)
 				Expect(err).ToNot(HaveOccurred())
 
 				cancel()
 
 				Eventually(func() error {
-					_, err := client.Get(listenAddr)
+					_, err := httpGet(ctx, listenAddr)
 					return err
 				}).Should(HaveOccurred())
 			})
@@ -839,7 +839,7 @@ var _ = Describe("Server", func() {
 					Expect(srv.Start(ctx)).To(Succeed())
 				}()
 
-				resp, err := client.Get(secureListenAddr)
+				resp, err := httpGet(ctx, secureListenAddr)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
@@ -854,13 +854,13 @@ var _ = Describe("Server", func() {
 					Expect(srv.Start(ctx)).To(Succeed())
 				}()
 
-				_, err := client.Get(secureListenAddr)
+				_, err := httpGet(ctx, secureListenAddr)
 				Expect(err).ToNot(HaveOccurred())
 
 				cancel()
 
 				Eventually(func() error {
-					_, err := client.Get(secureListenAddr)
+					_, err := httpGet(ctx, secureListenAddr)
 					return err
 				}).Should(HaveOccurred())
 			})
@@ -871,7 +871,7 @@ var _ = Describe("Server", func() {
 					Expect(srv.Start(ctx)).To(Succeed())
 				}()
 
-				resp, err := client.Get(secureListenAddr)
+				resp, err := httpGet(ctx, secureListenAddr)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
@@ -911,7 +911,7 @@ var _ = Describe("Server", func() {
 					Expect(srv.Start(ctx)).To(Succeed())
 				}()
 
-				resp, err := client.Get(listenAddr)
+				resp, err := httpGet(ctx, listenAddr)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
@@ -926,7 +926,7 @@ var _ = Describe("Server", func() {
 					Expect(srv.Start(ctx)).To(Succeed())
 				}()
 
-				resp, err := client.Get(secureListenAddr)
+				resp, err := httpGet(ctx, secureListenAddr)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
@@ -941,19 +941,19 @@ var _ = Describe("Server", func() {
 					Expect(srv.Start(ctx)).To(Succeed())
 				}()
 
-				_, err := client.Get(listenAddr)
+				_, err := httpGet(ctx, listenAddr)
 				Expect(err).ToNot(HaveOccurred())
-				_, err = client.Get(secureListenAddr)
+				_, err = httpGet(ctx, secureListenAddr)
 				Expect(err).ToNot(HaveOccurred())
 
 				cancel()
 
 				Eventually(func() error {
-					_, err := client.Get(listenAddr)
+					_, err := httpGet(ctx, listenAddr)
 					return err
 				}).Should(HaveOccurred())
 				Eventually(func() error {
-					_, err := client.Get(secureListenAddr)
+					_, err := httpGet(ctx, secureListenAddr)
 					return err
 				}).Should(HaveOccurred())
 			})

--- a/pkg/http/server_test.go
+++ b/pkg/http/server_test.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gleak"
 )
 
 const hello = "Hello World!"
@@ -559,6 +560,8 @@ var _ = Describe("Server", func() {
 
 		AfterEach(func() {
 			cancel()
+			Eventually(Goroutines).ShouldNot(HaveLeaked())
+
 		})
 
 		Context("with an ipv4 http server", func() {


### PR DESCRIPTION
While trying to make test happy in https://github.com/oauth2-proxy/oauth2-proxy/pull/1985 I saw weird behavior in the tests. Adding simple test broke the suite in odd ways.

## Description

I added gleak from gomega to check for leaking goroutines.

I found leaking goroutines, and an easy way to pass the correct context to avoid the leakage.

## Motivation and Context

It's part of fixing the stability for https://github.com/oauth2-proxy/oauth2-proxy/pull/1985
Since it seems to be quite an easy problem with a simple resolution I figured I'd put up a new PR just with this.

## How Has This Been Tested?

Tested with `go test`.
With only the first commit I was greeted with
```
• Failure in Spec Teardown (AfterEach) [1.003 seconds]
Server
/home/user/g/github.com/isodude/oauth2-proxy/pkg/http/server_test.go:20
  Start
  /home/user/g/github.com/isodude/oauth2-proxy/pkg/http/server_test.go:552
    with an ipv4 https server [AfterEach]
    /home/user/g/github.com/isodude/oauth2-proxy/pkg/http/server_test.go:617
      Serves the certificate provided
      /home/user/g/github.com/isodude/oauth2-proxy/pkg/http/server_test.go:670

      Timed out after 1.000s.
      Expected not to leak 8 goroutines:
          goroutine 38 [select]
              net/http.(*persistConn).readLoop(0xc0000d7200) at http/transport.go:2260
              created by net/http.(*Transport).dialConn in goroutine 51 at http/transport.go:1798
          goroutine 39 [select]
              net/http.(*persistConn).writeLoop(0xc0000d7200) at http/transport.go:2443
              created by net/http.(*Transport).dialConn in goroutine 51 at http/transport.go:1799
          goroutine 65 [select]
              net/http.(*persistConn).readLoop(0xc0000d6900) at http/transport.go:2260
              created by net/http.(*Transport).dialConn in goroutine 62 at http/transport.go:1798
          goroutine 82 [select]
              net/http.(*persistConn).writeLoop(0xc0000d6900) at http/transport.go:2443
              created by net/http.(*Transport).dialConn in goroutine 62 at http/transport.go:1799
          goroutine 114 [select]
              net/http.(*persistConn).readLoop(0xc0003ae120) at http/transport.go:2260
              created by net/http.(*Transport).dialConn in goroutine 98 at http/transport.go:1798
          goroutine 115 [select]
              net/http.(*persistConn).writeLoop(0xc0003ae120) at http/transport.go:2443
              created by net/http.(*Transport).dialConn in goroutine 98 at http/transport.go:1799
          goroutine 117 [select]
              net/http.(*persistConn).readLoop(0xc0000d7320) at http/transport.go:2260
              created by net/http.(*Transport).dialConn in goroutine 87 at http/transport.go:1798
          goroutine 118 [select]
              net/http.(*persistConn).writeLoop(0xc0000d7320) at http/transport.go:2443
              created by net/http.(*Transport).dialConn in goroutine 87 at http/transport.go:1799
```

With the second commit they stopped occurring.

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
- [x] I have written tests for my code changes.
