### PR TITLE
Add s390x nightly build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ build: validate-go-version clean $(BINARY)
 $(BINARY):
 	CGO_ENABLED=0 $(GO) build -a -installsuffix cgo -ldflags="-X github.com/oauth2-proxy/oauth2-proxy/v7/pkg/version.VERSION=${VERSION}" -o $@ github.com/oauth2-proxy/oauth2-proxy/v7
 
-DOCKER_BUILD_PLATFORM         ?= linux/amd64,linux/arm64,linux/ppc64le,linux/arm/v7
+DOCKER_BUILD_PLATFORM         ?= linux/amd64,linux/arm64,linux/ppc64le,linux/arm/v7,linux/s390x
 DOCKER_BUILD_RUNTIME_IMAGE    ?= gcr.io/distroless/static:nonroot
 DOCKER_BUILDX_ARGS            ?= --build-arg RUNTIME_IMAGE=${DOCKER_BUILD_RUNTIME_IMAGE} --build-arg VERSION=${VERSION}
 DOCKER_BUILDX                 := docker buildx build ${DOCKER_BUILDX_ARGS} --pull
@@ -50,7 +50,7 @@ DOCKER_BUILDX_X_PLATFORM      := $(DOCKER_BUILDX) --platform ${DOCKER_BUILD_PLAT
 DOCKER_BUILDX_PUSH            := $(DOCKER_BUILDX) --push
 DOCKER_BUILDX_PUSH_X_PLATFORM := $(DOCKER_BUILDX_PUSH) --platform ${DOCKER_BUILD_PLATFORM}
 
-DOCKER_BUILD_PLATFORM_ALPINE         ?= linux/amd64,linux/arm64,linux/ppc64le,linux/arm/v6,linux/arm/v7
+DOCKER_BUILD_PLATFORM_ALPINE         ?= linux/amd64,linux/arm64,linux/ppc64le,linux/arm/v6,linux/arm/v7,linux/s390x
 DOCKER_BUILD_RUNTIME_IMAGE_ALPINE    ?= alpine:3.20.0
 DOCKER_BUILDX_ARGS_ALPINE            ?= --build-arg RUNTIME_IMAGE=${DOCKER_BUILD_RUNTIME_IMAGE_ALPINE} --build-arg VERSION=${VERSION}
 DOCKER_BUILDX_X_PLATFORM_ALPINE      := docker buildx build ${DOCKER_BUILDX_ARGS_ALPINE} --platform ${DOCKER_BUILD_PLATFORM_ALPINE}
@@ -73,6 +73,7 @@ docker-all: docker
 	$(DOCKER_BUILDX) --platform linux/ppc64le -t $(REGISTRY)/$(REPOSITORY):latest-ppc64le -t $(REGISTRY)/$(REPOSITORY):${VERSION}-ppc64le .
 	$(DOCKER_BUILDX) --platform linux/arm/v6  -t $(REGISTRY)/$(REPOSITORY):latest-armv6   -t $(REGISTRY)/$(REPOSITORY):${VERSION}-armv6 .
 	$(DOCKER_BUILDX) --platform linux/arm/v7  -t $(REGISTRY)/$(REPOSITORY):latest-armv7   -t $(REGISTRY)/$(REPOSITORY):${VERSION}-armv7 .
+	$(DOCKER_BUILDX) --platform linux/s390x   -t $(REGISTRY)/$(REPOSITORY):latest-s390x -t $(REGISTRY)/$(REPOSITORY):${VERSION}-s390x .
 
 .PHONY: docker-push-all
 docker-push-all: docker-push
@@ -81,6 +82,7 @@ docker-push-all: docker-push
 	$(DOCKER_BUILDX_PUSH) --platform linux/ppc64le -t $(REGISTRY)/$(REPOSITORY):latest-ppc64le -t $(REGISTRY)/$(REPOSITORY):${VERSION}-ppc64le .
 	$(DOCKER_BUILDX_PUSH) --platform linux/arm/v6  -t $(REGISTRY)/$(REPOSITORY):latest-armv6   -t $(REGISTRY)/$(REPOSITORY):${VERSION}-armv6 .
 	$(DOCKER_BUILDX_PUSH) --platform linux/arm/v7  -t $(REGISTRY)/$(REPOSITORY):latest-armv7   -t $(REGISTRY)/$(REPOSITORY):${VERSION}-armv7 .
+	$(DOCKER_BUILDX_PUSH) --platform linux/s390x   -t $(REGISTRY)/$(REPOSITORY):latest-s390x -t $(REGISTRY)/$(REPOSITORY):${VERSION}-s390x .
 
 .PHONY: docker-nightly-build
 docker-nightly-build:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This will add the s390x architecture to the nightly build process, ultimately producing a container image and pushing it up to the quay repository.

## Description

Edited the makefile process to include the linux/s390x architecture to its targeted platform.

## Motivation and Context

We are running a RHOCP cluster on the IBM Z/s390x architecture and would like to be able to pull down the container image directly from quay.

## How Has This Been Tested?

I mirrored this repository to our github enterprise and ran the nightly git action workflow job in order to build/push the container image to our github container registry and verified the manifest file included the linux/s390x arch.

## Checklist:

- [ X ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ X ] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.
