### PR TITLE
Keycloak: Add Token Refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## Changes since v7.6.0
 
 - [#2539](https://github.com/oauth2-proxy/oauth2-proxy/pull/2539) pkg/http: Fix leaky test (@isodude)
+- [#2601](https://github.com/oauth2-proxy/oauth2-proxy/pull/2601) keycloak: add token refresh (@Primexz)
 
 # V7.6.0
 


### PR DESCRIPTION
## Description

The missing implementation of the token refresh for the OAuth2 provider: "Keycloak" is implemented here.

## Motivation and Context

When using the OAuth2 proxy, I noticed that no token refresh is implemented for the provider: "Keycloak". In the past, this issue has already been noted in issue: #501.
This PR will fix #501.

## How Has This Been Tested?

I have tested whether the session is updated in the browser and a new cookie is written.

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.
