### PR TITLE
Mention value seperation for plural environment variables

### DIFF
--- a/docs/docs/configuration/overview.md
+++ b/docs/docs/configuration/overview.md
@@ -280,7 +280,10 @@ This is particularly useful for storing secrets outside a configuration file
 or the command line.
 
 For example, the `--cookie-secret` flag becomes `OAUTH2_PROXY_COOKIE_SECRET`,
-and the `--email-domain` flag becomes `OAUTH2_PROXY_EMAIL_DOMAINS`.
+and the `--email-domain` flag becomes `OAUTH2_PROXY_EMAIL_DOMAINS`. 
+
+Values for plural environment variables should be seperated by `,` e.g. 
+`OAUTH2_PROXY_SKIP_AUTH_ROUTES="GET=^/api/status,POST=^/api/saved_objects/_import"`
 
 ## Logging Configuration
 

--- a/docs/docs/configuration/overview.md
+++ b/docs/docs/configuration/overview.md
@@ -279,11 +279,15 @@ environment variable should be plural (trailing `S`).
 This is particularly useful for storing secrets outside a configuration file
 or the command line.
 
-For example, the `--cookie-secret` flag becomes `OAUTH2_PROXY_COOKIE_SECRET`,
-and the `--email-domain` flag becomes `OAUTH2_PROXY_EMAIL_DOMAINS`. 
+For example, the `--cookie-secret` flag becomes `OAUTH2_PROXY_COOKIE_SECRET`.
+If a flag has the type `string | list` like the `--email-domain` flag it is
+available as an environment variable in plural form e.g. `OAUTH2_PROXY_EMAIL_DOMAINS`
 
-Values for plural environment variables should be seperated by `,` e.g. 
+Values for type `string | list` usually have a plural environment variable name
+and need to be seperated by `,` e.g.
 `OAUTH2_PROXY_SKIP_AUTH_ROUTES="GET=^/api/status,POST=^/api/saved_objects/_import"`
+
+Please check the type for each [config option](#config-options) first.
 
 ## Logging Configuration
 

--- a/docs/versioned_docs/version-7.6.x/configuration/overview.md
+++ b/docs/versioned_docs/version-7.6.x/configuration/overview.md
@@ -280,7 +280,10 @@ This is particularly useful for storing secrets outside a configuration file
 or the command line.
 
 For example, the `--cookie-secret` flag becomes `OAUTH2_PROXY_COOKIE_SECRET`,
-and the `--email-domain` flag becomes `OAUTH2_PROXY_EMAIL_DOMAINS`.
+and the `--email-domain` flag becomes `OAUTH2_PROXY_EMAIL_DOMAINS`. 
+
+Values for plural environment variables should be seperated by `,` e.g. 
+`OAUTH2_PROXY_SKIP_AUTH_ROUTES="GET=^/api/status,POST=^/api/saved_objects/_import"`
 
 ## Logging Configuration
 

--- a/docs/versioned_docs/version-7.6.x/configuration/overview.md
+++ b/docs/versioned_docs/version-7.6.x/configuration/overview.md
@@ -279,11 +279,15 @@ environment variable should be plural (trailing `S`).
 This is particularly useful for storing secrets outside a configuration file
 or the command line.
 
-For example, the `--cookie-secret` flag becomes `OAUTH2_PROXY_COOKIE_SECRET`,
-and the `--email-domain` flag becomes `OAUTH2_PROXY_EMAIL_DOMAINS`. 
+For example, the `--cookie-secret` flag becomes `OAUTH2_PROXY_COOKIE_SECRET`.
+If a flag has the type `string | list` like the `--email-domain` flag it is
+available as an environment variable in plural form e.g. `OAUTH2_PROXY_EMAIL_DOMAINS`
 
-Values for plural environment variables should be seperated by `,` e.g. 
+Values for type `string | list` usually have a plural environment variable name
+and need to be seperated by `,` e.g.
 `OAUTH2_PROXY_SKIP_AUTH_ROUTES="GET=^/api/status,POST=^/api/saved_objects/_import"`
+
+Please check the type for each [config option](#config-options) first.
 
 ## Logging Configuration
 


### PR DESCRIPTION
## Description

Improve documentation to mention how values should be given in plural environment variables.

## Motivation and Context

We needed to set `OAUTH2_PROXY_SKIP_AUTH_ROUTES` but the documentation was not clear how to seperate the values.

## How Has This Been Tested?

Was tested in our docker setup.

## Checklist:

- [ ] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.
