### PR TITLE
feat: Allow use more possible google admin-sdk api scopes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ c.out
 # Folders
 _obj
 _test
+.DS_Store
 .idea/
 .vscode/*
 !/.vscode/tasks.json

--- a/docs/docs/configuration/providers/google.md
+++ b/docs/docs/configuration/providers/google.md
@@ -25,18 +25,17 @@ account is still authorized.
 
 #### Restrict auth to specific Google groups on your domain. (optional)
 
-1.  Create a [service account](https://developers.google.com/identity/protocols/OAuth2ServiceAccount) and configure it 
+1.  Create a [service account](https://developers.google.com/identity/protocols/oauth2/service-account) and configure it 
     to use [Application Default Credentials / Workload Identity / Workload Identity Federation (recommended)](#using-application-default-credentials-adc--workload-identity--workload-identity-federation-recommended) or, 
     alternatively download the JSON.
 2.  Make note of the Client ID for a future step.
 3.  Under "APIs & Auth", choose APIs.
 4.  Click on Admin SDK and then Enable API.
-5.  Follow the steps on https://developers.google.com/admin-sdk/directory/v1/guides/delegation#delegate_domain-wide_authority_to_your_service_account 
+5.  Follow the steps on [Set up domain-wide delegation for a service account](https://developers.google.com/workspace/guides/create-credentials#optional_set_up_domain-wide_delegation_for_a_service_account)
     and give the client id from step 2 the following oauth scopes:
 
     ```
-    https://www.googleapis.com/auth/admin.directory.group.readonly
-    https://www.googleapis.com/auth/admin.directory.user.readonly
+    https://www.googleapis.com/auth/admin.directory.group.member.readonly
     ```
 
 6.  Follow the steps on https://support.google.com/a/answer/60757 to enable Admin API access.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

According to Google's requirements, as long as one of the API scopes is present, the `hasMember` method can be allow.

https://developers.google.com/admin-sdk/directory/reference/rest/v1/members/hasMember#authorization-scopes

```
https://apps-apis.google.com/a/feeds/groups/
https://www.googleapis.com/auth/admin.directory.group
https://www.googleapis.com/auth/admin.directory.group.member
https://www.googleapis.com/auth/admin.directory.group.member.readonly
https://www.googleapis.com/auth/admin.directory.group.readonly
```

Additionally, update the documentation to recommend setting the minimum required permissions scope.


## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.
