### PR TITLE
feat: Replace default Go user-agent with oauth2-proxy and version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [#2539](https://github.com/oauth2-proxy/oauth2-proxy/pull/2539) pkg/http: Fix leaky test (@isodude)
 - [#4917](https://github.com/oauth2-proxy/oauth2-proxy/pull/4917) Upgraded all modules to the latest version (@pierluigilenoci)
+- [#2570](https://github.com/oauth2-proxy/oauth2-proxy/pull/2570) Set default user agent to oauth2-proxy/$version (from default Golang one)
 
 # V7.6.0
 

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ lint: validate-go-version
 build: validate-go-version clean $(BINARY)
 
 $(BINARY):
-	CGO_ENABLED=0 $(GO) build -a -installsuffix cgo -ldflags="-X main.VERSION=${VERSION}" -o $@ github.com/oauth2-proxy/oauth2-proxy/v7
+	CGO_ENABLED=0 $(GO) build -a -installsuffix cgo -ldflags="-X github.com/oauth2-proxy/oauth2-proxy/v7/pkg.VERSION=${VERSION}" -o $@ github.com/oauth2-proxy/oauth2-proxy/v7
 
 DOCKER_BUILD_PLATFORM         ?= linux/amd64,linux/arm64,linux/ppc64le,linux/arm/v7
 DOCKER_BUILD_RUNTIME_IMAGE    ?= gcr.io/distroless/static:nonroot

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ lint: validate-go-version
 build: validate-go-version clean $(BINARY)
 
 $(BINARY):
-	CGO_ENABLED=0 $(GO) build -a -installsuffix cgo -ldflags="-X github.com/oauth2-proxy/oauth2-proxy/v7/pkg.VERSION=${VERSION}" -o $@ github.com/oauth2-proxy/oauth2-proxy/v7
+	CGO_ENABLED=0 $(GO) build -a -installsuffix cgo -ldflags="-X github.com/oauth2-proxy/oauth2-proxy/v7/pkg.version.VERSION=${VERSION}" -o $@ github.com/oauth2-proxy/oauth2-proxy/v7
 
 DOCKER_BUILD_PLATFORM         ?= linux/amd64,linux/arm64,linux/ppc64le,linux/arm/v7
 DOCKER_BUILD_RUNTIME_IMAGE    ?= gcr.io/distroless/static:nonroot

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ lint: validate-go-version
 build: validate-go-version clean $(BINARY)
 
 $(BINARY):
-	CGO_ENABLED=0 $(GO) build -a -installsuffix cgo -ldflags="-X github.com/oauth2-proxy/oauth2-proxy/v7/pkg.version.VERSION=${VERSION}" -o $@ github.com/oauth2-proxy/oauth2-proxy/v7
+	CGO_ENABLED=0 $(GO) build -a -installsuffix cgo -ldflags="-X github.com/oauth2-proxy/oauth2-proxy/v7/pkg/version.VERSION=${VERSION}" -o $@ github.com/oauth2-proxy/oauth2-proxy/v7
 
 DOCKER_BUILD_PLATFORM         ?= linux/amd64,linux/arm64,linux/ppc64le,linux/arm/v7
 DOCKER_BUILD_RUNTIME_IMAGE    ?= gcr.io/distroless/static:nonroot

--- a/dist.sh
+++ b/dist.sh
@@ -32,10 +32,12 @@ for ARCH in "${ARCHS[@]}"; do
 	# Create architecture specific binaries
 	if [[ ${GO_ARCH} == armv* ]]; then
 	  GO_ARM=$(echo $GO_ARCH | awk -Fv '{print $2}')
-		GO111MODULE=on GOOS=${GO_OS} GOARCH=arm GOARM=${GO_ARM} CGO_ENABLED=0 go build -ldflags="-X main.VERSION=${VERSION}" \
+		GO111MODULE=on GOOS=${GO_OS} GOARCH=arm GOARM=${GO_ARM} CGO_ENABLED=0 go build \
+			-ldflags="-X github.com/oauth2-proxy/oauth2-proxy/v7/pkg/version.VERSION=${VERSION}" \
 			-o release/${BINARY}-${VERSION}.${ARCH}/${BINARY} .
 	else
-		GO111MODULE=on GOOS=${GO_OS} GOARCH=${GO_ARCH} CGO_ENABLED=0 go build -ldflags="-X main.VERSION=${VERSION}" \
+		GO111MODULE=on GOOS=${GO_OS} GOARCH=${GO_ARCH} CGO_ENABLED=0 go build \
+			-ldflags="-X github.com/oauth2-proxy/oauth2-proxy/v7/pkg/version.VERSION=${VERSION}" \
 			-o release/${BINARY}-${VERSION}.${ARCH}/${BINARY} .
 	fi
 

--- a/main.go
+++ b/main.go
@@ -6,10 +6,10 @@ import (
 	"runtime"
 
 	"github.com/ghodss/yaml"
-	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg"
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/logger"
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/validation"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/version"
 	"github.com/spf13/pflag"
 )
 
@@ -29,7 +29,7 @@ func main() {
 	configFlagSet.Parse(os.Args[1:])
 
 	if *showVersion {
-		fmt.Printf("oauth2-proxy %s (built with %s)\n", pkg.VERSION, runtime.Version())
+		fmt.Printf("oauth2-proxy %s (built with %s)\n", version.VERSION, runtime.Version())
 		return
 	}
 

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 
 	"github.com/ghodss/yaml"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg"
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/logger"
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/validation"
@@ -28,7 +29,7 @@ func main() {
 	configFlagSet.Parse(os.Args[1:])
 
 	if *showVersion {
-		fmt.Printf("oauth2-proxy %s (built with %s)\n", VERSION, runtime.Version())
+		fmt.Printf("oauth2-proxy %s (built with %s)\n", pkg.VERSION, runtime.Version())
 		return
 	}
 

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/justinas/alice"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg"
 	ipapi "github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/ip"
 	middlewareapi "github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/middleware"
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
@@ -142,7 +143,7 @@ func NewOAuthProxy(opts *options.Options, validator func(string) bool) (*OAuthPr
 		CustomLogo:       opts.Templates.CustomLogo,
 		ProxyPrefix:      opts.ProxyPrefix,
 		Footer:           opts.Templates.Footer,
-		Version:          VERSION,
+		Version:          pkg.VERSION,
 		Debug:            opts.Templates.Debug,
 		ProviderName:     buildProviderName(provider, opts.Providers[0].Name),
 		SignInMessage:    buildSignInMessage(opts),

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/justinas/alice"
-	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg"
 	ipapi "github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/ip"
 	middlewareapi "github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/middleware"
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
@@ -31,6 +30,7 @@ import (
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/encryption"
 	proxyhttp "github.com/oauth2-proxy/oauth2-proxy/v7/pkg/http"
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/util"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/version"
 
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/ip"
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/logger"
@@ -143,7 +143,7 @@ func NewOAuthProxy(opts *options.Options, validator func(string) bool) (*OAuthPr
 		CustomLogo:       opts.Templates.CustomLogo,
 		ProxyPrefix:      opts.ProxyPrefix,
 		Footer:           opts.Templates.Footer,
-		Version:          pkg.VERSION,
+		Version:          version.VERSION,
 		Debug:            opts.Templates.Debug,
 		ProviderName:     buildProviderName(provider, opts.Providers[0].Name),
 		SignInMessage:    buildSignInMessage(opts),

--- a/pkg/providers/oidc/provider_verifier.go
+++ b/pkg/providers/oidc/provider_verifier.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/requests"
 	k8serrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
@@ -130,6 +131,7 @@ func getVerifierBuilder(ctx context.Context, opts ProviderVerifierOptions) (veri
 
 // newVerifierBuilder returns a function to create a IDToken verifier from an OIDC config.
 func newVerifierBuilder(ctx context.Context, issuerURL, jwksURL string, supportedSigningAlgs []string) verifierBuilder {
+	ctx = oidc.ClientContext(ctx, requests.DefaultHttpClient)
 	keySet := oidc.NewRemoteKeySet(ctx, jwksURL)
 	return func(oidcConfig *oidc.Config) *oidc.IDTokenVerifier {
 		if len(supportedSigningAlgs) > 0 {

--- a/pkg/providers/oidc/provider_verifier.go
+++ b/pkg/providers/oidc/provider_verifier.go
@@ -131,7 +131,7 @@ func getVerifierBuilder(ctx context.Context, opts ProviderVerifierOptions) (veri
 
 // newVerifierBuilder returns a function to create a IDToken verifier from an OIDC config.
 func newVerifierBuilder(ctx context.Context, issuerURL, jwksURL string, supportedSigningAlgs []string) verifierBuilder {
-	ctx = oidc.ClientContext(ctx, requests.DefaultHttpClient)
+	ctx = oidc.ClientContext(ctx, requests.DefaultHTTPClient)
 	keySet := oidc.NewRemoteKeySet(ctx, jwksURL)
 	return func(oidcConfig *oidc.Config) *oidc.IDTokenVerifier {
 		if len(supportedSigningAlgs) > 0 {

--- a/pkg/requests/builder.go
+++ b/pkg/requests/builder.go
@@ -58,7 +58,7 @@ func (r *builder) WithMethod(method string) Builder {
 
 // WithHeaders replaces the request header map with the given header map.
 func (r *builder) WithHeaders(header http.Header) Builder {
-	r.header = header
+	r.header = header.Clone()
 	return r
 }
 
@@ -99,7 +99,7 @@ func (r *builder) do() Result {
 	}
 	req.Header = r.header
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := DefaultHttpClient.Do(req)
 	if err != nil {
 		r.result = &result{err: fmt.Errorf("error performing request: %v", err)}
 		return r.result

--- a/pkg/requests/builder.go
+++ b/pkg/requests/builder.go
@@ -99,7 +99,7 @@ func (r *builder) do() Result {
 	}
 	req.Header = r.header
 
-	resp, err := DefaultHttpClient.Do(req)
+	resp, err := DefaultHTTPClient.Do(req)
 	if err != nil {
 		r.result = &result{err: fmt.Errorf("error performing request: %v", err)}
 		return r.result

--- a/pkg/requests/builder_test.go
+++ b/pkg/requests/builder_test.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/version"
 
 	"github.com/bitly/go-simplejson"
 	. "github.com/onsi/ginkgo"
@@ -21,7 +21,7 @@ var _ = Describe("Builder suite", func() {
 
 	baseHeaders := http.Header{
 		"Accept-Encoding": []string{"gzip"},
-		"User-Agent":      []string{"oauth2-proxy/" + pkg.VERSION},
+		"User-Agent":      []string{"oauth2-proxy/" + version.VERSION},
 	}
 
 	BeforeEach(func() {

--- a/pkg/requests/builder_test.go
+++ b/pkg/requests/builder_test.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg"
+
 	"github.com/bitly/go-simplejson"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -19,7 +21,7 @@ var _ = Describe("Builder suite", func() {
 
 	baseHeaders := http.Header{
 		"Accept-Encoding": []string{"gzip"},
-		"User-Agent":      []string{"Go-http-client/1.1"},
+		"User-Agent":      []string{"oauth2-proxy/" + pkg.VERSION},
 	}
 
 	BeforeEach(func() {

--- a/pkg/requests/http.go
+++ b/pkg/requests/http.go
@@ -12,9 +12,9 @@ type userAgentTransport struct {
 }
 
 func (t *userAgentTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	r2 := req.Clone(req.Context())
-	setDefaultUserAgent(r2.Header, t.userAgent)
-	return t.next.RoundTrip(r2)
+	r := req.Clone(req.Context())
+	setDefaultUserAgent(r.Header, t.userAgent)
+	return t.next.RoundTrip(r)
 }
 
 var DefaultHTTPClient = &http.Client{Transport: &userAgentTransport{

--- a/pkg/requests/http.go
+++ b/pkg/requests/http.go
@@ -1,0 +1,24 @@
+package requests
+
+import (
+	"net/http"
+
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg"
+)
+
+type userAgentTransport struct {
+}
+
+func (t *userAgentTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	r2 := req.Clone(req.Context())
+	setDefaultUserAgent(r2.Header)
+	return http.DefaultTransport.RoundTrip(r2)
+}
+
+var DefaultHttpClient = &http.Client{Transport: &userAgentTransport{}}
+
+func setDefaultUserAgent(header http.Header) {
+	if header != nil && len(header.Values("User-Agent")) == 0 {
+		header.Set("User-Agent", "oauth2-proxy/"+pkg.VERSION)
+	}
+}

--- a/pkg/requests/http.go
+++ b/pkg/requests/http.go
@@ -3,7 +3,7 @@ package requests
 import (
 	"net/http"
 
-	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/version"
 )
 
 type userAgentTransport struct {
@@ -18,8 +18,8 @@ func (t *userAgentTransport) RoundTrip(req *http.Request) (*http.Response, error
 }
 
 var DefaultHTTPClient = &http.Client{Transport: &userAgentTransport{
-	http.DefaultTransport,
-	"oauth2-proxy/" + pkg.VERSION,
+	next:      http.DefaultTransport,
+	userAgent: "oauth2-proxy/" + version.VERSION,
 }}
 
 func setDefaultUserAgent(header http.Header, userAgent string) {

--- a/pkg/requests/http.go
+++ b/pkg/requests/http.go
@@ -17,7 +17,7 @@ func (t *userAgentTransport) RoundTrip(req *http.Request) (*http.Response, error
 	return t.next.RoundTrip(r2)
 }
 
-var DefaultHttpClient = &http.Client{Transport: &userAgentTransport{
+var DefaultHTTPClient = &http.Client{Transport: &userAgentTransport{
 	http.DefaultTransport,
 	"oauth2-proxy/" + pkg.VERSION,
 }}

--- a/pkg/requests/http.go
+++ b/pkg/requests/http.go
@@ -7,18 +7,23 @@ import (
 )
 
 type userAgentTransport struct {
+	next      http.RoundTripper
+	userAgent string
 }
 
 func (t *userAgentTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	r2 := req.Clone(req.Context())
-	setDefaultUserAgent(r2.Header)
-	return http.DefaultTransport.RoundTrip(r2)
+	setDefaultUserAgent(r2.Header, t.userAgent)
+	return t.next.RoundTrip(r2)
 }
 
-var DefaultHttpClient = &http.Client{Transport: &userAgentTransport{}}
+var DefaultHttpClient = &http.Client{Transport: &userAgentTransport{
+	http.DefaultTransport,
+	"oauth2-proxy/" + pkg.VERSION,
+}}
 
-func setDefaultUserAgent(header http.Header) {
+func setDefaultUserAgent(header http.Header, userAgent string) {
 	if header != nil && len(header.Values("User-Agent")) == 0 {
-		header.Set("User-Agent", "oauth2-proxy/"+pkg.VERSION)
+		header.Set("User-Agent", userAgent)
 	}
 }

--- a/pkg/version.go
+++ b/pkg/version.go
@@ -1,4 +1,4 @@
-package main
+package pkg
 
 // VERSION contains version information
 var VERSION = "undefined"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,4 @@
-package pkg
+package version
 
 // VERSION contains version information
 var VERSION = "undefined"

--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -85,6 +85,7 @@ func (p *OIDCProvider) Redeem(ctx context.Context, redirectURL, code, codeVerifi
 		},
 		RedirectURL: redirectURL,
 	}
+
 	ctx = oidc.ClientContext(ctx, requests.DefaultHTTPClient)
 	token, err := c.Exchange(ctx, code, opts...)
 	if err != nil {

--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -85,7 +85,7 @@ func (p *OIDCProvider) Redeem(ctx context.Context, redirectURL, code, codeVerifi
 		},
 		RedirectURL: redirectURL,
 	}
-	ctx = oidc.ClientContext(ctx, requests.DefaultHttpClient)
+	ctx = oidc.ClientContext(ctx, requests.DefaultHTTPClient)
 	token, err := c.Exchange(ctx, code, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("token exchange failed: %v", err)
@@ -106,7 +106,7 @@ func (p *OIDCProvider) EnrichSession(_ context.Context, s *sessions.SessionState
 
 // ValidateSession checks that the session's IDToken is still valid
 func (p *OIDCProvider) ValidateSession(ctx context.Context, s *sessions.SessionState) bool {
-	ctx = oidc.ClientContext(ctx, requests.DefaultHttpClient)
+	ctx = oidc.ClientContext(ctx, requests.DefaultHTTPClient)
 	_, err := p.Verifier.Verify(ctx, s.IDToken)
 	if err != nil {
 		logger.Errorf("id_token verification failed: %v", err)
@@ -131,7 +131,7 @@ func (p *OIDCProvider) RefreshSession(ctx context.Context, s *sessions.SessionSt
 		return false, nil
 	}
 
-	ctx = oidc.ClientContext(ctx, requests.DefaultHttpClient)
+	ctx = oidc.ClientContext(ctx, requests.DefaultHTTPClient)
 	err := p.redeemRefreshToken(ctx, s)
 	if err != nil {
 		return false, fmt.Errorf("unable to redeem refresh token: %v", err)
@@ -190,7 +190,7 @@ func (p *OIDCProvider) redeemRefreshToken(ctx context.Context, s *sessions.Sessi
 
 // CreateSessionFromToken converts Bearer IDTokens into sessions
 func (p *OIDCProvider) CreateSessionFromToken(ctx context.Context, token string) (*sessions.SessionState, error) {
-	ctx = oidc.ClientContext(ctx, requests.DefaultHttpClient)
+	ctx = oidc.ClientContext(ctx, requests.DefaultHTTPClient)
 	idToken, err := p.Verifier.Verify(ctx, token)
 	if err != nil {
 		return nil, err

--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -7,9 +7,11 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/sessions"
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/logger"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/requests"
 	"golang.org/x/oauth2"
 )
 
@@ -83,6 +85,7 @@ func (p *OIDCProvider) Redeem(ctx context.Context, redirectURL, code, codeVerifi
 		},
 		RedirectURL: redirectURL,
 	}
+	ctx = oidc.ClientContext(ctx, requests.DefaultHttpClient)
 	token, err := c.Exchange(ctx, code, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("token exchange failed: %v", err)
@@ -103,6 +106,7 @@ func (p *OIDCProvider) EnrichSession(_ context.Context, s *sessions.SessionState
 
 // ValidateSession checks that the session's IDToken is still valid
 func (p *OIDCProvider) ValidateSession(ctx context.Context, s *sessions.SessionState) bool {
+	ctx = oidc.ClientContext(ctx, requests.DefaultHttpClient)
 	_, err := p.Verifier.Verify(ctx, s.IDToken)
 	if err != nil {
 		logger.Errorf("id_token verification failed: %v", err)
@@ -127,6 +131,7 @@ func (p *OIDCProvider) RefreshSession(ctx context.Context, s *sessions.SessionSt
 		return false, nil
 	}
 
+	ctx = oidc.ClientContext(ctx, requests.DefaultHttpClient)
 	err := p.redeemRefreshToken(ctx, s)
 	if err != nil {
 		return false, fmt.Errorf("unable to redeem refresh token: %v", err)
@@ -185,6 +190,7 @@ func (p *OIDCProvider) redeemRefreshToken(ctx context.Context, s *sessions.Sessi
 
 // CreateSessionFromToken converts Bearer IDTokens into sessions
 func (p *OIDCProvider) CreateSessionFromToken(ctx context.Context, token string) (*sessions.SessionState, error) {
+	ctx = oidc.ClientContext(ctx, requests.DefaultHttpClient)
 	idToken, err := p.Verifier.Verify(ctx, token)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Changing the default user agent from `Go-http-client/1.1` to `oauth2-proxy/x.y.z`.

## Description

I moved the `VERSION` to `pkg` and use it to replace the default user agent from the Go standard library with one that specifies `oauth2-proxy` with the current version. This is done by deriving a httpClient from the default one and add a `Transport` that sets the user-agent if not already set. Then using this httpClient in the requests package and setting it on the context for the oauth2 and oidc libraries.

## Motivation and Context

We have an authentication service that is behind Akamai which blocks generic user agents, like `Go-http-client/1.1`.
Using a more specific one fixes this. Also it can help to detect faulty clients when running an IdP related to oauth2-proxy or specific versions. This is a reason that Let's Encrypt have a strong policy to have people use an actual user agent instead of the standard library's one.

I thought about making the default user agent also configurable, but that is a bit more work if globals are not an option.
Also tried first to add default user-agent via the http builder, but then found out that if done also in the oauth2 and oidc library you need to customize it via the httpClient.

## How Has This Been Tested?

There is already a test that test this specific case, so I left it.
I did roll out a patched version on our environment and it fixed out issues.
If needed, I could add some more tests for the oidc case.

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
- [x] I have written tests for my code changes.
