### PR TITLE
chore: change version source to github-releases for codeclimate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
       env:
         # renovate: datasource=github-tags depName=golangci/golangci-lint
         GOLANGCI_LINT_VERSION: v1.55.2
-        # renovate: datasource=github-tags depName=codeclimate/test-reporter
+        # renovate: datasource=github-releases depName=codeclimate/test-reporter
         CODECLIMATE_VERSION: v0.11.1
       run: |
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin ${GOLANGCI_LINT_VERSION}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR changes the version source for codeclimate updates via Renovate from github-tags to github-releases. This PR can be closed if codeclimate/test-reporter#522 is acted on.
<!--- Describe your changes in detail -->

## Motivation and Context
This PR is here as a placeholder to have a fix if the above issue is not taken care of.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
-
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.
