### PR TITLE
fix(contrib): revamped systemd service example

### DIFF
--- a/contrib/oauth2-proxy.service.example
+++ b/contrib/oauth2-proxy.service.example
@@ -1,22 +1,33 @@
-# Systemd service file for oauth2-proxy daemon
-#
-# Date: Feb 9, 2016
-# Author: Srdjan Grubor <sgnn7@sgnn7.org>
-
 [Unit]
 Description=oauth2-proxy daemon service
-After=network.target
+After=network.target network-online.target nss-lookup.target basic.target
+Wants=network-online.target nss-lookup.target
+StartLimitIntervalSec=30
+StartLimitBurst=3
 
 [Service]
-# www-data group and user need to be created before using these lines
-User=www-data
-Group=www-data
-
-ExecStart=/usr/local/bin/oauth2-proxy --config=/etc/oauth2-proxy.cfg
+User=oauth2-proxy
+Group=oauth2-proxy
+Restart=on-failure
+RestartSec=30
+WorkingDirectory=/etc/oauth2-proxy
+ExecStart=/usr/bin/oauth2-proxy --config=/etc/oauth2-proxy/oauth2-proxy.cfg
 ExecReload=/bin/kill -HUP $MAINPID
-
-KillMode=process
-Restart=always
+LimitNOFILE=65535
+NoNewPrivileges=true
+ProtectHome=true
+ProtectSystem=full
+ProtectHostname=true
+ProtectControlGroups=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+LockPersonality=true
+RestrictRealtime=yes
+RestrictNamespaces=yes
+MemoryDenyWriteExecute=yes
+PrivateDevices=yes
+PrivateTmp=true
+CapabilityBoundingSet=
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
A file has been provided that can actually be used for packaging The file we have now is almost impossible to use, especially without the `--skip-oidc-discovery` option.

If the dependencies are not arranged, then when `oauth2-proxy` service starts - it will fail 100%. Also, the normal behavior of a `oauth2-proxy` is the termination in case of 'Temporary failure in name resolution', in this case we need to support for restarting the service, and so that these restarts do not look like a flood


----

Example of problem - server boot. As we can see, in 2 seconds service failed 5 times then dead

```python
Jun 05 12:07:13 hostname.example.com systemd[1]: Started oauth2-proxy daemon service.
Jun 05 12:07:13 hostname.example.com oauth2-proxy[539]: [2024/06/05 12:07:13] [provider.go:55] Performing OIDC Discovery...
Jun 05 12:07:13 hostname.example.com oauth2-proxy[539]: [2024/06/05 12:07:13] [main.go:58] ERROR: Failed to initialise OAuth2 Proxy: error initialising provider: could not create provider data: error building OIDC ProviderVerifier: could not get verifier builder: error while discovery OIDC configuration: failed to discover OIDC configuration: error performing request: Get "https://keycloak.example.com/realms/freeipa/.well-known/openid-configuration": dial tcp: lookup keycloak.example.com: Temporary failure in name resolution
Jun 05 12:07:13 hostname.example.com systemd[1]: oauth2-proxy.service: Main process exited, code=exited, status=1/FAILURE
Jun 05 12:07:13 hostname.example.com systemd[1]: oauth2-proxy.service: Failed with result 'exit-code'.
Jun 05 12:07:14 hostname.example.com systemd[1]: oauth2-proxy.service: Scheduled restart job, restart counter is at 1.
Jun 05 12:07:14 hostname.example.com systemd[1]: Started oauth2-proxy daemon service.
Jun 05 12:07:14 hostname.example.com oauth2-proxy[587]: [2024/06/05 12:07:14] [provider.go:55] Performing OIDC Discovery...
Jun 05 12:07:14 hostname.example.com oauth2-proxy[587]: [2024/06/05 12:07:14] [main.go:58] ERROR: Failed to initialise OAuth2 Proxy: error initialising provider: could not create provider data: error building OIDC ProviderVerifier: could not get verifier builder: error while discovery OIDC configuration: failed to discover OIDC configuration: error performing request: Get "https://keycloak.example.com/realms/freeipa/.well-known/openid-configuration": dial tcp: lookup keycloak.example.com: Temporary failure in name resolution
Jun 05 12:07:14 hostname.example.com systemd[1]: oauth2-proxy.service: Main process exited, code=exited, status=1/FAILURE
Jun 05 12:07:14 hostname.example.com systemd[1]: oauth2-proxy.service: Failed with result 'exit-code'.
Jun 05 12:07:14 hostname.example.com systemd[1]: oauth2-proxy.service: Scheduled restart job, restart counter is at 2.
Jun 05 12:07:14 hostname.example.com systemd[1]: Started oauth2-proxy daemon service.
Jun 05 12:07:14 hostname.example.com oauth2-proxy[600]: [2024/06/05 12:07:14] [provider.go:55] Performing OIDC Discovery...
Jun 05 12:07:14 hostname.example.com oauth2-proxy[600]: [2024/06/05 12:07:14] [main.go:58] ERROR: Failed to initialise OAuth2 Proxy: error initialising provider: could not create provider data: error building OIDC ProviderVerifier: could not get verifier builder: error while discovery OIDC configuration: failed to discover OIDC configuration: error performing request: Get "https://keycloak.example.com/realms/freeipa/.well-known/openid-configuration": dial tcp: lookup keycloak.example.com: Temporary failure in name resolution
Jun 05 12:07:14 hostname.example.com systemd[1]: oauth2-proxy.service: Main process exited, code=exited, status=1/FAILURE
Jun 05 12:07:14 hostname.example.com systemd[1]: oauth2-proxy.service: Failed with result 'exit-code'.
Jun 05 12:07:14 hostname.example.com systemd[1]: oauth2-proxy.service: Scheduled restart job, restart counter is at 3.
Jun 05 12:07:14 hostname.example.com systemd[1]: Started oauth2-proxy daemon service.
Jun 05 12:07:14 hostname.example.com oauth2-proxy[624]: [2024/06/05 12:07:14] [provider.go:55] Performing OIDC Discovery...
Jun 05 12:07:14 hostname.example.com oauth2-proxy[624]: [2024/06/05 12:07:14] [main.go:58] ERROR: Failed to initialise OAuth2 Proxy: error initialising provider: could not create provider data: error building OIDC ProviderVerifier: could not get verifier builder: error while discovery OIDC configuration: failed to discover OIDC configuration: error performing request: Get "https://keycloak.example.com/realms/freeipa/.well-known/openid-configuration": dial tcp: lookup keycloak.example.com: Temporary failure in name resolution
Jun 05 12:07:14 hostname.example.com systemd[1]: oauth2-proxy.service: Main process exited, code=exited, status=1/FAILURE
Jun 05 12:07:14 hostname.example.com systemd[1]: oauth2-proxy.service: Failed with result 'exit-code'.
Jun 05 12:07:14 hostname.example.com systemd[1]: oauth2-proxy.service: Scheduled restart job, restart counter is at 4.
Jun 05 12:07:14 hostname.example.com systemd[1]: Started oauth2-proxy daemon service.
Jun 05 12:07:14 hostname.example.com oauth2-proxy[651]: [2024/06/05 12:07:14] [provider.go:55] Performing OIDC Discovery...
Jun 05 12:07:14 hostname.example.com oauth2-proxy[651]: [2024/06/05 12:07:14] [main.go:58] ERROR: Failed to initialise OAuth2 Proxy: error initialising provider: could not create provider data: error building OIDC ProviderVerifier: could not get verifier builder: error while discovery OIDC configuration: failed to discover OIDC configuration: error performing request: Get "https://keycloak.example.com/realms/freeipa/.well-known/openid-configuration": dial tcp: lookup keycloak.example.com: Temporary failure in name resolution
Jun 05 12:07:14 hostname.example.com systemd[1]: oauth2-proxy.service: Main process exited, code=exited, status=1/FAILURE
Jun 05 12:07:14 hostname.example.com systemd[1]: oauth2-proxy.service: Failed with result 'exit-code'.
Jun 05 12:07:15 hostname.example.com systemd[1]: oauth2-proxy.service: Scheduled restart job, restart counter is at 5.
Jun 05 12:07:15 hostname.example.com systemd[1]: oauth2-proxy.service: Start request repeated too quickly.
Jun 05 12:07:15 hostname.example.com systemd[1]: oauth2-proxy.service: Failed with result 'exit-code'.
Jun 05 12:07:15 hostname.example.com systemd[1]: Failed to start oauth2-proxy daemon service.
```

