### PR TITLE
feat: support additional claims

### DIFF
--- a/docs/docs/configuration/alpha_config.md
+++ b/docs/docs/configuration/alpha_config.md
@@ -440,6 +440,7 @@ Provider holds all configuration for a single provider
 | `scope` | _string_ | Scope is the OAuth scope specification |
 | `allowedGroups` | _[]string_ | AllowedGroups is a list of restrict logins to members of this group |
 | `code_challenge_method` | _string_ | The code challenge method |
+| `allowAdditionalClaims` | _[]string_ | Allows additional claims to be obtained from the `id_token`. |
 | `backendLogoutURL` | _string_ | URL to call to perform backend logout, `{id_token}` would be replaced by the actual `id_token` if available in the session |
 
 ### ProviderType

--- a/pkg/apis/options/providers.go
+++ b/pkg/apis/options/providers.go
@@ -84,6 +84,9 @@ type Provider struct {
 	// The code challenge method
 	CodeChallengeMethod string `json:"code_challenge_method,omitempty"`
 
+	// Allows additional claims to be obtained from the `id_token`.
+	AllowAdditionalClaims []string `json:"allowAdditionalClaims,omitempty"`
+
 	// URL to call to perform backend logout, `{id_token}` would be replaced by the actual `id_token` if available in the session
 	BackendLogoutURL string `json:"backendLogoutURL"`
 }

--- a/pkg/apis/sessions/session_state.go
+++ b/pkg/apis/sessions/session_state.go
@@ -29,6 +29,9 @@ type SessionState struct {
 	Groups            []string `msgpack:"g,omitempty"`
 	PreferredUsername string   `msgpack:"pu,omitempty"`
 
+	// Additional claims
+	AdditionalClaims map[string]string `msgpack:"ac,omitempty"`
+
 	// Internal helpers, not serialized
 	Clock clock.Clock `msgpack:"-"`
 	Lock  Lock        `msgpack:"-"`
@@ -149,6 +152,10 @@ func (s *SessionState) GetClaim(claim string) []string {
 	case "preferred_username":
 		return []string{s.PreferredUsername}
 	default:
+		// Check in AdditionalClaims
+		if value, ok := s.AdditionalClaims[claim]; ok {
+			return []string{value}
+		}
 		return []string{}
 	}
 }

--- a/pkg/apis/sessions/session_state_test.go
+++ b/pkg/apis/sessions/session_state_test.go
@@ -225,6 +225,21 @@ func TestEncodeAndDecodeSessionState(t *testing.T) {
 			Nonce:             []byte("abcdef1234567890abcdef1234567890"),
 			Groups:            []string{"group-a", "group-b"},
 		},
