### PR TITLE
docs/fix-go-install-instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Going forward, all images shall be available at `quay.io/oauth2-proxy/oauth2-pro
     ```bash
     $ go install github.com/oauth2-proxy/oauth2-proxy/v7@latest
     ```
-    This will install the binary into `$GOPATH/bin`. Make sure you include `$GOPATH` in your `$PATH`. Otherwise your system won't find binaries install via `go install`
+    This will install the binary into `$GOPATH/bin`. Make sure you include `$GOPATH` in your `$PATH`. Otherwise your system won't find binaries installed via `go install`
 
     c. Using a [Prebuilt Docker Image](https://quay.io/oauth2-proxy/oauth2-proxy) (AMD64, PPC64LE, ARMv6, ARMv7, and ARM64 available)
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ Going forward, all images shall be available at `quay.io/oauth2-proxy/oauth2-pro
     b. Using Go to install the latest release
     ```bash
     $ go install github.com/oauth2-proxy/oauth2-proxy/v7@latest
-    # which will put the binary in `$GOROOT/bin`
     ```
+    This will install the binary into `$GOPATH/bin`. Make sure you include `$GOPATH` in your `$PATH`. Otherwise your system won't find binaries install via `go install`
+
     c. Using a [Prebuilt Docker Image](https://quay.io/oauth2-proxy/oauth2-proxy) (AMD64, PPC64LE, ARMv6, ARMv7, and ARM64 available)
 
     d. Using a [Pre-Release Nightly Docker Image](https://quay.io/oauth2-proxy/oauth2-proxy-nightly) (AMD64, PPC64LE, ARMv6, ARMv7, and ARM64 available)

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -11,7 +11,7 @@ title: Installation
     ```bash
     $ go install github.com/oauth2-proxy/oauth2-proxy/v7@latest
     ```
-    This will install the binary into `$GOPATH/bin`. Make sure you include `$GOPATH` in your `$PATH`. Otherwise your system won't find binaries install via `go install`
+    This will install the binary into `$GOPATH/bin`. Make sure you include `$GOPATH` in your `$PATH`. Otherwise your system won't find binaries installed via `go install`
 
     c. Using a [Prebuilt Docker Image](https://quay.io/oauth2-proxy/oauth2-proxy) (AMD64, PPC64LE, ARMv6, ARMv7, and ARM64 available)
 

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -10,8 +10,9 @@ title: Installation
     b. Using Go to install the latest release
     ```bash
     $ go install github.com/oauth2-proxy/oauth2-proxy/v7@latest
-    # which will put the binary in `$GOROOT/bin`
     ```
+    This will install the binary into `$GOPATH/bin`. Make sure you include `$GOPATH` in your `$PATH`. Otherwise your system won't find binaries install via `go install`
+
     c. Using a [Prebuilt Docker Image](https://quay.io/oauth2-proxy/oauth2-proxy) (AMD64, PPC64LE, ARMv6, ARMv7, and ARM64 available)
 
     d. Using a [Pre-Release Nightly Docker Image](https://quay.io/oauth2-proxy/oauth2-proxy-nightly) (AMD64, PPC64LE, ARMv6, ARMv7, and ARM64 available)

--- a/docs/versioned_docs/version-7.5.x/installation.md
+++ b/docs/versioned_docs/version-7.5.x/installation.md
@@ -12,7 +12,7 @@ slug: /
     ```bash
     $ go install github.com/oauth2-proxy/oauth2-proxy/v7@latest
     ```
-    This will install the binary into `$GOPATH/bin`. Make sure you include `$GOPATH` in your `$PATH`. Otherwise your system won't find binaries install via `go install`
+    This will install the binary into `$GOPATH/bin`. Make sure you include `$GOPATH` in your `$PATH`. Otherwise your system won't find binaries installed via `go install`
 
     c. Using a [Prebuilt Docker Image](https://quay.io/oauth2-proxy/oauth2-proxy) (AMD64, PPC64LE, ARMv6, ARMv7, and ARM64 available)
 

--- a/docs/versioned_docs/version-7.5.x/installation.md
+++ b/docs/versioned_docs/version-7.5.x/installation.md
@@ -11,8 +11,9 @@ slug: /
     b. Using Go to install the latest release
     ```bash
     $ go install github.com/oauth2-proxy/oauth2-proxy/v7@latest
-    # which will put the binary in `$GOROOT/bin`
     ```
+    This will install the binary into `$GOPATH/bin`. Make sure you include `$GOPATH` in your `$PATH`. Otherwise your system won't find binaries install via `go install`
+
     c. Using a [Prebuilt Docker Image](https://quay.io/oauth2-proxy/oauth2-proxy) (AMD64, PPC64LE, ARMv6, ARMv7, and ARM64 available)
 
     d. Using a [Pre-Release Nightly Docker Image](https://quay.io/oauth2-proxy/oauth2-proxy-nightly) (AMD64, PPC64LE, ARMv6, ARMv7, and ARM64 available)

--- a/docs/versioned_docs/version-7.6.x/installation.md
+++ b/docs/versioned_docs/version-7.6.x/installation.md
@@ -11,7 +11,7 @@ title: Installation
     ```bash
     $ go install github.com/oauth2-proxy/oauth2-proxy/v7@latest
     ```
-    This will install the binary into `$GOPATH/bin`. Make sure you include `$GOPATH` in your `$PATH`. Otherwise your system won't find binaries install via `go install`
+    This will install the binary into `$GOPATH/bin`. Make sure you include `$GOPATH` in your `$PATH`. Otherwise your system won't find binaries installed via `go install`
 
     c. Using a [Prebuilt Docker Image](https://quay.io/oauth2-proxy/oauth2-proxy) (AMD64, PPC64LE, ARMv6, ARMv7, and ARM64 available)
 

--- a/docs/versioned_docs/version-7.6.x/installation.md
+++ b/docs/versioned_docs/version-7.6.x/installation.md
@@ -10,8 +10,9 @@ title: Installation
     b. Using Go to install the latest release
     ```bash
     $ go install github.com/oauth2-proxy/oauth2-proxy/v7@latest
-    # which will put the binary in `$GOROOT/bin`
     ```
+    This will install the binary into `$GOPATH/bin`. Make sure you include `$GOPATH` in your `$PATH`. Otherwise your system won't find binaries install via `go install`
+
     c. Using a [Prebuilt Docker Image](https://quay.io/oauth2-proxy/oauth2-proxy) (AMD64, PPC64LE, ARMv6, ARMv7, and ARM64 available)
 
     d. Using a [Pre-Release Nightly Docker Image](https://quay.io/oauth2-proxy/oauth2-proxy-nightly) (AMD64, PPC64LE, ARMv6, ARMv7, and ARM64 available)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
As identified in #2577 the `go install` instruction in the `README.md` and our docs has been mentioning the wrong directory `$GOROOT/bin` instead of `$GOPATH/bin` since the beginning of this project.
<!--- Describe your changes in detail -->

Fixes: #2577 