----

The example with fixed file. When service is run, it was fail, then, on next scheduled restart, the `oauth2-proxy` service recovered and up

```python
Jun 05 14:01:06 hostname.example.com systemd[1]: Started oauth2-proxy daemon service.
Jun 05 14:01:06 hostname.example.com oauth2-proxy[1599358]: [2024/06/05 14:01:06] [provider.go:55] Performing OIDC Discovery...
Jun 05 14:01:06 hostname.example.com oauth2-proxy[1599358]: [2024/06/05 14:01:06] [main.go:58] ERROR: Failed to initialise OAuth2 Proxy: error initialising provider: could not create provider data: error building OIDC ProviderVerifier: could not get verifier builder: error while discovery OIDC configuration: failed to discover OIDC configuration: error performing request: Get "https://keycloak.example.com/realms/freeipa/.well-known/openid-configuration": dial tcp: lookup keycloak.example.com: Temporary failure in name resolution
Jun 05 14:01:06 hostname.example.com systemd[1]: oauth2-proxy.service: Main process exited, code=exited, status=1/FAILURE
Jun 05 14:01:06 hostname.example.com systemd[1]: oauth2-proxy.service: Failed with result 'exit-code'.
Jun 05 14:01:36 hostname.example.com systemd[1]: oauth2-proxy.service: Scheduled restart job, restart counter is at 1.
Jun 05 14:01:36 hostname.example.com systemd[1]: Started oauth2-proxy daemon service.
Jun 05 14:01:36 hostname.example.com oauth2-proxy[1599453]: [2024/06/05 14:01:36] [provider.go:55] Performing OIDC Discovery...
Jun 05 14:01:37 hostname.example.com oauth2-proxy[1599453]: [2024/06/05 14:01:37] [oauthproxy.go:171] OAuthProxy configured for Keycloak OIDC Client ID: example-client
Jun 05 14:01:37 hostname.example.com oauth2-proxy[1599453]: [2024/06/05 14:01:37] [oauthproxy.go:177] Cookie settings: name:_oauth2_proxy secure(https):true httponly:true expiry:720h0m0s domains:.example.com path:/ samesite: refresh:disabled
```

----

As we can see, instead flood restarts then fail, service is started from second try
The source of systemd options - is Archlinux [Prometheus package](https://gitlab.archlinux.org/archlinux/packaging/packages/prometheus/-/blob/main/prometheus.service)