### PR TITLE
Add a Discord provider (based off of PR 2113)

### DIFF
--- a/docs/docs/configuration/providers/discord.md
+++ b/docs/docs/configuration/providers/discord.md
@@ -1,0 +1,44 @@
+---
+id: discord
+title: Discord
+---
+
+## Config Options
+
+| Flag                 | Toml Field          | Type           | Description                                              | Default |
+| -------------------- | ------------------- | -------------- | -------------------------------------------------------- | ------- |
+| `--discord-guild-id` | `discord_guild_ids` | string \| list | restricts logins to members of a specific Discord server |         |
+
+## Usage
+
+Note: On Discord, the terms 'guild' and 'channel' are interchangeable with 'server'.
+
+***Application Setup***
+1.  Create a new Discord App from https://discord.com/developers/applications/
+    * The Application Name will be what appears when users attempt to authenticate.
+2.  On the left hand side of the application information page, navigate to "OAuth2".
+3.  On this page, keep track of the Client ID and reset the Client Secret to generate a new secret.
+4.  Under Redirects, add your Valid OAuth redirect URIs to `https://<proxied host>oauth2/callback`
+
+***Getting Discord Guild IDs***
+
+The Discord provider only supports Guild IDs and not names because Discord does not require Guild names to be unique.
+
+* **Option 1:** 
+    1. In the Discord application or website, navigate to `User Settings -> Advanced` and enable `Developer Mode`.
+    2. Right click the Server you wish to get the guild ID for and click the option `Copy Server ID`.
+* **Option 2:**
+    1. On the discord website, navigate to the server you wish to get the guild ID for.
+    2. The URL in the web bar should be formatted as `https://discord.com/channels/<guild_id>/<channel_id>`
+
+To use the provider, pass the following options:
+
+```
+   --provider=discord
+   --client-id=<Client ID from Step 3>
+   --client-secret=<Client Secret from Step 3>
+   --discord-guild-id=<guild_id> 
+```
+
+The `--discord-guild-id` arg can be specified multiple times with different guild IDs to allow multiple guilds 
+to authenticate.

--- a/docs/docs/configuration/providers/index.md
+++ b/docs/docs/configuration/providers/index.md
@@ -23,6 +23,7 @@ Valid providers are :
 - [Nextcloud](nextcloud.md)
 - [DigitalOcean](digitalocean.md)
 - [Bitbucket](bitbucket.md)
+- [Discord](discord.md)
 
 The provider can be selected using the `provider` configuration value.
 

