### PR TITLE
feat: send html meta refresh for /start and /sign_in endpoint

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"html"
 	"net"
 	"net/http"
 	"net/url"
@@ -584,6 +585,17 @@ func isAllowedPath(req *http.Request, route allowedRoute) bool {
 	return matches
 }
 
+func httpRedirect(rw http.ResponseWriter, req *http.Request, url string, code int) {
+	http.Redirect(rw, req, url, code)
+
+	// this is a workaround for browsers not redirecting when status code has been overridden
+	// for example:
+	// traefik custom error handlers won't change the original status code
+	// so we need to send a meta refresh to the browser to force the redirect
+	location := rw.Header().Get("Location")
+	fmt.Fprintln(rw, "<meta http-equiv=\"refresh\" content=\"0; url="+html.EscapeString(location)+"\" />\n")
+}
+
 // IsAllowedRoute is used to check if the request method & path is allowed without auth
 func (p *OAuthProxy) isAllowedRoute(req *http.Request) bool {
 	for _, route := range p.allowedRoutes {
@@ -685,7 +697,7 @@ func (p *OAuthProxy) SignIn(rw http.ResponseWriter, req *http.Request) {
 			p.ErrorPage(rw, req, http.StatusInternalServerError, err.Error())
 			return
 		}
-		http.Redirect(rw, req, redirect, http.StatusFound)
+		httpRedirect(rw, req, redirect, http.StatusFound)
 	} else {
 		if p.SkipProviderButton {
 			p.OAuthStart(rw, req)
@@ -845,7 +857,7 @@ func (p *OAuthProxy) doOAuthStart(rw http.ResponseWriter, req *http.Request, ove
 		return
 	}
 
-	http.Redirect(rw, req, loginURL, http.StatusFound)
+	httpRedirect(rw, req, loginURL, http.StatusFound)
 }
 
 // OAuthCallback is the OAuth2 authentication flow callback that finishes the


### PR DESCRIPTION
Golang's [`http.Redirect`](https://github.com/golang/go/blob/d0051be847163f1bedb5a5c68f7827f40b4ef4e4/src/net/http/server.go#L2280) method will only send a `Location` header and a link as body. The `Location` header will only trigger a redirect if the status code is [3XX](https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2.2-4).

Unfortunately, Traefik's custom error middleware doesn't use the status code it gets from the oauth2 proxy, so we need a workaround to get browsers to redirect even if the status code isn't 3XX.


## Description

It's a simple workaround that wraps the original `http.Redirect' method.

## Motivation and Context

This will solve the following issues:

https://github.com/oauth2-proxy/oauth2-proxy/issues/334
https://github.com/oauth2-proxy/oauth2-proxy/issues/1297

## How Has This Been Tested?

I've tested the local build with Traefik and it works

## Checklist:

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.
