### PR TITLE
fix: Unable to use hyphen in JSON path for oidc-groups-claim option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## Changes since v7.7.0
 
 - [#2803](https://github.com/oauth2-proxy/oauth2-proxy/pull/2803) fix: self signed certificate handling in v7.7.0 (@tuunit)
+- [#2619](https://github.com/oauth2-proxy/oauth2-proxy/pull/2619) fix: unable to use hyphen in JSON path for oidc-groups-claim option (@rd-danny-fleer)
 
 # V7.7.0
 

--- a/pkg/providers/util/claim_extractor.go
+++ b/pkg/providers/util/claim_extractor.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/bitly/go-simplejson"
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/requests"
-	"github.com/ohler55/ojg/jp"
 	"github.com/spf13/cast"
 )
 
@@ -140,12 +139,11 @@ func parseJWT(p string) ([]byte, error) {
 }
 
 // getClaimFrom gets a claim from a Json object.
-// It can accept either a single claim name or a json path if the path is a valid json path.
+// It can accept either a single claim name or a json path. The claim is always evaluated first as a single claim name.
 // Paths with indexes are not supported.
 func getClaimFrom(claim string, src *simplejson.Json) interface{} {
-	_, err := jp.ParseString(claim)
-	if err != nil {
-		return src.Get(claim).Interface()
+	if value, ok := src.CheckGet(claim); ok {
+		return value.Interface()
 	}
 	claimParts := strings.Split(claim, ".")
 	return src.GetPath(claimParts...).Interface()

--- a/pkg/providers/util/claim_extractor_test.go
+++ b/pkg/providers/util/claim_extractor_test.go
@@ -26,10 +26,10 @@ const (
         "idTokenGroup2"
       ],
 	  "nested-groups-claim-containing-hyphen": {
-		"groups": [
-			"nestedClaimContainingHypenGroup1",
-			"nestedClaimContainingHypenGroup2"
-		]
+			"groups": [
+				"nestedClaimContainingHypenGroup1",
+				"nestedClaimContainingHypenGroup2"
+			]
 	  },
       "https://groups.test": [
         "fqdnGroup1",

--- a/pkg/providers/util/claim_extractor_test.go
+++ b/pkg/providers/util/claim_extractor_test.go
@@ -25,6 +25,12 @@ const (
         "idTokenGroup1",
         "idTokenGroup2"
       ],
+	  "nested-groups-claim-containing-hyphen": {
+		"groups": [
+			"nestedClaimContainingHypenGroup1",
+			"nestedClaimContainingHypenGroup2"
+		]
+	  },
       "https://groups.test": [
         "fqdnGroup1",
         "fqdnGroup2"
@@ -237,6 +243,18 @@ var _ = Describe("Claim Extractor Suite", func() {
 				claim:         "https://groups.test",
 				expectExists:  true,
 				expectedValue: []interface{}{"fqdnGroup1", "fqdnGroup2"},
+				expectedError: nil,
+			}),
+			Entry("retrieves claim with nested groups claim containing hyphen", getClaimTableInput{
+				testClaimExtractorOpts: testClaimExtractorOpts{
+					idTokenPayload:        basicIDTokenPayload,
+					setProfileURL:         true,
+					profileRequestHeaders: newAuthorizedHeader(),
+					profileRequestHandler: shouldNotBeRequestedProfileHandler,
+				},
+				claim:         "nested-groups-claim-containing-hyphen.groups",
+				expectExists:  true,
+				expectedValue: []interface{}{"nestedClaimContainingHypenGroup1", "nestedClaimContainingHypenGroup2"},
 				expectedError: nil,
 			}),
 		)


### PR DESCRIPTION
## Description

- Removed dependency "github.com/ohler55/ojg/jp"
- Always evaluate claim as string literal first and as JSON path as fallback

## Motivation and Context

Fix #2618

I know there might be better solutions, like implementing a feature flag and an additional option to control if `oidc-groups-claims` should be evaluated as string or JSON path.
However such a change might be breaking and I didn't want to anticipate the decision for an alternative. Therefore I implemented a simple solution in the first step.

## How Has This Been Tested?

Added additional tests.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My change requires a change to the documentation or CHANGELOG.
- [X] I have updated the documentation/CHANGELOG accordingly.
- [X] I have created a feature (non-master) branch for my PR.
- [x] I have written tests for my code changes.
