### PR TITLE
Enable JWT token in non-standard headers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/go:1-1.21
+FROM mcr.microsoft.com/vscode/devcontainers/go:1-1.22
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -401,7 +401,7 @@ func buildSessionChain(opts *options.Options, provider providers.Provider, sessi
 				middlewareapi.CreateTokenToSessionFunc(verifier.Verify))
 		}
 
-		chain = chain.Append(middleware.NewJwtSessionLoader(sessionLoaders))
+		chain = chain.Append(middleware.NewJwtSessionLoader(sessionLoaders, opts.ExtraJwtHeaders))
 	}
 
 	if validator != nil {

--- a/pkg/apis/options/options.go
+++ b/pkg/apis/options/options.go
@@ -57,6 +57,7 @@ type Options struct {
 	SkipAuthRoutes        []string `flag:"skip-auth-route" cfg:"skip_auth_routes"`
 	SkipJwtBearerTokens   bool     `flag:"skip-jwt-bearer-tokens" cfg:"skip_jwt_bearer_tokens"`
 	ExtraJwtIssuers       []string `flag:"extra-jwt-issuers" cfg:"extra_jwt_issuers"`
+	ExtraJwtHeaders       []string `flag:"extra-jwt-headers" cfg:"extra_jwt_headers"`
 	SkipProviderButton    bool     `flag:"skip-provider-button" cfg:"skip_provider_button"`
 	SSLInsecureSkipVerify bool     `flag:"ssl-insecure-skip-verify" cfg:"ssl_insecure_skip_verify"`
 	SkipAuthPreflight     bool     `flag:"skip-auth-preflight" cfg:"skip_auth_preflight"`
@@ -132,6 +133,7 @@ func NewFlagSet() *pflag.FlagSet {
 	flagSet.Bool("encode-state", false, "will encode oauth state with base64")
 	flagSet.Bool("allow-query-semicolons", false, "allow the use of semicolons in query args")
 	flagSet.StringSlice("extra-jwt-issuers", []string{}, "if skip-jwt-bearer-tokens is set, a list of extra JWT issuer=audience pairs (where the issuer URL has a .well-known/openid-configuration or a .well-known/jwks.json)")
+	flagSet.StringSlice("extra-jwt-headers", []string{}, "if skip-jwt-bearer-tokens is set, a list of additional headers to look for a JWT bearer token")
 
 	flagSet.StringSlice("email-domain", []string{}, "authenticate emails with the specified domain (may be given multiple times). Use * to authenticate any email")
 	flagSet.StringSlice("whitelist-domain", []string{}, "allowed domains for redirection after authentication. Prefix domain with a . or a *. to allow subdomains (eg .example.com, *.example.com)")

--- a/pkg/middleware/jwt_session_test.go
+++ b/pkg/middleware/jwt_session_test.go
@@ -89,9 +89,11 @@ Nnc3a3lGVWFCNUMxQnNJcnJMTWxka1dFaHluYmI4Ongtb2F1dGgtYmFzaWM=`
 		})
 
 		type jwtSessionLoaderTableInput struct {
-			authorizationHeader string
-			existingSession     *sessionsapi.SessionState
-			expectedSession     *sessionsapi.SessionState
+			authorizationHeader  string
+			additionalJwtHeaders []string
+			extraHeaders         map[string]string
+			existingSession      *sessionsapi.SessionState
+			expectedSession      *sessionsapi.SessionState
 		}
 
 		DescribeTable("with an authorization header",
@@ -103,6 +105,9 @@ Nnc3a3lGVWFCNUMxQnNJcnJMTWxka1dFaHluYmI4Ongtb2F1dGgtYmFzaWM=`
 				// Set up the request with the authorization header and a request scope
 				req := httptest.NewRequest("", "/", nil)
 				req.Header.Set("Authorization", in.authorizationHeader)
+				for headerName, headerValue := range in.extraHeaders {
+					req.Header.Set(headerName, headerValue)
+				}
 				req = middlewareapi.AddRequestScope(req, scope)
 
 				rw := httptest.NewRecorder()
@@ -114,7 +119,7 @@ Nnc3a3lGVWFCNUMxQnNJcnJMTWxka1dFaHluYmI4Ongtb2F1dGgtYmFzaWM=`
 				// Create the handler with a next handler that will capture the session
 				// from the scope
 				var gotSession *sessionsapi.SessionState
-				handler := NewJwtSessionLoader(sessionLoaders)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				handler := NewJwtSessionLoader(sessionLoaders, in.additionalJwtHeaders)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					gotSession = middlewareapi.GetRequestScope(r).Session
 				}))
 				handler.ServeHTTP(rw, req)
@@ -122,44 +127,102 @@ Nnc3a3lGVWFCNUMxQnNJcnJMTWxka1dFaHluYmI4Ongtb2F1dGgtYmFzaWM=`
 				Expect(gotSession).To(Equal(in.expectedSession))
 			},
 			Entry("<no value>", jwtSessionLoaderTableInput{
-				authorizationHeader: "",
-				existingSession:     nil,
-				expectedSession:     nil,
+				authorizationHeader:  "",
+				extraHeaders:         nil,
+				additionalJwtHeaders: []string{},
+				existingSession:      nil,
+				expectedSession:      nil,
 			}),
 			Entry("abcdef", jwtSessionLoaderTableInput{
-				authorizationHeader: "abcdef",
-				existingSession:     nil,
-				expectedSession:     nil,
+				authorizationHeader:  "abcdef",
+				extraHeaders:         nil,
+				additionalJwtHeaders: []string{},
+				existingSession:      nil,
+				expectedSession:      nil,
 			}),
 			Entry("abcdef  (with existing session)", jwtSessionLoaderTableInput{
-				authorizationHeader: "abcdef",
-				existingSession:     &sessionsapi.SessionState{User: "user"},
-				expectedSession:     &sessionsapi.SessionState{User: "user"},
+				authorizationHeader:  "abcdef",
+				extraHeaders:         nil,
+				additionalJwtHeaders: []string{},
+				existingSession:      &sessionsapi.SessionState{User: "user"},
+				expectedSession:      &sessionsapi.SessionState{User: "user"},
 			}),
 			Entry("Bearer <verifiedToken>", jwtSessionLoaderTableInput{
-				authorizationHeader: fmt.Sprintf("Bearer %s", verifiedToken),
-				existingSession:     nil,
-				expectedSession:     verifiedSession,
+				authorizationHeader:  fmt.Sprintf("Bearer %s", verifiedToken),
+				extraHeaders:         nil,
+				additionalJwtHeaders: []string{},
+				existingSession:      nil,
+				expectedSession:      verifiedSession,
 			}),
 			Entry("Bearer <nonVerifiedToken>", jwtSessionLoaderTableInput{
-				authorizationHeader: fmt.Sprintf("Bearer %s", nonVerifiedToken),
-				existingSession:     nil,
-				expectedSession:     nil,
+				authorizationHeader:  fmt.Sprintf("Bearer %s", nonVerifiedToken),
+				extraHeaders:         nil,
+				additionalJwtHeaders: []string{},
+				existingSession:      nil,
+				expectedSession:      nil,
+			}),
+			Entry("<VerifiedToken> in unknown header", jwtSessionLoaderTableInput{
+				authorizationHeader: "",
+				extraHeaders: map[string]string{
+					"x-my-token": fmt.Sprintf("Bearer %s", verifiedToken),
+				},
+				additionalJwtHeaders: []string{},
+				existingSession:      nil,
+				expectedSession:      nil,
+			}),
+			Entry("<VerifiedToken> in custom header", jwtSessionLoaderTableInput{
+				authorizationHeader: "",
+				extraHeaders: map[string]string{
+					"x-my-token": fmt.Sprintf("Bearer %s", verifiedToken),
+				},
+				additionalJwtHeaders: []string{
+					"x-my-token",
+				},
+				existingSession: nil,
+				expectedSession: verifiedSession,
+			}),
+			Entry("<VerifiedToken> in custom header without tokenType", jwtSessionLoaderTableInput{
+				authorizationHeader: "",
+				extraHeaders: map[string]string{
+					"x-my-token": verifiedToken,
+				},
+				additionalJwtHeaders: []string{
+					"x-my-token",
+				},
+				existingSession: nil,
+				expectedSession: verifiedSession,
+			}),
+			Entry("<nonVerifiedToken> in custom header", jwtSessionLoaderTableInput{
+				authorizationHeader: "",
+				extraHeaders: map[string]string{
+					"x-my-token": fmt.Sprintf("Bearer %s", nonVerifiedToken),
+				},
+				additionalJwtHeaders: []string{
+					"x-my-token",
+				},
+				existingSession: nil,
+				expectedSession: nil,
 			}),
 			Entry("Bearer <verifiedToken> (with existing session)", jwtSessionLoaderTableInput{
-				authorizationHeader: fmt.Sprintf("Bearer %s", verifiedToken),
-				existingSession:     &sessionsapi.SessionState{User: "user"},
-				expectedSession:     &sessionsapi.SessionState{User: "user"},
+				authorizationHeader:  fmt.Sprintf("Bearer %s", verifiedToken),
+				extraHeaders:         nil,
+				additionalJwtHeaders: []string{},
+				existingSession:      &sessionsapi.SessionState{User: "user"},
+				expectedSession:      &sessionsapi.SessionState{User: "user"},
 			}),
 			Entry("Basic Base64(<nonVerifiedToken>:) (No password)", jwtSessionLoaderTableInput{
-				authorizationHeader: "Basic ZXlKZm9vYmFyLmV5SmZvb2Jhci4xMjM0NWFzZGY6",
-				existingSession:     nil,
-				expectedSession:     nil,
+				authorizationHeader:  "Basic ZXlKZm9vYmFyLmV5SmZvb2Jhci4xMjM0NWFzZGY6",
+				extraHeaders:         nil,
+				additionalJwtHeaders: []string{},
+				existingSession:      nil,
+				expectedSession:      nil,
 			}),
 			Entry("Basic Base64(<verifiedToken>:x-oauth-basic) (Sentinel password)", jwtSessionLoaderTableInput{
-				authorizationHeader: fmt.Sprintf("Basic %s", verifiedTokenXOAuthBasicBase64),
-				existingSession:     nil,
-				expectedSession:     verifiedSession,
+				authorizationHeader:  fmt.Sprintf("Basic %s", verifiedTokenXOAuthBasicBase64),
+				extraHeaders:         nil,
+				additionalJwtHeaders: []string{},
+				existingSession:      nil,
+				expectedSession:      verifiedSession,
 			}),
 		)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Oauth2-proxy allows verification and validation of a JWT token present in the `Authorization` header.
Some systems however inject the JWT token in a different header.

This PR addresses this, and allows for additional locations to search for an existing JWT token.

## Motivation and Context

The use-case where we would like to use this is in combination with an AWS ALB (Application Load Balancer) with OIDC [authentication](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/listener-authenticate-users.html) enabled. 

This ALB puts the JWT token in the `x-amzn-oidc-accesstoken` header, without any prefix.

## How Has This Been Tested?

Verified in a test deployment where oauth-proxy is being used as a side-car

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
- [x] I have written tests for my code changes.
