### PR TITLE
Fix: Missing Resource Type "/microsoft.graph.group?" in the REST API call

### DIFF
--- a/providers/azure.go
+++ b/providers/azure.go
@@ -126,17 +126,17 @@ func overrideTenantURL(current, defaultURL *url.URL, tenant, path string) {
 
 func getMicrosoftGraphGroupsURL(profileURL *url.URL, graphGroupField string) *url.URL {
 
-	selectStatement := "$select=displayName,id"
-	if !slices.Contains([]string{"displayName", "id"}, graphGroupField) {
-		selectStatement += "," + graphGroupField
+	selectStatement := ""
+	if slices.Contains([]string{"displayName", "id"}, graphGroupField) {
+		selectStatement += "&$select=" + graphGroupField
 	}
 
 	// Select only security groups. Due to the filter option, count param is mandatory even if unused otherwise
 	return &url.URL{
 		Scheme:   "https",
 		Host:     profileURL.Host,
-		Path:     "/v1.0/me/transitiveMemberOf",
-		RawQuery: "$count=true&$filter=securityEnabled+eq+true&" + selectStatement,
+		Path:     "/v1.0/me/transitiveMemberOf/microsoft.graph.group",
+		RawQuery: "$count=true&$filter=securityEnabled+eq+true" + selectStatement,
 	}
 }
 


### PR DESCRIPTION
the Resource Type: microsoft.graph.group (this specifies the type of resource you are querying within the path) is missing
+

Based on the docs:

> GraphGroupField configures the group field to be used when building the groups list from Microsoft Graph
> Default value is 'id'

It is also the case now otherwise displayName, only displayName and id are supported 
```
{
  "error": {
    "code": "BadRequest",
    "message": "The request URI is not valid. Since the segment 'transitiveMemberOf' refers to a collection, this must be the last segment in the request URI or it must be followed by an function or action that can be bound to it otherwise all intermediate segments must refer to a single resource.",
    "innerError": {
      "date": "2024-08-18T21:09:01",
      "request-id": "d3d1113a-3cd3-4aed-be5d-bd96127cdf52",
      "client-request-id": "d3d1113a-3cd3-4aed-be5d-bd96127cdf52"
    }
  }
}
```