### PR TITLE
Add a cookie-csrf-per-request-limit attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## Changes since v7.6.0
 
 - [#2539](https://github.com/oauth2-proxy/oauth2-proxy/pull/2539) pkg/http: Fix leaky test (@isodude)
+- [#2615](https://github.com/oauth2-proxy/oauth2-proxy/pull/2615) pgk/cookies: add option to set a limit on the number of per-request CSRF cookies oauth2-proxy sets.
 
 # V7.6.0
 

--- a/docs/docs/configuration/overview.md
+++ b/docs/docs/configuration/overview.md
@@ -91,6 +91,7 @@ An example [oauth2-proxy.cfg](https://github.com/oauth2-proxy/oauth2-proxy/blob/
 | `--cookie-secure` | bool | set [secure (HTTPS only) cookie flag](https://owasp.org/www-community/controls/SecureFlag) | true |
 | `--cookie-samesite` | string | set SameSite cookie attribute (`"lax"`, `"strict"`, `"none"`, or `""`). | `""` |
 | `--cookie-csrf-per-request` | bool | Enable having different CSRF cookies per request, making it possible to have parallel requests. | false |
+| `--cookie-csrf-per-request-limit` | int | Sets a limit on the number of different CSRF requests cookies that oauth2-proxy will set. The oldest cookie will be removed. Useful if users end up with 431 Request headers too large status codes. Only effective if --cookie-csrf-per-request is true | "infinite" |
 | `--cookie-csrf-expire` | duration | expire timeframe for CSRF cookie | 15m |
 | `--custom-templates-dir` | string | path to custom html templates | |
 | `--custom-sign-in-logo` | string | path or a URL to an custom image for the sign_in page logo. Use `"-"` to disable default logo. |

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -838,13 +838,12 @@ func (p *OAuthProxy) doOAuthStart(rw http.ResponseWriter, req *http.Request, ove
 		csrf.HashOIDCNonce(),
 		extraParams,
 	)
-
+	cookies.ClearExtraCsrfCookies(p.CookieOptions, rw, req)
 	if _, err := csrf.SetCookie(rw, req); err != nil {
 		logger.Errorf("Error setting CSRF cookie: %v", err)
 		p.ErrorPage(rw, req, http.StatusInternalServerError, err.Error())
 		return
 	}
-
 	http.Redirect(rw, req, loginURL, http.StatusFound)
 }
 

--- a/pkg/apis/options/cookie.go
+++ b/pkg/apis/options/cookie.go
@@ -8,17 +8,18 @@ import (
 
 // Cookie contains configuration options relating to Cookie configuration
 type Cookie struct {
-	Name           string        `flag:"cookie-name" cfg:"cookie_name"`
-	Secret         string        `flag:"cookie-secret" cfg:"cookie_secret"`
-	Domains        []string      `flag:"cookie-domain" cfg:"cookie_domains"`
-	Path           string        `flag:"cookie-path" cfg:"cookie_path"`
-	Expire         time.Duration `flag:"cookie-expire" cfg:"cookie_expire"`
-	Refresh        time.Duration `flag:"cookie-refresh" cfg:"cookie_refresh"`
-	Secure         bool          `flag:"cookie-secure" cfg:"cookie_secure"`
-	HTTPOnly       bool          `flag:"cookie-httponly" cfg:"cookie_httponly"`
-	SameSite       string        `flag:"cookie-samesite" cfg:"cookie_samesite"`
-	CSRFPerRequest bool          `flag:"cookie-csrf-per-request" cfg:"cookie_csrf_per_request"`
-	CSRFExpire     time.Duration `flag:"cookie-csrf-expire" cfg:"cookie_csrf_expire"`
+	Name                string        `flag:"cookie-name" cfg:"cookie_name"`
+	Secret              string        `flag:"cookie-secret" cfg:"cookie_secret"`
+	Domains             []string      `flag:"cookie-domain" cfg:"cookie_domains"`
+	Path                string        `flag:"cookie-path" cfg:"cookie_path"`
+	Expire              time.Duration `flag:"cookie-expire" cfg:"cookie_expire"`
+	Refresh             time.Duration `flag:"cookie-refresh" cfg:"cookie_refresh"`
+	Secure              bool          `flag:"cookie-secure" cfg:"cookie_secure"`
+	HTTPOnly            bool          `flag:"cookie-httponly" cfg:"cookie_httponly"`
+	SameSite            string        `flag:"cookie-samesite" cfg:"cookie_samesite"`
+	CSRFPerRequest      bool          `flag:"cookie-csrf-per-request" cfg:"cookie_csrf_per_request"`
+	CSRFExpire          time.Duration `flag:"cookie-csrf-expire" cfg:"cookie_csrf_expire"`
+	CSRFPerRequestLimit int           `flag:"cookie-csrf-per-request-limit" cfg:"cookie_csrf_per_request_limit"`
 }
 
 func cookieFlagSet() *pflag.FlagSet {

--- a/pkg/cookies/csrf.go
+++ b/pkg/cookies/csrf.go
@@ -215,7 +215,7 @@ func (c *csrf) encodeCookie() (string, error) {
 // decodeCSRFCookie validates the signature then decrypts and decodes a CSRF
 // cookie into a CSRF struct
 func decodeCSRFCookie(cookie *http.Cookie, opts *options.Cookie) (*csrf, error) {
-	val, _, ok := encryption.Validate(cookie, opts.Secret, opts.Expire)
+	val, t, ok := encryption.Validate(cookie, opts.Secret, opts.Expire)
 	if !ok {
 		return nil, errors.New("CSRF cookie failed validation")
 	}
@@ -226,7 +226,9 @@ func decodeCSRFCookie(cookie *http.Cookie, opts *options.Cookie) (*csrf, error) 
 	}
 
 	// Valid cookie, Unmarshal the CSRF
-	csrf := &csrf{cookieOpts: opts}
+	clock := clock.Clock{}
+	clock.Set(t)
+	csrf := &csrf{cookieOpts: opts, time: clock}
 	err = msgpack.Unmarshal(decrypted, csrf)
 	if err != nil {
 		return nil, fmt.Errorf("error unmarshalling data to CSRF: %v", err)

--- a/pkg/cookies/csrf.go
+++ b/pkg/cookies/csrf.go
@@ -149,7 +149,7 @@ func (c *csrf) SetCookie(rw http.ResponseWriter, req *http.Request) (*http.Cooki
 }
 
 func ClearExtraCsrfCookies(opts *options.Cookie, rw http.ResponseWriter, req *http.Request) {
-	if !opts.CSRFPerRequest {
+	if !opts.CSRFPerRequest || opts.CSRFPerRequestLimit <= 0 {
 		return
 	}
 	cookies := req.Cookies()

--- a/pkg/cookies/csrf_per_request_test.go
+++ b/pkg/cookies/csrf_per_request_test.go
@@ -191,5 +191,71 @@ var _ = Describe("CSRF Cookie with non-fixed name Tests", func() {
 				Expect(privateCSRF.cookieName()).To(ContainSubstring(cookieName))
 			})
 		})
+
+		Context("CSRF max cookies", func() {
+			It("disables the 3rd cookie if a limit of 2 is set", func() {
+				//needs to be now as pkg/encryption/utils.go uses time.Now()
+				testNow := time.Now()
+				cookieOpts.CSRFPerRequestLimit = 2
+
+				publicCSRF1, err := NewCSRF(cookieOpts, "verifier")
+				Expect(err).ToNot(HaveOccurred())
+				privateCSRF1 := publicCSRF1.(*csrf)
+				privateCSRF1.time.Set(testNow)
+
+				publicCSRF2, err := NewCSRF(cookieOpts, "verifier")
+				Expect(err).ToNot(HaveOccurred())
+				privateCSRF2 := publicCSRF2.(*csrf)
+				privateCSRF2.time.Set(testNow.Add(time.Minute))
+
+				publicCSRF3, err := NewCSRF(cookieOpts, "verifier")
+				Expect(err).ToNot(HaveOccurred())
+				privateCSRF3 := publicCSRF3.(*csrf)
+				privateCSRF3.time.Set(testNow.Add(time.Minute * 2))
+
+				//for the test we set all the cookies on a single request, but in reality this will be multiple requests after another
+				cookies := []string{}
+				for _, csrf := range []*csrf{privateCSRF1, privateCSRF2, privateCSRF3} {
+					encoded, err := csrf.encodeCookie()
+					Expect(err).ToNot(HaveOccurred())
+					cookie := MakeCookieFromOptions(
+						req,
+						csrf.cookieName(),
+						encoded,
+						csrf.cookieOpts,
+						csrf.cookieOpts.CSRFExpire,
+						csrf.time.Now(),
+					)
+					cookies = append(cookies, fmt.Sprintf("%v=%v", cookie.Name, cookie.Value))
+				}
+				header := make(map[string][]string, 1)
+				header["Cookie"] = cookies
+				req = &http.Request{
+					Method: http.MethodGet,
+					Proto:  "HTTP/1.1",
+					Host:   cookieDomain,
+
+					URL: &url.URL{
+						Scheme: "https",
+						Host:   cookieDomain,
+						Path:   cookiePath,
+					},
+					Header: header,
+				}
+				fmt.Println(req.Cookies())
+				rw := httptest.NewRecorder()
+				ClearExtraCsrfCookies(cookieOpts, rw, req)
+
+				Expect(rw.Header().Values("Set-Cookie")).To(ContainElement(
+					fmt.Sprintf(
+						"%s=; Path=%s; Domain=%s; Expires=%s; HttpOnly; Secure",
+						privateCSRF1.cookieName(),
+						cookiePath,
+						cookieDomain,
+						testCookieExpires(testNow.Add(time.Hour*-1)),
+					),
+				))
+			})
+		})
 	})
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds the option for a limit in the number of per-request CSRF cookies oauth2-proxy sets. During the doOAuthStart method we call this method in order to remove the oldest cookies.
<!--- Describe your changes in detail -->

## Motivation and Context
See #2383
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Using a unit test, I ran `go test ./pgk/cookies`
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
- [x] I have written tests for my code changes.
