### PR TITLE
revert: ignoring non-code paths

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,21 +4,9 @@ on:
   push:
     branches:
       - '**'
-    paths-ignore:
-      - '.devcontainer/**'
-      - '.vscode/**'
-      - 'contrib/**'
-      - 'docs/**'
-      - '*.md'
   pull_request:
     branches:
       - '**'
-    paths-ignore:
-      - '.devcontainer/**'
-      - '.vscode/**'
-      - 'contrib/**'
-      - 'docs/**'
-      - '*.md'
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Revert is necessary because build is currently marked as a required workflow.