--- a/pkg/apis/options/legacy_options.go
+++ b/pkg/apis/options/legacy_options.go
@@ -490,7 +490,7 @@ type LegacyProvider struct {
 	AzureGraphGroupField                   string   `flag:"azure-graph-group-field" cfg:"azure_graph_group_field"`
 	BitbucketTeam                          string   `flag:"bitbucket-team" cfg:"bitbucket_team"`
 	BitbucketRepository                    string   `flag:"bitbucket-repository" cfg:"bitbucket_repository"`
-	DiscordGuilds                          []string `flag:"discord-guild" cfg:"discord_guilds"`
+	DiscordGuilds                          []string `flag:"discord-guild-id" cfg:"discord_guild_ids"`
 	GitHubOrg                              string   `flag:"github-org" cfg:"github_org"`
 	GitHubTeam                             string   `flag:"github-team" cfg:"github_team"`
 	GitHubRepo                             string   `flag:"github-repo" cfg:"github_repo"`
@@ -553,7 +553,7 @@ func legacyProviderFlagSet() *pflag.FlagSet {
 	flagSet.String("azure-graph-group-field", "", "configures the group field to be used when building the groups list(`id` or `displayName`. Default is `id`) from Microsoft Graph(available only for v2.0 oidc url). Based on this value, the `allowed-group` config values should be adjusted accordingly. If using `id` as group field, `allowed-group` should contains groups IDs, if using `displayName` as group field, `allowed-group` should contains groups name")
 	flagSet.String("bitbucket-team", "", "restrict logins to members of this team")
 	flagSet.String("bitbucket-repository", "", "restrict logins to user with access to this repository")
-	flagSet.StringSlice("discord-guild", []string{}, "restrict logins to members of this Discord server (may be given multiple times)")
+	flagSet.StringSlice("discord-guild-id", []string{}, "restrict logins to members of this Discord server with the provided guild id (may be given multiple times)")
 	flagSet.String("github-org", "", "restrict logins to members of this organisation")
 	flagSet.String("github-team", "", "restrict logins to members of this team")
 	flagSet.String("github-repo", "", "restrict logins to collaborators of this repository")

--- a/pkg/apis/options/legacy_options.go
+++ b/pkg/apis/options/legacy_options.go
@@ -490,6 +490,7 @@ type LegacyProvider struct {
 	AzureGraphGroupField                   string   `flag:"azure-graph-group-field" cfg:"azure_graph_group_field"`
 	BitbucketTeam                          string   `flag:"bitbucket-team" cfg:"bitbucket_team"`
 	BitbucketRepository                    string   `flag:"bitbucket-repository" cfg:"bitbucket_repository"`
+	DiscordGuilds                          []string `flag:"discord-guild" cfg:"discord_guilds"`
 	GitHubOrg                              string   `flag:"github-org" cfg:"github_org"`
 	GitHubTeam                             string   `flag:"github-team" cfg:"github_team"`
 	GitHubRepo                             string   `flag:"github-repo" cfg:"github_repo"`
@@ -552,6 +553,7 @@ func legacyProviderFlagSet() *pflag.FlagSet {
 	flagSet.String("azure-graph-group-field", "", "configures the group field to be used when building the groups list(`id` or `displayName`. Default is `id`) from Microsoft Graph(available only for v2.0 oidc url). Based on this value, the `allowed-group` config values should be adjusted accordingly. If using `id` as group field, `allowed-group` should contains groups IDs, if using `displayName` as group field, `allowed-group` should contains groups name")
 	flagSet.String("bitbucket-team", "", "restrict logins to members of this team")
 	flagSet.String("bitbucket-repository", "", "restrict logins to user with access to this repository")
+	flagSet.StringSlice("discord-guild", []string{}, "restrict logins to members of this Discord server (may be given multiple times)")
 	flagSet.String("github-org", "", "restrict logins to members of this organisation")
 	flagSet.String("github-team", "", "restrict logins to members of this team")
 	flagSet.String("github-repo", "", "restrict logins to collaborators of this repository")
@@ -708,6 +710,10 @@ func (l *LegacyProvider) convert() (Providers, error) {
 	}
 
 	switch provider.Type {
+	case "discord":
+		provider.DiscordConfig = DiscordOptions{
+			Guilds: l.DiscordGuilds,
+		}
 	case "github":
 		provider.GitHubConfig = GitHubOptions{
 			Org:   l.GitHubOrg,

--- a/pkg/apis/options/providers.go
+++ b/pkg/apis/options/providers.go
@@ -34,6 +34,8 @@ type Provider struct {
 	ADFSConfig ADFSOptions `json:"ADFSConfig,omitempty"`
 	// BitbucketConfig holds all configurations for Bitbucket provider.
 	BitbucketConfig BitbucketOptions `json:"bitbucketConfig,omitempty"`
+	// DiscordConfig holds all configurations for Discord provider.
+	DiscordConfig DiscordOptions `json:"discordConfig,omitempty"`
 	// GitHubConfig holds all configurations for GitHubC provider.
 	GitHubConfig GitHubOptions `json:"githubConfig,omitempty"`
 	// GitLabConfig holds all configurations for GitLab provider.
@@ -103,6 +105,9 @@ const (
 
 	// BitbucketProvider is the provider type for Bitbucket
 	BitbucketProvider ProviderType = "bitbucket"
+
+	// DiscordProvider is the provider type for Discord
+	DiscordProvider ProviderType = "discord"
 
 	// DigitalOceanProvider is the provider type for DigitalOcean
 	DigitalOceanProvider ProviderType = "digitalocean"
@@ -181,6 +186,11 @@ type GitHubOptions struct {
 	// Users allows users with these usernames to login
 	// even if they do not belong to the specified org and team or collaborators
 	Users []string `json:"users,omitempty"`
+}
+
+type DiscordOptions struct {
+	// Restrict logins to certain guilds
+	Guilds []string `json:"guilds,omitempty"`
 }
 
 type GitLabOptions struct {

--- a/providers/discord.go
+++ b/providers/discord.go
@@ -1,0 +1,147 @@
+package providers
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/sessions"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/requests"
+)
+
+// DiscordProvider represents an Discord based Identity Provider
+type DiscordProvider struct {
+	*ProviderData
+}
+
+var _ Provider = (*DiscordProvider)(nil)
+
+const (
+	discordProviderName = "Discord"
+	discordDefaultScope = "identify email guilds"
+)
+
+var (
+	// Default Login URL for Discord.
+	// Pre-parsed URL of https://discord.com/api/oauth2/authorize.
+	discordDefaultLoginURL = &url.URL{
+		Scheme: "https",
+		Host:   "discord.com",
+		Path:   "/api/oauth2/authorize",
+	}
+
+	// Default Redeem URL for Discord.
+	// Pre-parsed URL of https://discord.com/api/oauth2/token
+	discordDefaultRedeemURL = &url.URL{
+		Scheme: "https",
+		Host:   "discord.com",
+		Path:   "/api/oauth2/token",
+	}
+
+	// Default Validate URL for Discord.
+	// Pre-parsed URL of https://discord.com/api/users/@me
+	discordDefaultValidateURL = &url.URL{
+		Scheme: "https",
+		Host:   "discord.com",
+		Path:   "/api/users/@me",
+	}
+
+	// Default Validate URL for Discord.
+	// Pre-parsed URL of https://discord.com/api/users/@me/guilds
+	discordGuildURL = &url.URL{
+		Scheme: "https",
+		Host:   "discord.com",
+		Path:   "/api/users/@me/guilds",
+	}
+)
+
+// NewDiscordProvider initiates a new DiscordProvider
+func NewDiscordProvider(p *ProviderData, opts options.DiscordOptions) *DiscordProvider {
+	p.setProviderDefaults(providerDefaults{
+		name:        discordProviderName,
+		loginURL:    discordDefaultLoginURL,
+		redeemURL:   discordDefaultRedeemURL,
+		profileURL:  discordDefaultValidateURL,
+		validateURL: discordDefaultValidateURL,
+		scope:       discordDefaultScope,
+	})
+	p.setAllowedGroups(opts.Guilds)
+	return &DiscordProvider{ProviderData: p}
+}
+
+func (p *DiscordProvider) EnrichSession(ctx context.Context, s *sessions.SessionState) error {
+	user, err := p.getUserInfo(ctx, s)
+	if err != nil {
+		return err
+	}
+
+	s.User = fmt.Sprintf("%s#%s", user.Username, user.Discriminator)
+	s.PreferredUsername = user.Username
+	s.Email = user.Email
+
+	guilds, err := p.getUserGuilds(ctx, s)
+	if err != nil {
+		return err
+	}
+
+	for _, guild := range guilds {
+		s.Groups = append(s.Groups, guild.ID)
+	}
+
+	return nil
+}
+
+// https://discord.com/developers/docs/resources/user#user-object
+type discordUserInfo struct {
+	ID            string `json:"id"`
+	Username      string `json:"username"`
+	Email         string `json:"email"`
+	Verified      bool   `json:"verified"`
+	Discriminator string `json:"discriminator"`
+	// Avatar   string `json:"avatar"`
+	// Flags    int    `json:"flags"`
+}
+
+// Retrive user Info
+// https://discord.com/developers/docs/resources/user#get-user
+func (p *DiscordProvider) getUserInfo(ctx context.Context, s *sessions.SessionState) (*discordUserInfo, error) {
+	var userinfo discordUserInfo
+	err := requests.New(discordDefaultValidateURL.String()).
+		WithContext(ctx).
+		SetHeader("Authorization", "Bearer "+s.AccessToken).
+		Do().
+		UnmarshalInto(&userinfo)
+	if err != nil {
+		return nil, fmt.Errorf("error getting user's guilds info: %v", err)
+	}
+
+	return &userinfo, nil
+}
+
+// https://discord.com/developers/docs/resources/guild#guild-object
+type discordGuild struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// Retrieve user guilds
+// https://discord.com/developers/docs/resources/user#get-current-user-guilds
+func (p *DiscordProvider) getUserGuilds(ctx context.Context, s *sessions.SessionState) ([]discordGuild, error) {
+	guilds := []discordGuild{}
+	err := requests.New(discordGuildURL.String()).
+		WithContext(ctx).
+		SetHeader("Authorization", "Bearer "+s.AccessToken).
+		Do().
+		UnmarshalInto(&guilds)
+	if err != nil {
+		return nil, fmt.Errorf("error getting user's guilds info: %v", err)
+	}
+
+	return guilds, nil
+}
+
+// ValidateSession validates the AccessToken
+func (p *DiscordProvider) ValidateSession(ctx context.Context, s *sessions.SessionState) bool {
+	return validateToken(ctx, p, s.AccessToken, makeOIDCHeader(s.AccessToken))
+}

--- a/providers/discord.go
+++ b/providers/discord.go
@@ -103,7 +103,7 @@ type discordUserInfo struct {
 	Discriminator string `json:"discriminator"`
 }
 
-// Retrive user Info
+// Retrieve user Info
 // https://discord.com/developers/docs/resources/user#get-user
 func (p *DiscordProvider) getUserInfo(ctx context.Context, s *sessions.SessionState) (*discordUserInfo, error) {
 	var userinfo discordUserInfo

--- a/providers/discord.go
+++ b/providers/discord.go
@@ -85,6 +85,8 @@ func (p *DiscordProvider) EnrichSession(ctx context.Context, s *sessions.Session
 		return err
 	}
 
+	// Only allow guild IDs as guild names don't have to be unique and can be changed after
+	// guild creation.
 	for _, guild := range guilds {
 		s.Groups = append(s.Groups, guild.ID)
 	}
@@ -99,8 +101,6 @@ type discordUserInfo struct {
 	Email         string `json:"email"`
 	Verified      bool   `json:"verified"`
 	Discriminator string `json:"discriminator"`
-	// Avatar   string `json:"avatar"`
-	// Flags    int    `json:"flags"`
 }
 
 // Retrive user Info
@@ -113,7 +113,7 @@ func (p *DiscordProvider) getUserInfo(ctx context.Context, s *sessions.SessionSt
 		Do().
 		UnmarshalInto(&userinfo)
 	if err != nil {
-		return nil, fmt.Errorf("error getting user's guilds info: %v", err)
+		return nil, fmt.Errorf("error getting user's guilds info: %w", err)
 	}
 
 	return &userinfo, nil
@@ -135,7 +135,7 @@ func (p *DiscordProvider) getUserGuilds(ctx context.Context, s *sessions.Session
 		Do().
 		UnmarshalInto(&guilds)
 	if err != nil {
-		return nil, fmt.Errorf("error getting user's guilds info: %v", err)
+		return nil, fmt.Errorf("error getting user's guilds info: %w", err)
 	}
 
 	return guilds, nil

--- a/providers/discord_test.go
+++ b/providers/discord_test.go
@@ -1,0 +1,143 @@
+package providers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/sessions"
+	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
+)
+
+func testDiscordProvider(hostname string, guilds []string) *DiscordProvider {
+	p := NewDiscordProvider(
+		&ProviderData{
+			ProviderName: "",
+			LoginURL:     &url.URL{},
+			RedeemURL:    &url.URL{},
+			ProfileURL:   &url.URL{},
+			ValidateURL:  &url.URL{},
+			Scope:        ""},
+		options.DiscordOptions{
+			Guilds: guilds,
+		})
+
+	if hostname != "" {
+		updateURL(p.Data().LoginURL, hostname)
+		updateURL(p.Data().RedeemURL, hostname)
+		updateURL(p.Data().ProfileURL, hostname)
+		originalGuildURL := discordGuildURL
+		defer func() { discordGuildURL = originalGuildURL }()
+		updateURL(discordGuildURL, hostname)
+	}
+	return p
+}
+
+func testDiscordBackend(payload string) *httptest.Server {
+	guildsPath := "/api/users/@me/guilds"
+
+	return httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != guildsPath {
+				w.WriteHeader(404)
+			} else if !IsAuthorizedInHeader(r.Header) {
+				w.WriteHeader(403)
+			} else {
+				w.WriteHeader(200)
+				w.Write([]byte(payload))
+			}
+		}))
+}
+
+func TestNewDiscordProvider(t *testing.T) {
+	g := NewWithT(t)
+
+	// Test that defaults are set when calling for a new provider with nothing set
+	providerData := NewDiscordProvider(&ProviderData{}, options.DiscordOptions{}).Data()
+	g.Expect(providerData.ProviderName).To(Equal("Discord"))
+	g.Expect(providerData.LoginURL.String()).To(Equal("https://discord.com/api/oauth2/authorize"))
+	g.Expect(providerData.RedeemURL.String()).To(Equal("https://discord.com/api/oauth2/token"))
+	g.Expect(providerData.ProfileURL.String()).To(Equal("https://discord.com/api/users/@me"))
+	g.Expect(providerData.ValidateURL.String()).To(Equal("https://discord.com/api/users/@me"))
+	g.Expect(providerData.Scope).To(Equal("identify email guilds"))
+}
+
+func TestDiscordProviderOverrides(t *testing.T) {
+	p := NewDiscordProvider(
+		&ProviderData{
+			LoginURL: &url.URL{
+				Scheme: "https",
+				Host:   "example.com",
+				Path:   "/oauth/auth"},
+			RedeemURL: &url.URL{
+				Scheme: "https",
+				Host:   "example.com",
+				Path:   "/oauth/token"},
+			ProfileURL: &url.URL{
+				Scheme: "https",
+				Host:   "example.com",
+				Path:   "/oauth/profile"},
+			ValidateURL: &url.URL{
+				Scheme: "https",
+				Host:   "example.com",
+				Path:   "/oauth/tokeninfo"},
+			Scope: "profile"},
+		options.DiscordOptions{})
+	assert.NotEqual(t, nil, p)
+	assert.Equal(t, "Discord", p.Data().ProviderName)
+	assert.Equal(t, "https://example.com/oauth/auth",
+		p.Data().LoginURL.String())
+	assert.Equal(t, "https://example.com/oauth/token",
+		p.Data().RedeemURL.String())
+	assert.Equal(t, "https://example.com/oauth/profile",
+		p.Data().ProfileURL.String())
+	assert.Equal(t, "https://example.com/oauth/tokeninfo",
+		p.Data().ValidateURL.String())
+	assert.Equal(t, "profile", p.Data().Scope)
+}
+
+func TestDiscordProviderGetGuilds(t *testing.T) {
+	b := testDiscordBackend(`[{"id":"1234","name":"testname"}]`)
+	defer b.Close()
+
+	bURL, _ := url.Parse(b.URL)
+	p := testDiscordProvider(bURL.Host, []string{})
+
+	session := CreateAuthorizedSession()
+	guilds, err := p.getUserGuilds(context.Background(), session)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "1234", guilds[0].ID)
+}
+
+func TestDiscordProviderGetGuildsFailedRequest(t *testing.T) {
+	b := testDiscordBackend("unused payload")
+	defer b.Close()
+
+	bURL, _ := url.Parse(b.URL)
+	p := testDiscordProvider(bURL.Host, []string{})
+
+	// We'll trigger a request failure by using an unexpected access
+	// token. Alternatively, we could allow the parsing of the payload as
+	// JSON to fail.
+	session := &sessions.SessionState{AccessToken: "unexpected_access_token"}
+	guilds, err := p.getUserGuilds(context.Background(), session)
+	assert.NotEqual(t, nil, err)
+	assert.Equal(t, "", guilds)
+}
+
+func TestDiscordProviderGuildsNotPresentInPayload(t *testing.T) {
+	b := testDiscordBackend("{\"foo\": \"bar\"}")
+	defer b.Close()
+
+	bURL, _ := url.Parse(b.URL)
+	p := testDiscordProvider(bURL.Host, []string{})
+
+	session := CreateAuthorizedSession()
+	guilds, err := p.getUserGuilds(context.Background(), session)
+	assert.NotEqual(t, nil, err)
+	assert.Equal(t, "", guilds)
+}

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -43,6 +43,8 @@ func NewProvider(providerConfig options.Provider) (Provider, error) {
 		return NewAzureProvider(providerData, providerConfig.AzureConfig), nil
 	case options.BitbucketProvider:
 		return NewBitbucketProvider(providerData, providerConfig.BitbucketConfig), nil
+	case options.DiscordProvider:
+		return NewDiscordProvider(providerData, providerConfig.DiscordConfig), nil
 	case options.DigitalOceanProvider:
 		return NewDigitalOceanProvider(providerData), nil
 	case options.FacebookProvider:
@@ -178,7 +180,7 @@ func parseCodeChallengeMethod(providerConfig options.Provider) string {
 
 func providerRequiresOIDCProviderVerifier(providerType options.ProviderType) (bool, error) {
 	switch providerType {
-	case options.BitbucketProvider, options.DigitalOceanProvider, options.FacebookProvider, options.GitHubProvider,
+	case options.BitbucketProvider, options.DiscordProvider, options.DigitalOceanProvider, options.FacebookProvider, options.GitHubProvider,
 		options.GoogleProvider, options.KeycloakProvider, options.LinkedInProvider, options.LoginGovProvider, options.NextCloudProvider:
 		return false, nil
 	case options.ADFSProvider, options.AzureProvider, options.GitLabProvider, options.KeycloakOIDCProvider, options.OIDCProvider:


### PR DESCRIPTION
Add a discord provider that supports authentication based on Discord guilds

## Description

This is a continuation of the PR at https://github.com/oauth2-proxy/oauth2-proxy/pull/2113. That change hasn't been updated in a while so I thought I'd address the comments as well as add the documentation and some tests. I also added the legacy option required to pass the discord guild ids. 

## Motivation and Context

The goal was to allow members of my discord server to access some resources that I host based on their membership to the server. This honestly seemed a lot easier than setting up a service like authentik or authelia, both of which don't support discord as far as I'm aware. 

Note the functionality implemented only checks the guild membership and doesn't check email or username, that could be added in the future but I don't think it really fits the intended use case as the implication to me is that if you're using discord to authenticate, you want the scope to be on a per-guild bases usually. 

## How Has This Been Tested?

I built the resulting image using the docker and am running it with docker using nginx proxy manager as my reverse proxy.

I've tested that everything is working as expected and authentication does work successfully. Specifically if the appropriate guild id is provided then authentication works but if there are no provided guild ids or if the user isn't a member of any of the provided guilds then it fails. 

I also did manually double check that Discord allows multiple guilds to have the same name and that you could bypass the auth by creating a new server with the same name as the server that you are authenticating against if using name based authentication.

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
- [x] I have written tests for my code changes.
