### PR TITLE
chore(ci): ignore markdown files for build ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,7 @@ on:
       - '.vscode/**'
       - 'contrib/**'
       - 'docs/**'
+      - '*.md'
   pull_request:
     branches:
       - '**'
@@ -17,6 +18,7 @@ on:
       - '.vscode/**'
       - 'contrib/**'
       - 'docs/**'
+      - '*.md'
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Don't run build CI and Code Quality check if only markdown files changed.
<!--- Describe your changes in detail -->

## Motivation and Context
Less CI/CD overhead.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->