### PR TITLE
Add scopes claim

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -720,11 +720,13 @@ func (p *OAuthProxy) UserInfo(rw http.ResponseWriter, req *http.Request) {
 		Email             string   `json:"email"`
 		Groups            []string `json:"groups,omitempty"`
 		PreferredUsername string   `json:"preferredUsername,omitempty"`
+		Name              string   `json:"name"`
 	}{
 		User:              session.User,
 		Email:             session.Email,
 		Groups:            session.Groups,
 		PreferredUsername: session.PreferredUsername,
+		Name:              session.Name,
 	}
 
 	if err := json.NewEncoder(rw).Encode(userInfo); err != nil {

--- a/pkg/apis/middleware/session.go
+++ b/pkg/apis/middleware/session.go
@@ -24,7 +24,9 @@ func CreateTokenToSessionFunc(verify VerifyFunc) TokenToSessionFunc {
 			Email             string   `json:"email"`
 			Verified          *bool    `json:"email_verified"`
 			PreferredUsername string   `json:"preferred_username"`
+			Name              string   `json:"name"`
 			Groups            []string `json:"groups"`
+			Scopes            []string `json:"scopes"`
 		}
 
 		idToken, err := verify(ctx, token)
@@ -49,6 +51,8 @@ func CreateTokenToSessionFunc(verify VerifyFunc) TokenToSessionFunc {
 			User:              claims.Subject,
 			Groups:            claims.Groups,
 			PreferredUsername: claims.PreferredUsername,
+			Name:              claims.Name,
+			Scopes:            claims.Scopes,
 			AccessToken:       token,
 			IDToken:           token,
 			RefreshToken:      "",

--- a/pkg/apis/options/providers.go
+++ b/pkg/apis/options/providers.go
@@ -4,8 +4,14 @@ const (
 	// OIDCEmailClaim is the generic email claim used by the OIDC provider.
 	OIDCEmailClaim = "email"
 
+	// OIDCNameClaim is the generic name claim used by the OIDC provider.
+	OIDCNameClaim = "name"
+
 	// OIDCGroupsClaim is the generic groups claim used by the OIDC provider.
 	OIDCGroupsClaim = "groups"
+
+	// OIDCScopesClaim is the generic scopes claim used by the OIDC provider.
+	OIDCScopesClaim = "scopes"
 )
 
 // OIDCAudienceClaims is the generic audience claim list used by the OIDC provider.
@@ -228,9 +234,15 @@ type OIDCOptions struct {
 	// EmailClaim indicates which claim contains the user email,
 	// default set to 'email'
 	EmailClaim string `json:"emailClaim,omitempty"`
+	// NameClaim indicates which claim contains the user name,
+	// default set to 'name'
+	NameClaim string `json:"nameClaim,omitempty"`
 	// GroupsClaim indicates which claim contains the user groups
 	// default set to 'groups'
 	GroupsClaim string `json:"groupsClaim,omitempty"`
+	// ScopesClaim indicates which claim contains the user scopes
+	// default set to 'scopes'
+	ScopesClaim string `json:"scopesClaim,omitempty"`
 	// UserIDClaim indicates which claim contains the user ID
 	// default set to 'email'
 	UserIDClaim string `json:"userIDClaim,omitempty"`
@@ -264,7 +276,9 @@ func providerDefaults() Providers {
 				SkipDiscovery:                false,
 				UserIDClaim:                  OIDCEmailClaim, // Deprecated: Use OIDCEmailClaim
 				EmailClaim:                   OIDCEmailClaim,
+				NameClaim:                    OIDCNameClaim,
 				GroupsClaim:                  OIDCGroupsClaim,
+				ScopesClaim:                  OIDCScopesClaim,
 				AudienceClaims:               OIDCAudienceClaims,
 				ExtraAudiences:               []string{},
 			},

--- a/pkg/apis/sessions/session_state.go
+++ b/pkg/apis/sessions/session_state.go
@@ -28,6 +28,8 @@ type SessionState struct {
 	User              string   `msgpack:"u,omitempty"`
 	Groups            []string `msgpack:"g,omitempty"`
 	PreferredUsername string   `msgpack:"pu,omitempty"`
+	Name              string   `msgpack:"dn,omitempty"`
+	Scopes            []string `msgpack:"s,omitempty"`
 
 	// Internal helpers, not serialized
 	Clock clock.Clock `msgpack:"-"`
@@ -101,7 +103,7 @@ func (s *SessionState) Age() time.Duration {
 
 // String constructs a summary of the session state
 func (s *SessionState) String() string {
-	o := fmt.Sprintf("Session{email:%s user:%s PreferredUsername:%s", s.Email, s.User, s.PreferredUsername)
+	o := fmt.Sprintf("Session{email:%s user:%s PreferredUsername:%s Name:%s", s.Email, s.User, s.PreferredUsername, s.Name)
 	if s.AccessToken != "" {
 		o += " token:true"
 	}
@@ -119,6 +121,9 @@ func (s *SessionState) String() string {
 	}
 	if len(s.Groups) > 0 {
 		o += fmt.Sprintf(" groups:%v", s.Groups)
+	}
+	if len(s.Scopes) > 0 {
+		o += fmt.Sprintf(" scopes:%v", s.Scopes)
 	}
 	return o + "}"
 }
@@ -148,6 +153,12 @@ func (s *SessionState) GetClaim(claim string) []string {
 		return groups
 	case "preferred_username":
 		return []string{s.PreferredUsername}
+	case "name":
+		return []string{s.Name}
+	case "scopes":
+		scopes := make([]string, len(s.Scopes))
+		copy(scopes, s.Scopes)
+		return scopes
 	default:
 		return []string{}
 	}

--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -178,7 +178,9 @@ func (p *OIDCProvider) redeemRefreshToken(ctx context.Context, s *sessions.Sessi
 		s.Email = newSession.Email
 		s.User = newSession.User
 		s.Groups = newSession.Groups
+		s.Scopes = newSession.Scopes
 		s.PreferredUsername = newSession.PreferredUsername
+		s.Name = newSession.Name
 	}
 
 	s.AccessToken = newSession.AccessToken

--- a/providers/provider_data.go
+++ b/providers/provider_data.go
@@ -46,7 +46,9 @@ type ProviderData struct {
 	AllowUnverifiedEmail     bool
 	UserClaim                string
 	EmailClaim               string
+	NameClaim                string
 	GroupsClaim              string
+	ScopesClaim              string
 	Verifier                 internaloidc.IDTokenVerifier
 	SkipClaimsFromProfileURL bool
 
@@ -260,6 +262,8 @@ func (p *ProviderData) buildSessionFromClaims(rawIDToken, accessToken string) (*
 		{p.GroupsClaim, &ss.Groups},
 		// TODO (@NickMeves) Deprecate for dynamic claim to session mapping
 		{"preferred_username", &ss.PreferredUsername},
+		{p.NameClaim, &ss.Name},
+		{p.ScopesClaim, &ss.Scopes},
 	} {
 		if _, err := extractor.GetClaimInto(c.claim, c.dst); err != nil {
 			return nil, err

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -137,7 +137,9 @@ func newProviderDataFromConfig(providerConfig options.Provider) (*ProviderData, 
 	// Make the OIDC options available to all providers that support it
 	p.AllowUnverifiedEmail = providerConfig.OIDCConfig.InsecureAllowUnverifiedEmail
 	p.EmailClaim = providerConfig.OIDCConfig.EmailClaim
+	p.NameClaim = providerConfig.OIDCConfig.NameClaim
 	p.GroupsClaim = providerConfig.OIDCConfig.GroupsClaim
+	p.ScopesClaim = providerConfig.OIDCConfig.ScopesClaim
 	p.SkipClaimsFromProfileURL = providerConfig.SkipClaimsFromProfileURL
 
 	// Set PKCE enabled or disabled based on discovery and force options


### PR DESCRIPTION
## Description

The "scopes" claim is added

## Motivation and Context

I want to provide upstream with X-Forwarded-Scopes header which shall contain the effective scopes granted by IDM.
Consider [kanidm](https://kanidm.github.io/kanidm/master/integrations/oauth2.html#scope-relationships) where scopes are collected with respect to user-group membership. The scopes are effectively rights granted to the user and passing them directly will allow to switch some applications to trusted sso headers thus simplifying such applications auth procedures (no need in unpacking cookie/authorization header).

## How Has This Been Tested?

I'm new to Go and I just clone the existing code relevant to very similar "groups" claim. It works fine on my setup.
I don't see how it could affect affects other areas of the code in negative way.
If this PR is welcome I would appreciate if someone with stronger level in Go took the code and added needed (if any) tests.
This would allow me to study by example.
TIA

## Checklist:

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.
