### PR TITLE
Feature/s390x option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [#2674](https://github.com/oauth2-proxy/oauth2-proxy/pull/2674) docs: additional notes about available claims for HeaderValue (@vegetablest)
 - [#2459](https://github.com/oauth2-proxy/oauth2-proxy/pull/2459) chore(deps): Updated to ginkgo v2 (@kvanzuijlen, @tuunit)
 - [#2112](https://github.com/oauth2-proxy/oauth2-proxy/pull/2112) docs: update list of providers which support refresh tokens (@mikefab-msf)
+- [#2734](https://github.com/oauth2-proxy/oauth2-proxy/pull/2734) Added s390x architecture option support (@priby05)
 
 # V7.6.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ RUN case ${TARGETPLATFORM} in \
          # https://github.com/golang/go/wiki/GoArm
          "linux/arm64" | "linux/arm/v8")  GOARCH=arm64  ;; \
          "linux/ppc64le")  GOARCH=ppc64le  ;; \
+         "linux/s390x")  GOARCH=s390x  ;; \
          "linux/arm/v6") GOARCH=arm GOARM=6  ;; \
          "linux/arm/v7") GOARCH=arm GOARM=7 ;; \
     esac && \

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ Going forward, all images shall be available at `quay.io/oauth2-proxy/oauth2-pro
     ```
     This will install the binary into `$GOPATH/bin`. Make sure you include `$GOPATH` in your `$PATH`. Otherwise your system won't find binaries installed via `go install`
 
-    c. Using a [Prebuilt Docker Image](https://quay.io/oauth2-proxy/oauth2-proxy) (AMD64, PPC64LE, ARMv6, ARMv7, and ARM64 available)
+    c. Using a [Prebuilt Docker Image](https://quay.io/oauth2-proxy/oauth2-proxy) (AMD64, PPC64LE, S390x, ARMv6, ARMv7, and ARM64 available)
 
-    d. Using a [Pre-Release Nightly Docker Image](https://quay.io/oauth2-proxy/oauth2-proxy-nightly) (AMD64, PPC64LE, ARMv6, ARMv7, and ARM64 available)
+    d. Using a [Pre-Release Nightly Docker Image](https://quay.io/oauth2-proxy/oauth2-proxy-nightly) (AMD64, PPC64LE, S390x, ARMv6, ARMv7, and ARM64 available)
 
     e. Using the official [Kubernetes manifest](https://github.com/oauth2-proxy/manifests) (Helm)
 

--- a/dist.sh
+++ b/dist.sh
@@ -16,6 +16,7 @@ ARCHS=(
   linux-armv6
   linux-armv7
   linux-ppc64le
+  linux-s390x
   freebsd-amd64
   windows-amd64
 )

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -13,7 +13,7 @@ title: Installation
     ```
     This will install the binary into `$GOPATH/bin`. Make sure you include `$GOPATH` in your `$PATH`. Otherwise your system won't find binaries installed via `go install`
 
-    c. Using a [Prebuilt Docker Image](https://quay.io/oauth2-proxy/oauth2-proxy) (AMD64, PPC64LE, ARMv6, ARMv7, and ARM64 available)
+    c. Using a [Prebuilt Docker Image](https://quay.io/oauth2-proxy/oauth2-proxy) (AMD64, PPC64LE, S390x, ARMv6, ARMv7, and ARM64 available)
 
     d. Using a [Pre-Release Nightly Docker Image](https://quay.io/oauth2-proxy/oauth2-proxy-nightly) (AMD64, PPC64LE, ARMv6, ARMv7, and ARM64 available)
 


### PR DESCRIPTION
This PR simply adds the option of s390x as an architecture choice.

## Description

This change simply adds the option of s390x to both the Dockerfile and the dist.sh.

## Motivation and Context

Currently, we have an IBM Z mainframe that is trying to leverage the oauth proxy image in our kubernetes deployments but by default this does not allow Z (or s390x) architecture images.

## How Has This Been Tested?

I forked this repo and tested building, pushing and deploying this on our RHOCP cluster running on the IBM Z hardware. So the dependencies are not a problem on our hardware.

## Checklist:

- [X] My change requires a change to the documentation or CHANGELOG.
- [X] I have updated the documentation/CHANGELOG accordingly.
- [X] I have created a feature (non-master) branch for my PR.
- [] I have written tests for my code changes.