### PR TITLE
Role-based Authorization support in `/oauth2/auth` endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [#2674](https://github.com/oauth2-proxy/oauth2-proxy/pull/2674) docs: additional notes about available claims for HeaderValue (@vegetablest)
 - [#2459](https://github.com/oauth2-proxy/oauth2-proxy/pull/2459) chore(deps): Updated to ginkgo v2 (@kvanzuijlen, @tuunit)
 - [#2112](https://github.com/oauth2-proxy/oauth2-proxy/pull/2112) docs: update list of providers which support refresh tokens (@mikefab-msf)
+- [#2724](https://github.com/oauth2-proxy/oauth2-proxy/pull/2724) `/oauth2/auth` Introduced `allowed_roles` querystring parameter for use with Keycloak OIDC; it behaves the same as the existing `allowed_groups` parameter.
 
 # V7.6.0
 

--- a/docs/versioned_docs/version-7.6.x/features/endpoints.md
+++ b/docs/versioned_docs/version-7.6.x/features/endpoints.md
@@ -42,6 +42,8 @@ BEWARE that the domain you want to redirect to (`my-oidc-provider.example.com` i
 This endpoint returns 202 Accepted response or a 401 Unauthorized response.
 
 It can be configured using the following query parameters:
+
 - `allowed_groups`: comma separated list of allowed groups
+- `allowed_roles`: comma separated list of allowed roles; only works with the keycloak-oidc provider
 - `allowed_email_domains`: comma separated list of allowed email domains
 - `allowed_emails`: comma separated list of allowed emails


### PR DESCRIPTION
## Description

As a follow-up to #849 and the discussions in #831, this adds support for an additional query parameter `allowed_roles` to allow authorization by role when using the Keycloak OIDC provider. Since the configuration already supports such a setting, it felt natural to add it to the `auth` endpoint as well.

## How Has This Been Tested?

Added unit tests, tests against my own implementation.

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation accordingly.
- [x] I have updated the CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
- [x] I have written tests for my code changes.
