### PR TITLE
Add json logging format option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [#2539](https://github.com/oauth2-proxy/oauth2-proxy/pull/2539) pkg/http: Fix leaky test (@isodude)
 - [#4917](https://github.com/oauth2-proxy/oauth2-proxy/pull/4917) Upgraded all modules to the latest version (@pierluigilenoci)
+- [#2681](https://github.com/oauth2-proxy/oauth2-proxy/pull/2681) Add json logging format option (@ternbusty)
 
 # V7.6.0
 
@@ -51,6 +52,7 @@
 # V7.5.1
 
 ## Release Highlights
+
 - 🐛 Several bugs have been squashed
 - 🕵️‍♀️ Vulnerabilities have been addressed
 - 📖Improved docs
@@ -59,13 +61,14 @@
 
 - This release includes fixes for a number of CVEs, we recommend to upgrade as soon as possible.
 - The environment variable OAUTH2_PROXY_GOOGLE_GROUP has been deprecated in favor of OAUTH2_PROXY_GOOGLE_GROUPS. Next major release
-will remove this option. This change makes sure that the configuration options follow the documentation.
+  will remove this option. This change makes sure that the configuration options follow the documentation.
 
 ## Breaking Changes
 
 N/A
 
 ## Changes since v7.5.0
+
 - [#2220](https://github.com/oauth2-proxy/oauth2-proxy/pull/2220) Added binary and docker release platforms (@kvanzuijlen)
 - [#2221](https://github.com/oauth2-proxy/oauth2-proxy/pull/2221) Backwards compatible fix for wrong environment variable name (OAUTH2_PROXY_GOOGLE_GROUPS) (@kvanzuijlen)
 - [#1989](https://github.com/oauth2-proxy/oauth2-proxy/pull/1989) Fix default scope for keycloak-oidc provider (@tuunit)
@@ -77,6 +80,7 @@ N/A
 # V7.5.0
 
 ## Release Highlights
+
 - 🐛 Several bugs have been squashed
 - 🕵️‍♀️ Vulnerabilities have been addressed
 - ⭐️ Added a readiness endpoint to check if the application is ready to receive traffic
@@ -90,10 +94,13 @@ N/A
 - This release introduced a bug with the Keycloak OIDC provider causing no scopes to be send along with the request. Use v7.5.1 instead.
 
 ## Breaking Changes
+
 The following PR introduces a change to how auth routes are evaluated using the flags `skip-auth-route`/`skip-auth-regex`. The new behaviour uses the regex you specify to evaluate the full path including query parameters. For more details please read the detailed description [#2271](https://github.com/oauth2-proxy/oauth2-proxy/issues/2271)
+
 - [#2192](https://github.com/oauth2-proxy/oauth2-proxy/pull/2192) Use X-Forwarded-Uri if it exists for pathRegex match (@mzndr / @jawys)
 
 ## Changes since v7.4.0
+
 - [#2028](https://github.com/oauth2-proxy/oauth2-proxy/pull/2028) Update golang.org/x/net to v0.7.0 ato address GHSA-vvpx-j8f3-3w6h (@amrmahdi)
 - [#1873](https://github.com/oauth2-proxy/oauth2-proxy/pull/1873) Fix empty users with some OIDC providers (@babs)
 - [#1882](https://github.com/oauth2-proxy/oauth2-proxy/pull/1882) Make `htpasswd.GetUsers` racecondition safe (@babs)
@@ -149,8 +156,8 @@ N/A
 - [#1720](https://github.com/oauth2-proxy/oauth2-proxy/pull/1720) Extract roles from authToken, to allow using allowed roles with Keycloak. (@MrDeerly )
 - [#1774](https://github.com/oauth2-proxy/oauth2-proxy/pull/1774) Fix vulnerabilities CVE-2022-27191, CVE-2021-44716 and CVE-2022-29526. (@felipeconti)
 - [#1667](https://github.com/oauth2-proxy/oauth2-proxy/issues/1667) Rename configuration file flag for PKCE (@ChrisEke)
-to remain consistent with CLI flags. You should specify `code_challenge_method` in your configuration instead of
-`force_code_challenge_method`.
+  to remain consistent with CLI flags. You should specify `code_challenge_method` in your configuration instead of
+  `force_code_challenge_method`.
 - [#1708](https://github.com/oauth2-proxy/oauth2-proxy/pull/1708) Enable different CSRF cookies per request (@miguelborges99)
   - Add flag "--cookie-csrf-per-request" which activates an algorithm to name CSRF cookies differently per request.
     This feature allows parallel callbacks and by default it is disabled.
@@ -165,6 +172,7 @@ to remain consistent with CLI flags. You should specify `code_challenge_method` 
 - [#1815](https://github.com/oauth2-proxy/oauth2-proxy/pull/1815) Keycloak: save user and preferredUsername in session to populate headers for the backend (@babs)
 - [#1847](https://github.com/oauth2-proxy/oauth2-proxy/pull/1847) Update go-redis/redis to v9 (@arhamGH)
 -
+
 # V7.3.0
 
 ## Release Highlights
@@ -179,7 +187,7 @@ to remain consistent with CLI flags. You should specify `code_challenge_method` 
 ## Important Notes
 
 - [oauth2-proxy](https://quay.io/repository/oauth2-proxy/oauth2-proxy?tab=tags&tag=latest) separate image tags for each architecture is deprecated. Instead, images are cross compiled and pushed as the same tag for every platform.
-If you are using an architecture specific tag (ex: v7.2.1-arm64) you should move to the generic tag instead (ex: v7.2.1 )
+  If you are using an architecture specific tag (ex: v7.2.1-arm64) you should move to the generic tag instead (ex: v7.2.1 )
 - [#1478](https://github.com/oauth2-proxy/oauth2-proxy/pull/1478) Changes the UID and GID of the runtime user to `65532`.
   Which also is known as `nonroot` user in [distroless images](https://github.com/GoogleContainerTools/distroless).
 - This release includes fixes for a number of CVEs, we recomend to upgrade as soon as possible.
@@ -292,7 +300,7 @@ N/A
 - [#1207](https://github.com/oauth2-proxy/oauth2-proxy/pull/1207) Fix URI fragment handling on sign-in page, regression introduced in 7.1.0 (@tarvip)
 - [#1210](https://github.com/oauth2-proxy/oauth2-proxy/pull/1210) New Keycloak OIDC Provider (@pb82)
 - [#1244](https://github.com/oauth2-proxy/oauth2-proxy/pull/1244) Update Alpine image version to 3.14 (@ahovgaard)
-- [#1317](https://github.com/oauth2-proxy/oauth2-proxy/pull/1317) Fix incorrect `</form>` tag on the sing_in page when *not* using a custom template (@jord1e)
+- [#1317](https://github.com/oauth2-proxy/oauth2-proxy/pull/1317) Fix incorrect `</form>` tag on the sing_in page when _not_ using a custom template (@jord1e)
 - [#1330](https://github.com/oauth2-proxy/oauth2-proxy/pull/1330) Allow specifying URL as input for custom sign in logo (@MaikuMori)
 - [#1357](https://github.com/oauth2-proxy/oauth2-proxy/pull/1357) Fix unsafe access to session variable (@harzallah)
 - [#997](https://github.com/oauth2-proxy/oauth2-proxy/pull/997) Allow passing the raw url path when proxying upstream requests - e.g. /%2F/ (@FStelzer)
@@ -443,7 +451,6 @@ N/A
 - GitLab provider now supports restricting to members of a project
 - Keycloak provider now supports restricting users to members of a set of groups
 - (Alpha) Flexible header configuration allowing user defined mapping of session claims to header values
-
 
 ## Important Notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,6 @@
 # V7.5.1
 
 ## Release Highlights
-
 - 🐛 Several bugs have been squashed
 - 🕵️‍♀️ Vulnerabilities have been addressed
 - 📖Improved docs
@@ -61,14 +60,13 @@
 
 - This release includes fixes for a number of CVEs, we recommend to upgrade as soon as possible.
 - The environment variable OAUTH2_PROXY_GOOGLE_GROUP has been deprecated in favor of OAUTH2_PROXY_GOOGLE_GROUPS. Next major release
-  will remove this option. This change makes sure that the configuration options follow the documentation.
+will remove this option. This change makes sure that the configuration options follow the documentation.
 
 ## Breaking Changes
 
 N/A
 
 ## Changes since v7.5.0
-
 - [#2220](https://github.com/oauth2-proxy/oauth2-proxy/pull/2220) Added binary and docker release platforms (@kvanzuijlen)
 - [#2221](https://github.com/oauth2-proxy/oauth2-proxy/pull/2221) Backwards compatible fix for wrong environment variable name (OAUTH2_PROXY_GOOGLE_GROUPS) (@kvanzuijlen)
 - [#1989](https://github.com/oauth2-proxy/oauth2-proxy/pull/1989) Fix default scope for keycloak-oidc provider (@tuunit)
@@ -80,7 +78,6 @@ N/A
 # V7.5.0
 
 ## Release Highlights
-
 - 🐛 Several bugs have been squashed
 - 🕵️‍♀️ Vulnerabilities have been addressed
 - ⭐️ Added a readiness endpoint to check if the application is ready to receive traffic
@@ -94,13 +91,10 @@ N/A
 - This release introduced a bug with the Keycloak OIDC provider causing no scopes to be send along with the request. Use v7.5.1 instead.
 
 ## Breaking Changes
-
 The following PR introduces a change to how auth routes are evaluated using the flags `skip-auth-route`/`skip-auth-regex`. The new behaviour uses the regex you specify to evaluate the full path including query parameters. For more details please read the detailed description [#2271](https://github.com/oauth2-proxy/oauth2-proxy/issues/2271)
-
 - [#2192](https://github.com/oauth2-proxy/oauth2-proxy/pull/2192) Use X-Forwarded-Uri if it exists for pathRegex match (@mzndr / @jawys)
 
 ## Changes since v7.4.0
-
 - [#2028](https://github.com/oauth2-proxy/oauth2-proxy/pull/2028) Update golang.org/x/net to v0.7.0 ato address GHSA-vvpx-j8f3-3w6h (@amrmahdi)
 - [#1873](https://github.com/oauth2-proxy/oauth2-proxy/pull/1873) Fix empty users with some OIDC providers (@babs)
 - [#1882](https://github.com/oauth2-proxy/oauth2-proxy/pull/1882) Make `htpasswd.GetUsers` racecondition safe (@babs)
@@ -156,8 +150,8 @@ N/A
 - [#1720](https://github.com/oauth2-proxy/oauth2-proxy/pull/1720) Extract roles from authToken, to allow using allowed roles with Keycloak. (@MrDeerly )
 - [#1774](https://github.com/oauth2-proxy/oauth2-proxy/pull/1774) Fix vulnerabilities CVE-2022-27191, CVE-2021-44716 and CVE-2022-29526. (@felipeconti)
 - [#1667](https://github.com/oauth2-proxy/oauth2-proxy/issues/1667) Rename configuration file flag for PKCE (@ChrisEke)
-  to remain consistent with CLI flags. You should specify `code_challenge_method` in your configuration instead of
-  `force_code_challenge_method`.
+to remain consistent with CLI flags. You should specify `code_challenge_method` in your configuration instead of
+`force_code_challenge_method`.
 - [#1708](https://github.com/oauth2-proxy/oauth2-proxy/pull/1708) Enable different CSRF cookies per request (@miguelborges99)
   - Add flag "--cookie-csrf-per-request" which activates an algorithm to name CSRF cookies differently per request.
     This feature allows parallel callbacks and by default it is disabled.
@@ -172,7 +166,6 @@ N/A
 - [#1815](https://github.com/oauth2-proxy/oauth2-proxy/pull/1815) Keycloak: save user and preferredUsername in session to populate headers for the backend (@babs)
 - [#1847](https://github.com/oauth2-proxy/oauth2-proxy/pull/1847) Update go-redis/redis to v9 (@arhamGH)
 -
-
 # V7.3.0
 
 ## Release Highlights
@@ -187,7 +180,7 @@ N/A
 ## Important Notes
 
 - [oauth2-proxy](https://quay.io/repository/oauth2-proxy/oauth2-proxy?tab=tags&tag=latest) separate image tags for each architecture is deprecated. Instead, images are cross compiled and pushed as the same tag for every platform.
-  If you are using an architecture specific tag (ex: v7.2.1-arm64) you should move to the generic tag instead (ex: v7.2.1 )
+If you are using an architecture specific tag (ex: v7.2.1-arm64) you should move to the generic tag instead (ex: v7.2.1 )
 - [#1478](https://github.com/oauth2-proxy/oauth2-proxy/pull/1478) Changes the UID and GID of the runtime user to `65532`.
   Which also is known as `nonroot` user in [distroless images](https://github.com/GoogleContainerTools/distroless).
 - This release includes fixes for a number of CVEs, we recomend to upgrade as soon as possible.
@@ -300,7 +293,7 @@ N/A
 - [#1207](https://github.com/oauth2-proxy/oauth2-proxy/pull/1207) Fix URI fragment handling on sign-in page, regression introduced in 7.1.0 (@tarvip)
 - [#1210](https://github.com/oauth2-proxy/oauth2-proxy/pull/1210) New Keycloak OIDC Provider (@pb82)
 - [#1244](https://github.com/oauth2-proxy/oauth2-proxy/pull/1244) Update Alpine image version to 3.14 (@ahovgaard)
-- [#1317](https://github.com/oauth2-proxy/oauth2-proxy/pull/1317) Fix incorrect `</form>` tag on the sing_in page when _not_ using a custom template (@jord1e)
+- [#1317](https://github.com/oauth2-proxy/oauth2-proxy/pull/1317) Fix incorrect `</form>` tag on the sing_in page when *not* using a custom template (@jord1e)
 - [#1330](https://github.com/oauth2-proxy/oauth2-proxy/pull/1330) Allow specifying URL as input for custom sign in logo (@MaikuMori)
 - [#1357](https://github.com/oauth2-proxy/oauth2-proxy/pull/1357) Fix unsafe access to session variable (@harzallah)
 - [#997](https://github.com/oauth2-proxy/oauth2-proxy/pull/997) Allow passing the raw url path when proxying upstream requests - e.g. /%2F/ (@FStelzer)
@@ -451,6 +444,7 @@ N/A
 - GitLab provider now supports restricting to members of a project
 - Keycloak provider now supports restricting users to members of a set of groups
 - (Alpha) Flexible header configuration allowing user defined mapping of session claims to header values
+
 
 ## Important Notes
 

--- a/docs/docs/configuration/overview.md
+++ b/docs/docs/configuration/overview.md
@@ -197,6 +197,7 @@ An example [oauth2-proxy.cfg](https://github.com/oauth2-proxy/oauth2-proxy/blob/
 | `--ssl-upstream-insecure-skip-verify` | bool | skip validation of certificates presented when using HTTPS upstreams | false |
 | `--standard-logging` | bool | Log standard runtime information | true |
 | `--standard-logging-format` | string | Template for standard log lines | see [Logging Configuration](#logging-configuration) |
+| `--structured-logging-format` | string | log format structure, either `"plain"` or `"json"`. This overrides `--auth-logging-format`, `--standard-logging-format` and  `--request-logging-format`. | `"plain"` |
 | `--tls-cert-file` | string | path to certificate file | |
 | `--tls-cipher-suite` | string \| list | Restricts TLS cipher suites used by server to those listed (e.g. TLS_RSA_WITH_RC4_128_SHA) (may be given multiple times). If not specified, the default Go safe cipher list is used. List of valid cipher suites can be found in the [crypto/tls documentation](https://pkg.go.dev/crypto/tls#pkg-constants). | |
 | `--tls-key-file` | string | path to private key file | |

--- a/main.go
+++ b/main.go
@@ -25,7 +25,12 @@ func main() {
 	alphaConfig := configFlagSet.String("alpha-config", "", "path to alpha config file (use at your own risk - the structure in this config file may change between minor releases)")
 	convertConfig := configFlagSet.Bool("convert-config-to-alpha", false, "if true, the proxy will load configuration as normal and convert existing configuration to the alpha config structure, and print it to stdout")
 	showVersion := configFlagSet.Bool("version", false, "print version string")
+	setLogJsonEnable := configFlagSet.Bool("logjson", true, "enable JSON logging")
 	configFlagSet.Parse(os.Args[1:])
+
+	if *setLogJsonEnable {
+		logger.SetOutputFormatJsonEnabled(true)
+	}
 
 	if *showVersion {
 		fmt.Printf("oauth2-proxy %s (built with %s)\n", VERSION, runtime.Version())

--- a/main.go
+++ b/main.go
@@ -25,12 +25,7 @@ func main() {
 	alphaConfig := configFlagSet.String("alpha-config", "", "path to alpha config file (use at your own risk - the structure in this config file may change between minor releases)")
 	convertConfig := configFlagSet.Bool("convert-config-to-alpha", false, "if true, the proxy will load configuration as normal and convert existing configuration to the alpha config structure, and print it to stdout")
 	showVersion := configFlagSet.Bool("version", false, "print version string")
-	setLogJsonEnable := configFlagSet.Bool("logjson", true, "enable JSON logging")
 	configFlagSet.Parse(os.Args[1:])
-
-	if *setLogJsonEnable {
-		logger.SetOutputFormatJsonEnabled(true)
-	}
 
 	if *showVersion {
 		fmt.Printf("oauth2-proxy %s (built with %s)\n", VERSION, runtime.Version())

--- a/pkg/apis/options/logging.go
+++ b/pkg/apis/options/logging.go
@@ -7,18 +7,19 @@ import (
 
 // Logging contains all options required for configuring the logging
 type Logging struct {
-	AuthEnabled     bool           `flag:"auth-logging" cfg:"auth_logging"`
-	AuthFormat      string         `flag:"auth-logging-format" cfg:"auth_logging_format"`
-	RequestEnabled  bool           `flag:"request-logging" cfg:"request_logging"`
-	RequestFormat   string         `flag:"request-logging-format" cfg:"request_logging_format"`
-	StandardEnabled bool           `flag:"standard-logging" cfg:"standard_logging"`
-	StandardFormat  string         `flag:"standard-logging-format" cfg:"standard_logging_format"`
-	ErrToInfo       bool           `flag:"errors-to-info-log" cfg:"errors_to_info_log"`
-	ExcludePaths    []string       `flag:"exclude-logging-path" cfg:"exclude_logging_paths"`
-	LocalTime       bool           `flag:"logging-local-time" cfg:"logging_local_time"`
-	SilencePing     bool           `flag:"silence-ping-logging" cfg:"silence_ping_logging"`
-	RequestIDHeader string         `flag:"request-id-header" cfg:"request_id_header"`
-	File            LogFileOptions `cfg:",squash"`
+	AuthEnabled      bool           `flag:"auth-logging" cfg:"auth_logging"`
+	AuthFormat       string         `flag:"auth-logging-format" cfg:"auth_logging_format"`
+	RequestEnabled   bool           `flag:"request-logging" cfg:"request_logging"`
+	RequestFormat    string         `flag:"request-logging-format" cfg:"request_logging_format"`
+	StandardEnabled  bool           `flag:"standard-logging" cfg:"standard_logging"`
+	StandardFormat   string         `flag:"standard-logging-format" cfg:"standard_logging_format"`
+	ErrToInfo        bool           `flag:"errors-to-info-log" cfg:"errors_to_info_log"`
+	ExcludePaths     []string       `flag:"exclude-logging-path" cfg:"exclude_logging_paths"`
+	LocalTime        bool           `flag:"logging-local-time" cfg:"logging_local_time"`
+	SilencePing      bool           `flag:"silence-ping-logging" cfg:"silence_ping_logging"`
+	RequestIDHeader  string         `flag:"request-id-header" cfg:"request_id_header"`
+	File             LogFileOptions `cfg:",squash"`
+	StructuredFormat string         `flag:"structured-logging-format" cfg:"structured_logging_format"`
 }
 
 // LogFileOptions contains options for configuring logging to a file
@@ -51,6 +52,7 @@ func loggingFlagSet() *pflag.FlagSet {
 	flagSet.Int("logging-max-age", 7, "Maximum number of days to retain old log files")
 	flagSet.Int("logging-max-backups", 0, "Maximum number of old log files to retain; 0 to disable")
 	flagSet.Bool("logging-compress", false, "Should rotated log files be compressed using gzip")
+	flagSet.String("structured-logging-format", "plain", "Structured logging format: plain or json")
 
 	return flagSet
 }
@@ -76,5 +78,6 @@ func loggingDefaults() Logging {
 			MaxBackups: 0,
 			Compress:   false,
 		},
+		StructuredFormat: "plain",
 	}
 }

--- a/pkg/middleware/request_logger_test.go
+++ b/pkg/middleware/request_logger_test.go
@@ -125,7 +125,7 @@ var _ = Describe("Request logger suite", func() {
 })
 
 var _ = Describe("Request logger suite when used with structured format setting", func() {
-	type requestLoggerTableInputJson struct {
+	type requestLoggerTableInputJSON struct {
 		StructuredFormat   logger.StructuredFormat
 		ExpectedLogMessage map[string]interface{}
 	}
@@ -136,7 +136,7 @@ var _ = Describe("Request logger suite when used with structured format setting"
 	}
 
 	DescribeTable("when service a request with json format setting",
-		func(in *requestLoggerTableInputJson) {
+		func(in *requestLoggerTableInputJSON) {
 			buf := bytes.NewBuffer(nil)
 			logger.SetOutput(buf)
 			logger.SetExcludePaths([]string{})
@@ -169,7 +169,7 @@ var _ = Describe("Request logger suite when used with structured format setting"
 
 			Expect(logData).To(Equal(expectedMessage))
 		},
-		Entry("standard request", &requestLoggerTableInputJson{
+		Entry("standard request", &requestLoggerTableInputJSON{
 			StructuredFormat: logger.JSON,
 			ExpectedLogMessage: map[string]interface{}{
 				"client":           "127.0.0.1",

--- a/pkg/validation/logging.go
+++ b/pkg/validation/logging.go
@@ -52,6 +52,15 @@ func configureLogger(o options.Logging, msgs []string) []string {
 	logger.SetAuthTemplate(o.AuthFormat)
 	logger.SetReqTemplate(o.RequestFormat)
 
+	switch o.StructuredFormat {
+	case "plain":
+		logger.SetStructuredFormat(logger.Plain)
+	case "json":
+		logger.SetStructuredFormat(logger.JSON)
+	default:
+		return append(msgs, "invalid structured logging format: "+o.StructuredFormat)
+	}
+
 	logger.SetExcludePaths(o.ExcludePaths)
 
 	if !o.LocalTime {


### PR DESCRIPTION
Add support for structured logging (json)
See: https://github.com/oauth2-proxy/oauth2-proxy/issues/1057

## Description

Add configuration for structured logging. I added an option `structured-logging-format=plain|json` based on [the comment](https://github.com/oauth2-proxy/oauth2-proxy/issues/1057#issuecomment-782764686)

## Motivation and Context

Currently, oauth2-proxy allows clients to pass templates logging, but these formats are all limited to plain text because messages are not escaped before being passed to the logging template.
Since the strings aren't escaped, they can contain tokens which break the structured log parsing. For example:
`{ "message": "These nested "quotes" are unescaped JSON tokens." }`

## How Has This Been Tested?

I tested the application by providing `--structured-logging-format="json|plain|foo"` or by running the application without the `--structured-logging-format` option.

###  `--structured-logging-format="json"`
<details>
<summary>output</summary>

```
{"timestamp":"2024/06/22 18:14:00","file":"provider.go:55","message":"Performing OIDC Discovery..."}
{"timestamp":"2024/06/22 18:14:01","file":"providers.go:146","message":"Warning: Your provider supports PKCE methods [\"S256\"], but you have not enabled one with --code-challenge-method"}
{"timestamp":"2024/06/22 18:14:01","file":"oauthproxy.go:171","message":"OAuthProxy configured for OpenID Connect Client ID: xxxxxxxxxxxxxxxxxxxx"}
{"timestamp":"2024/06/22 18:14:01","file":"oauthproxy.go:177","message":"Cookie settings: name:_oauth2_proxy secure(https):true httponly:true expiry:168h0m0s domains: path:/ samesite: refresh:disabled"}
{"timestamp":"2024/06/22 18:14:12","file":"oauthproxy.go:1017","message":"No valid authentication in request. Initiating login."}
{"client":"127.0.0.1:64899","host":"localhost:4180","protocol":"HTTP/1.1","request_id":"xxxxxxxx-xxxx-xxxxxxxx","request_duration":"0.002","request_method":"GET","request_uri":"\"/\"","response_size":"8496","status_code":"403","timestamp":"2024/06/22 18:14:12","upstream":"-","user_agent":"\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36\"","username":"-"}
{"timestamp":"2024/06/22 18:14:12","file":"oauthproxy.go:1017","message":"No valid authentication in request. Initiating login."}
{"client":"127.0.0.1:64899","host":"localhost:4180","protocol":"HTTP/1.1","request_id":"xxxxxxxx-xxxx-xxxxxxxx","request_duration":"0.000","request_method":"GET","request_uri":"\"/\"","response_size":"8496","status_code":"403","timestamp":"2024/06/22 18:14:12","upstream":"-","user_agent":"\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36\"","username":"-"}
{"client":"127.0.0.1:64899","host":"localhost:4180","protocol":"HTTP/1.1","request_id":"xxxxxxxx-xxxx-xxxxxxxx","request_duration":"0.004","request_method":"GET","request_uri":"\"/oauth2/static/css/bulma.min.css\"","response_size":"207302","status_code":"200","timestamp":"2024/06/22 18:14:12","upstream":"-","user_agent":"\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36\"","username":"-"}
{"timestamp":"2024/06/22 18:14:13","file":"oauthproxy.go:1017","message":"No valid authentication in request. Initiating login."}
{"client":"127.0.0.1:64899","host":"localhost:4180","protocol":"HTTP/1.1","request_id":"xxxxxxxx-xxxx-xxxxxxxx","request_duration":"0.000","request_method":"GET","request_uri":"\"/favicon.ico\"","response_size":"8507","status_code":"403","timestamp":"2024/06/22 18:14:13","upstream":"-","user_agent":"\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36\"","username":"-"}
{"client":"127.0.0.1:64904","host":"localhost:4180","protocol":"HTTP/1.1","request_id":"8753fcad-6221-422b-bb61-9bad051df2dd","request_duration":"0.001","request_method":"GET","request_uri":"\"/oauth2/start?rd=%2F\"","response_size":"330","status_code":"302","timestamp":"2024/06/22 18:14:14","upstream":"-","user_agent":"\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36\"","username":"-"}
```
</details>

###  `--structured-logging-format="plain"`
<details>
<summary>output</summary>

```
[2024/06/23 08:01:06] [provider.go:55] Performing OIDC Discovery...
[2024/06/23 08:01:06] [providers.go:146] Warning: Your provider supports PKCE methods ["S256"], but you have not enabled one with --code-challenge-method
[2024/06/23 08:01:06] [oauthproxy.go:171] OAuthProxy configured for OpenID Connect Client ID: xxxxxxxxxxxxxxxxxxxx
[2024/06/23 08:01:06] [oauthproxy.go:177] Cookie settings: name:_oauth2_proxy secure(https):true httponly:true expiry:168h0m0s domains: path:/ samesite: refresh:disabled
[2024/06/23 08:01:09] [oauthproxy.go:1017] No valid authentication in request. Initiating login.
127.0.0.1:51576 - fxxxxxxxx-xxxx-xxxxxxxx - - [2024/06/23 08:01:09] localhost:4180 GET - "/" HTTP/1.1 "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36" 403 8496 0.003
[2024/06/23 08:01:10] [oauthproxy.go:1017] No valid authentication in request. Initiating login.
127.0.0.1:51576 - xxxxxxxx-xxxx-xxxxxxxx - - [2024/06/23 08:01:10] localhost:4180 GET - "/" HTTP/1.1 "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36" 403 8496 0.001
127.0.0.1:51576 - xxxxxxxx-xxxx-xxxxxxxx - - [2024/06/23 08:01:10] localhost:4180 GET - "/oauth2/static/css/bulma.min.css" HTTP/1.1 "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36" 200 207302 0.012
[2024/06/23 08:01:10] [oauthproxy.go:1017] No valid authentication in request. Initiating login.
127.0.0.1:51576 - xxxxxxxx-xxxx-xxxxxxxx - - [2024/06/23 08:01:10] localhost:4180 GET - "/favicon.ico" HTTP/1.1 "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36" 403 8507 0.000
127.0.0.1:51587 - xxxxxxxx-xxxx-xxxxxxxx - - [2024/06/23 08:01:14] localhost:4180 GET - "/oauth2/start?rd=%2F" HTTP/1.1 "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36" 302 330 0.000
```
</details>

### `--structured-logging-format="foo"`
<details>
<summary>output</summary>

```
[2024/06/23 08:03:10] [main.go:52] invalid configuration:
  invalid structured logging format: foo
```
</details>

### Run without `--structured-logging-format` option
output: same as when `--structured-logging-format="plain"` is provided

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
- [x] I have written tests for my code changes.
