### PR TITLE
Fix broken traefik docs link

### DIFF
--- a/docs/docs/configuration/integration.md
+++ b/docs/docs/configuration/integration.md
@@ -169,7 +169,7 @@ http:
 
 ## ForwardAuth with static upstreams configuration
 
-Redirect to sign_in functionality provided without the use of `errors` middleware with [Traefik v2 `ForwardAuth` middleware](https://doc.traefik.io/traefik/middlewares/http/forwardauth/) pointing to oauth2-proxy service's `/` endpoint 
+Redirect to sign_in functionality provided without the use of `errors` middleware with [Traefik v2 `ForwardAuth` middleware](https://doc.traefik.io/traefik/middlewares/http/forwardauth/) pointing to oauth2-proxy service's `/` endpoint
 
 **Following options need to be set on `oauth2-proxy`:**
 - `--upstream=static://202`: Configures a static response for authenticated sessions

--- a/docs/versioned_docs/version-7.0.x/configuration/overview.md
+++ b/docs/versioned_docs/version-7.0.x/configuration/overview.md
@@ -417,7 +417,7 @@ You have to substitute *name* with the actual cookie name you configured via --c
 
 ### ForwardAuth with 401 errors middleware
 
-The [Traefik v2 `ForwardAuth` middleware](https://doc.traefik.io/traefik/middlewares/forwardauth/) allows Traefik to authenticate requests via the oauth2-proxy's `/oauth2/auth` endpoint on every request, which only returns a 202 Accepted response or a 401 Unauthorized response without proxying the whole request through. For example, on Dynamic File (YAML) Configuration:
+The [Traefik v2 `ForwardAuth` middleware](https://doc.traefik.io/traefik/middlewares/http/forwardauth/) allows Traefik to authenticate requests via the oauth2-proxy's `/oauth2/auth` endpoint on every request, which only returns a 202 Accepted response or a 401 Unauthorized response without proxying the whole request through. For example, on Dynamic File (YAML) Configuration:
 
 ```yaml
 http:
@@ -482,7 +482,7 @@ http:
 
 ### ForwardAuth with static upstreams configuration
 
-Redirect to sign_in functionality provided without the use of `errors` middleware with [Traefik v2 `ForwardAuth` middleware](https://doc.traefik.io/traefik/middlewares/forwardauth/) pointing to oauth2-proxy service's `/` endpoint
+Redirect to sign_in functionality provided without the use of `errors` middleware with [Traefik v2 `ForwardAuth` middleware](https://doc.traefik.io/traefik/middlewares/http/forwardauth/) pointing to oauth2-proxy service's `/` endpoint
 
 **Following options need to be set on `oauth2-proxy`:**
 - `--upstream=static://202`: Configures a static response for authenticated sessions

--- a/docs/versioned_docs/version-7.1.x/configuration/overview.md
+++ b/docs/versioned_docs/version-7.1.x/configuration/overview.md
@@ -371,7 +371,7 @@ You have to substitute *name* with the actual cookie name you configured via --c
 
 ### ForwardAuth with 401 errors middleware
 
-The [Traefik v2 `ForwardAuth` middleware](https://doc.traefik.io/traefik/middlewares/forwardauth/) allows Traefik to authenticate requests via the oauth2-proxy's `/oauth2/auth` endpoint on every request, which only returns a 202 Accepted response or a 401 Unauthorized response without proxying the whole request through. For example, on Dynamic File (YAML) Configuration:
+The [Traefik v2 `ForwardAuth` middleware](https://doc.traefik.io/traefik/middlewares/http/forwardauth/) allows Traefik to authenticate requests via the oauth2-proxy's `/oauth2/auth` endpoint on every request, which only returns a 202 Accepted response or a 401 Unauthorized response without proxying the whole request through. For example, on Dynamic File (YAML) Configuration:
 
 ```yaml
 http:
@@ -436,7 +436,7 @@ http:
 
 ### ForwardAuth with static upstreams configuration
 
-Redirect to sign_in functionality provided without the use of `errors` middleware with [Traefik v2 `ForwardAuth` middleware](https://doc.traefik.io/traefik/middlewares/forwardauth/) pointing to oauth2-proxy service's `/` endpoint
+Redirect to sign_in functionality provided without the use of `errors` middleware with [Traefik v2 `ForwardAuth` middleware](https://doc.traefik.io/traefik/middlewares/http/forwardauth/) pointing to oauth2-proxy service's `/` endpoint
 
 **Following options need to be set on `oauth2-proxy`:**
 - `--upstream=static://202`: Configures a static response for authenticated sessions

--- a/docs/versioned_docs/version-7.2.x/configuration/overview.md
+++ b/docs/versioned_docs/version-7.2.x/configuration/overview.md
@@ -426,7 +426,7 @@ You have to substitute *name* with the actual cookie name you configured via --c
 
 ### ForwardAuth with 401 errors middleware
 
-The [Traefik v2 `ForwardAuth` middleware](https://doc.traefik.io/traefik/middlewares/forwardauth/) allows Traefik to authenticate requests via the oauth2-proxy's `/oauth2/auth` endpoint on every request, which only returns a 202 Accepted response or a 401 Unauthorized response without proxying the whole request through. For example, on Dynamic File (YAML) Configuration:
+The [Traefik v2 `ForwardAuth` middleware](https://doc.traefik.io/traefik/middlewares/http/forwardauth/) allows Traefik to authenticate requests via the oauth2-proxy's `/oauth2/auth` endpoint on every request, which only returns a 202 Accepted response or a 401 Unauthorized response without proxying the whole request through. For example, on Dynamic File (YAML) Configuration:
 
 ```yaml
 http:
@@ -491,7 +491,7 @@ http:
 
 ### ForwardAuth with static upstreams configuration
 
-Redirect to sign_in functionality provided without the use of `errors` middleware with [Traefik v2 `ForwardAuth` middleware](https://doc.traefik.io/traefik/middlewares/forwardauth/) pointing to oauth2-proxy service's `/` endpoint
+Redirect to sign_in functionality provided without the use of `errors` middleware with [Traefik v2 `ForwardAuth` middleware](https://doc.traefik.io/traefik/middlewares/http/forwardauth/) pointing to oauth2-proxy service's `/` endpoint
 
 **Following options need to be set on `oauth2-proxy`:**
 - `--upstream=static://202`: Configures a static response for authenticated sessions

--- a/docs/versioned_docs/version-7.3.x/configuration/overview.md
+++ b/docs/versioned_docs/version-7.3.x/configuration/overview.md
@@ -431,7 +431,7 @@ You have to substitute *name* with the actual cookie name you configured via --c
 
 ### ForwardAuth with 401 errors middleware
 
-The [Traefik v2 `ForwardAuth` middleware](https://doc.traefik.io/traefik/middlewares/forwardauth/) allows Traefik to authenticate requests via the oauth2-proxy's `/oauth2/auth` endpoint on every request, which only returns a 202 Accepted response or a 401 Unauthorized response without proxying the whole request through. For example, on Dynamic File (YAML) Configuration:
+The [Traefik v2 `ForwardAuth` middleware](https://doc.traefik.io/traefik/middlewares/http/forwardauth/) allows Traefik to authenticate requests via the oauth2-proxy's `/oauth2/auth` endpoint on every request, which only returns a 202 Accepted response or a 401 Unauthorized response without proxying the whole request through. For example, on Dynamic File (YAML) Configuration:
 
 ```yaml
 http:
@@ -496,7 +496,7 @@ http:
 
 ### ForwardAuth with static upstreams configuration
 
-Redirect to sign_in functionality provided without the use of `errors` middleware with [Traefik v2 `ForwardAuth` middleware](https://doc.traefik.io/traefik/middlewares/forwardauth/) pointing to oauth2-proxy service's `/` endpoint
+Redirect to sign_in functionality provided without the use of `errors` middleware with [Traefik v2 `ForwardAuth` middleware](https://doc.traefik.io/traefik/middlewares/http/forwardauth/) pointing to oauth2-proxy service's `/` endpoint
 
 **Following options need to be set on `oauth2-proxy`:**
 - `--upstream=static://202`: Configures a static response for authenticated sessions

--- a/docs/versioned_docs/version-7.4.x/configuration/overview.md
+++ b/docs/versioned_docs/version-7.4.x/configuration/overview.md
@@ -436,7 +436,7 @@ You have to substitute *name* with the actual cookie name you configured via --c
 
 ### ForwardAuth with 401 errors middleware
 
-The [Traefik v2 `ForwardAuth` middleware](https://doc.traefik.io/traefik/middlewares/forwardauth/) allows Traefik to authenticate requests via the oauth2-proxy's `/oauth2/auth` endpoint on every request, which only returns a 202 Accepted response or a 401 Unauthorized response without proxying the whole request through. For example, on Dynamic File (YAML) Configuration:
+The [Traefik v2 `ForwardAuth` middleware](https://doc.traefik.io/traefik/middlewares/http/forwardauth/) allows Traefik to authenticate requests via the oauth2-proxy's `/oauth2/auth` endpoint on every request, which only returns a 202 Accepted response or a 401 Unauthorized response without proxying the whole request through. For example, on Dynamic File (YAML) Configuration:
 
 ```yaml
 http:
@@ -501,7 +501,7 @@ http:
 
 ### ForwardAuth with static upstreams configuration
 
-Redirect to sign_in functionality provided without the use of `errors` middleware with [Traefik v2 `ForwardAuth` middleware](https://doc.traefik.io/traefik/middlewares/forwardauth/) pointing to oauth2-proxy service's `/` endpoint
+Redirect to sign_in functionality provided without the use of `errors` middleware with [Traefik v2 `ForwardAuth` middleware](https://doc.traefik.io/traefik/middlewares/http/forwardauth/) pointing to oauth2-proxy service's `/` endpoint
 
 **Following options need to be set on `oauth2-proxy`:**
 - `--upstream=static://202`: Configures a static response for authenticated sessions

--- a/docs/versioned_docs/version-7.5.x/configuration/overview.md
+++ b/docs/versioned_docs/version-7.5.x/configuration/overview.md
@@ -439,7 +439,7 @@ You have to substitute *name* with the actual cookie name you configured via --c
 
 ### ForwardAuth with 401 errors middleware
 
-The [Traefik v2 `ForwardAuth` middleware](https://doc.traefik.io/traefik/middlewares/forwardauth/) allows Traefik to authenticate requests via the oauth2-proxy's `/oauth2/auth` endpoint on every request, which only returns a 202 Accepted response or a 401 Unauthorized response without proxying the whole request through. For example, on Dynamic File (YAML) Configuration:
+The [Traefik v2 `ForwardAuth` middleware](https://doc.traefik.io/traefik/middlewares/http/forwardauth/) allows Traefik to authenticate requests via the oauth2-proxy's `/oauth2/auth` endpoint on every request, which only returns a 202 Accepted response or a 401 Unauthorized response without proxying the whole request through. For example, on Dynamic File (YAML) Configuration:
 
 ```yaml
 http:
@@ -504,7 +504,7 @@ http:
 
 ### ForwardAuth with static upstreams configuration
 
-Redirect to sign_in functionality provided without the use of `errors` middleware with [Traefik v2 `ForwardAuth` middleware](https://doc.traefik.io/traefik/middlewares/forwardauth/) pointing to oauth2-proxy service's `/` endpoint
+Redirect to sign_in functionality provided without the use of `errors` middleware with [Traefik v2 `ForwardAuth` middleware](https://doc.traefik.io/traefik/middlewares/http/forwardauth/) pointing to oauth2-proxy service's `/` endpoint
 
 **Following options need to be set on `oauth2-proxy`:**
 - `--upstream=static://202`: Configures a static response for authenticated sessions

--- a/docs/versioned_docs/version-7.6.x/configuration/integration.md
+++ b/docs/versioned_docs/version-7.6.x/configuration/integration.md
@@ -169,7 +169,7 @@ http:
 
 ## ForwardAuth with static upstreams configuration
 
-Redirect to sign_in functionality provided without the use of `errors` middleware with [Traefik v2 `ForwardAuth` middleware](https://doc.traefik.io/traefik/middlewares/http/forwardauth/) pointing to oauth2-proxy service's `/` endpoint 
+Redirect to sign_in functionality provided without the use of `errors` middleware with [Traefik v2 `ForwardAuth` middleware](https://doc.traefik.io/traefik/middlewares/http/forwardauth/) pointing to oauth2-proxy service's `/` endpoint
 
 **Following options need to be set on `oauth2-proxy`:**
 - `--upstream=static://202`: Configures a static response for authenticated sessions


### PR DESCRIPTION
## Description

Replaces the outdated docs link 

```
https://doc.traefik.io/traefik/middlewares/forwardauth/
```

with the currently correct link

```
https://doc.traefik.io/traefik/middlewares/http/forwardauth/
```

## Motivation and Context

Traefik docs moved; old link is broken.

## How Has This Been Tested?

Manually tested the new link (no changes to function, only docs).

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.
