### PR TITLE
remove automatic update of golang to major versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,6 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        # renovate: datasource=golang-version depName=golang
         go-version: 1.21.6
       id: go
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
As major versions of golang might cause issues and a lot more files would need to be updated simultaneously. I would prefer we remove this automation with renovate for the github action step in our CI workflow.