+		"With additional claims": {
+			Email:             "username@example.com",
+			User:              "username",
+			PreferredUsername: "preferred.username",
+			AccessToken:       "AccessToken.12349871293847fdsaihf9238h4f91h8fr.1349f831y98fd7",
+			IDToken:           "IDToken.12349871293847fdsaihf9238h4f91h8fr.1349f831y98fd7",
+			CreatedAt:         &created,
+			ExpiresOn:         &expires,
+			RefreshToken:      "RefreshToken.12349871293847fdsaihf9238h4f91h8fr.1349f831y98fd7",
+			Nonce:             []byte("abcdef1234567890abcdef1234567890"),
+			Groups:            []string{"group-a", "group-b"},
+			AdditionalClaims: map[string]string{
+				"custom_claim_1": "value1",
+			},
+		},
 	}
 
 	for _, secretSize := range []int{16, 24, 32} {
@@ -291,4 +306,47 @@ func compareSessionStates(t *testing.T, expected *SessionState, actual *SessionS
 	act.CreatedAt = nil
 	act.ExpiresOn = nil
 	assert.Equal(t, exp, act)
+}
+
+func TestGetClaim(t *testing.T) {
+	createdAt := time.Now()
+	expiresOn := createdAt.Add(1 * time.Hour)
+
+	ss := &SessionState{
+		CreatedAt:         &createdAt,
+		ExpiresOn:         &expiresOn,
+		AccessToken:       "AccessToken.12349871293847fdsaihf9238h4f91h8fr.1349f831y98fd7",
+		IDToken:           "IDToken.12349871293847fdsaihf9238h4f91h8fr.1349f831y98fd7",
+		RefreshToken:      "RefreshToken.12349871293847fdsaihf9238h4f91h8fr.1349f831y98fd7",
+		Email:             "user@example.com",
+		User:              "user123",
+		Groups:            []string{"group1", "group2"},
+		PreferredUsername: "preferred_user",
+		AdditionalClaims: map[string]string{
+			"custom_claim_1": "value1",
+		},
+	}
+
+	tests := []struct {
+		claim string
+		want  []string
+	}{
+		{"access_token", []string{"AccessToken.12349871293847fdsaihf9238h4f91h8fr.1349f831y98fd7"}},
+		{"id_token", []string{"IDToken.12349871293847fdsaihf9238h4f91h8fr.1349f831y98fd7"}},
+		{"refresh_token", []string{"RefreshToken.12349871293847fdsaihf9238h4f91h8fr.1349f831y98fd7"}},
+		{"created_at", []string{createdAt.String()}},
+		{"expires_on", []string{expiresOn.String()}},
+		{"email", []string{"user@example.com"}},
+		{"user", []string{"user123"}},
+		{"groups", []string{"group1", "group2"}},
+		{"preferred_username", []string{"preferred_user"}},
+		{"custom_claim_1", []string{"value1"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.claim, func(t *testing.T) {
+			gs := NewWithT(t)
+			gs.Expect(ss.GetClaim(tt.claim)).To(Equal(tt.want))
+		})
+	}
 }

--- a/providers/provider_data.go
+++ b/providers/provider_data.go
@@ -48,6 +48,7 @@ type ProviderData struct {
 	EmailClaim               string
 	GroupsClaim              string
 	Verifier                 internaloidc.IDTokenVerifier
+	AllowAdditionalClaims    []string `json:"allowAdditionalClaims,omitempty"`
 	SkipClaimsFromProfileURL bool
 
 	// Universal Group authorization data structure
@@ -264,6 +265,19 @@ func (p *ProviderData) buildSessionFromClaims(rawIDToken, accessToken string) (*
 		if _, err := extractor.GetClaimInto(c.claim, c.dst); err != nil {
 			return nil, err
 		}
+	}
+
+	// Extract additional claims
+	for _, claim := range p.AllowAdditionalClaims {
+		var value string
+		if _, err := extractor.GetClaimInto(claim, &value); err != nil {
+			return nil, err
+		}
+
+		if ss.AdditionalClaims == nil {
+			ss.AdditionalClaims = make(map[string]string)
+		}
+		ss.AdditionalClaims[claim] = value
 	}
 
 	// `email_verified` must be present and explicitly set to `false` to be

--- a/providers/provider_data_test.go
+++ b/providers/provider_data_test.go
@@ -237,6 +237,7 @@ func TestProviderData_buildSessionFromClaims(t *testing.T) {
 		ExpectedError            error
 		ExpectedSession          *sessions.SessionState
 		ExpectProfileURLCalled   bool
+		AllowAdditionalClaims    []string
 	}{
 		"Standard": {
 			IDToken:         defaultIDToken,
@@ -417,6 +418,17 @@ func TestProviderData_buildSessionFromClaims(t *testing.T) {
 			SkipClaimsFromProfileURL: true,
 			ExpectedSession:          &sessions.SessionState{},
 		},
+		"Allow additional claims": {
+			IDToken:               defaultIDToken,
+			AllowAdditionalClaims: []string{"phone_number", "picture"},
+			ExpectedSession: &sessions.SessionState{
+				PreferredUsername: "Jane Dobbs",
+				AdditionalClaims: map[string]string{
+					"phone_number": "+4798765432",
+					"picture":      "http://mugbook.com/janed/me.jpg",
+				},
+			},
+		},
 	}
 	for testName, tc := range testCases {
 		t.Run(testName, func(t *testing.T) {
@@ -453,6 +465,7 @@ func TestProviderData_buildSessionFromClaims(t *testing.T) {
 			provider.EmailClaim = tc.EmailClaim
 			provider.GroupsClaim = tc.GroupsClaim
 			provider.SkipClaimsFromProfileURL = tc.SkipClaimsFromProfileURL
+			provider.AllowAdditionalClaims = tc.AllowAdditionalClaims
 
 			rawIDToken, err := newSignedTestIDToken(tc.IDToken)
 			g.Expect(err).ToNot(HaveOccurred())

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -76,6 +76,8 @@ func newProviderDataFromConfig(providerConfig options.Provider) (*ProviderData, 
 		ClientID:         providerConfig.ClientID,
 		ClientSecret:     providerConfig.ClientSecret,
 		ClientSecretFile: providerConfig.ClientSecretFile,
+		// allow additional claims to be extracted from the ID Token
+		AllowAdditionalClaims: providerConfig.AllowAdditionalClaims,
 	}
 
 	needsVerifier, err := providerRequiresOIDCProviderVerifier(providerConfig.Type)


### PR DESCRIPTION
## Description

Allows retrieval of additional claims from `IDToken`.

## Motivation and Context

The `IDToken` from the `OIDCProvider` I'm using contains claims that I want to use, but currently only a few of them can be injected into the response headers. This change allows users to specify additional claims from the `IDToken` that they want to include.

## Checklist:

- [X] My change requires a change to the documentation or CHANGELOG.
- [X] I have updated the documentation/CHANGELOG accordingly.
- [X] I have created a feature (non-master) branch for my PR.
- [X] I have written tests for my code changes.




