### PR TITLE
Add a healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,4 +48,6 @@ FROM ${RUNTIME_IMAGE}
 COPY --from=builder /go/src/github.com/oauth2-proxy/oauth2-proxy/oauth2-proxy /bin/oauth2-proxy
 COPY --from=builder /go/src/github.com/oauth2-proxy/oauth2-proxy/jwt_signing_key.pem /etc/ssl/private/jwt_signing_key.pem
 
+HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 CMD ["/bin/oauth2-proxy", "--healthcheck"]
+
 ENTRYPOINT ["/bin/oauth2-proxy"]

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -1,0 +1,87 @@
+package healthcheck
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/requests"
+)
+
+func PerformHealthcheck(opts *options.Options) error {
+	var errs = make([]error, 0)
+
+	if opts.Server.BindAddress != "" && opts.Server.BindAddress != "-" {
+		errs = append(errs, performHealthcheckWithScheme("http", opts.Server.BindAddress, opts.PingPath))
+	}
+	if opts.Server.SecureBindAddress != "" && opts.Server.SecureBindAddress != "-" {
+		errs = append(errs, performHealthcheckWithScheme("https", opts.Server.SecureBindAddress, opts.PingPath))
+	}
+
+	return errors.Join(errs...)
+}
+
+func performHealthcheckWithScheme(scheme string, addr string, path string) error {
+	url, err := getHealthcheckURL(scheme, addr, path)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+
+	res, err := requests.DefaultHTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	return checkHealthcheckResponse(res)
+}
+
+func getHealthcheckURL(scheme string, addr string, path string) (string, error) {
+	if !strings.HasPrefix(path, "/") {
+		return "", fmt.Errorf("ping-path must be non-empty and start with '/'")
+	}
+
+	i := strings.Index(addr, "://")
+	if i > -1 {
+		scheme, addr = addr[:i], addr[i+1:]
+	}
+
+	if scheme != "http" && scheme != "https" {
+		return "", fmt.Errorf("only http and https schemes supported for healthcheck, not %v", scheme)
+	}
+
+	i = strings.LastIndex(addr, ":")
+	if i < 0 {
+		return "", fmt.Errorf("no port delimiter (':') in %v", addr)
+	}
+
+	host, port := addr[:i], addr[i+1:]
+	if host == "" || host == "0.0.0.0" {
+		host = "127.0.0.1"
+	}
+	if host == "[::]" {
+		host = "[::1]"
+	}
+
+	return fmt.Sprintf("%s://%s:%s%s", scheme, host, port, path), nil
+}
+
+func checkHealthcheckResponse(res *http.Response) error {
+	if res.StatusCode != 200 {
+		body, err := io.ReadAll(res.Body)
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("url %v, status %v, body %q", res.Request.URL, res.StatusCode, body)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Still a work in progress. No tests or documentation yet.

<!--- Provide a general summary of your changes in the Title above -->

## Description

Comprises:

* a new `--healthcheck` option
* a healthcheck implementation that uses the config to discover the
  ping endpoint
* a `HEALTHCHECK` Dockerfile directive to register the healthcheck

The healthcheck is tied to the ping endpoint and not the ready endpoint,
because an inability to connect to external services (which is what the
ready endpoint checks) is not a problem with oauth2-proxy itself.

## Motivation and Context

Closes #2555.

## How Has This Been Tested?

Have run against a serving oauth2-proxy instance that uses Redis.

With oauth2-proxy available:

```sh
$ dotenv -f oauth2-proxy.env run ./oauth2-proxy --alpha-config oauth2-proxy-alpha-config.yaml --healthcheck
[2024/07/25 13:16:44] [main.go:88] WARNING: You are using alpha configuration. The structure in this configuration file may change without notice. You MUST remove conflicting options from your existing configuration.
[2024/07/25 13:16:44] [main.go:63] INFO: healthcheck ok
$ echo $?
0
```

With oauth2-proxy subsequently unavailable:

```sh
$ dotenv -f oauth2-proxy.env run ./oauth2-proxy --alpha-config oauth2-proxy-alpha-config.yaml --healthcheck
[2024/07/25 13:16:50] [main.go:88] WARNING: You are using alpha configuration. The structure in this configuration file may change without notice. You MUST remove conflicting options from your existing configuration.
[2024/07/25 13:16:50] [main.go:61] ERROR: healthcheck failed: Get "http://127.0.0.1:8001/ping": dial tcp 127.0.0.1:8001: connect: connection refused
$ echo $?
1
```

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.
