### PR TITLE
[doc] Add example for caddy v2 forward_auth

### DIFF
--- a/docs/docs/configuration/integration.md
+++ b/docs/docs/configuration/integration.md
@@ -267,7 +267,7 @@ http:
 
 ## Configuring for use with the caddy v2 `forward_auth` directive
 
-The [Caddy `forward_auth` directive](caddyserver.com/docs/caddyfile/directives/forward_auth) allowes Caddy to authenticate requests via the oauth2-proxy's `/auth`.
+The [Caddy `forward_auth` directive](https://caddyserver.com/docs/caddyfile/directives/forward_auth) allowes Caddy to authenticate requests via the oauth2-proxy's `/auth`.
 
 This example is for a simple reverse proxy setup where the `/oauth2/` path is kept under the same domain and failed auth `(status:401)` request will be catched and redirect to the `sign_in` endpoint.
 

--- a/docs/docs/configuration/integration.md
+++ b/docs/docs/configuration/integration.md
@@ -267,9 +267,9 @@ http:
 
 ## Configuring for use with the caddy v2 `forward_auth` directive
 
-The [Caddy `forward_auth` directive](https://caddyserver.com/docs/caddyfile/directives/forward_auth) allowes Caddy to authenticate requests via the oauth2-proxy's `/auth`.
+The [Caddy `forward_auth` directive](https://caddyserver.com/docs/caddyfile/directives/forward_auth) allows Caddy to authenticate requests via the `oauth2-proxy`'s `/auth`.
 
-This example is for a simple reverse proxy setup where the `/oauth2/` path is kept under the same domain and failed auth `(status:401)` request will be catched and redirect to the `sign_in` endpoint.
+This example is for a simple reverse proxy setup where the `/oauth2/` path is kept under the same domain and failed auth requests (401 status returned) will be caught and redirected to the `sign_in` endpoint.
 
 **Following options need to be set on `oauth2-proxy`:**
 - `--reverse-proxy=true`: Enables the use of `X-Forwarded-*` headers to determine redirects correctly

--- a/docs/docs/configuration/integration.md
+++ b/docs/docs/configuration/integration.md
@@ -265,6 +265,42 @@ http:
           - Authorization
 ```
 
+## Configuring for use with the caddy v2 `forward_auth` directive
+
+The [Caddy `forward_auth` directive](caddyserver.com/docs/caddyfile/directives/forward_auth) allowes Caddy to authenticate requests via the oauth2-proxy's `/auth`.
+
+This example is for a simple reverse proxy setup where the `/oauth2/` path is kept under the same domain and failed auth `(status:401)` request will be catched and redirect to the `sign_in` endpoint.
+
+**Following options need to be set on `oauth2-proxy`:**
+- `--reverse-proxy=true`: Enables the use of `X-Forwarded-*` headers to determine redirects correctly
+
+```nginx
+{{ domain }} {
+	# define forward auth for any path under `/`, if not more specific defined
+	forward_auth / {{ oauth.internalIP }}:4180 {
+		uri /oauth2/auth
+		copy_headers Authorization X-Auth-Request-User X-Auth-Request-Email
+
+		@error status 401
+		handle_response @error {
+			redir * /oauth2/sign_in?rd={scheme}://{host}{uri} 302
+		}
+	}
+
+	# define `/oauth2/*` as specific endpoint, to avoid forward auth protection to be able to use service
+	reverse_proxy /oauth2/* {{ oauth.internalIP }}:4180 {
+		header_up X-Real-IP {remote}
+		header_up X-Forwarded-Proto https
+	}
+
+	# unspecific reverse proxy will be protected from `forward_auth /`
+	reverse_proxy {{ endpointIP }} {
+		header_up X-Real-IP {remote}
+		header_up X-Forwarded-Proto https
+	}
+}
+```
+
 :::note
 If you set up your OAuth2 provider to rotate your client secret, you can use the `client-secret-file` option to reload the secret when it is updated.
 :::

--- a/docs/versioned_docs/version-7.6.x/configuration/integration.md
+++ b/docs/versioned_docs/version-7.6.x/configuration/integration.md
@@ -267,7 +267,7 @@ http:
 
 ## Configuring for use with the caddy v2 `forward_auth` directive
 
-The [Caddy `forward_auth` directive](caddyserver.com/docs/caddyfile/directives/forward_auth) allowes Caddy to authenticate requests via the oauth2-proxy's `/auth`.
+The [Caddy `forward_auth` directive](https://caddyserver.com/docs/caddyfile/directives/forward_auth) allowes Caddy to authenticate requests via the oauth2-proxy's `/auth`.
 
 This example is for a simple reverse proxy setup where the `/oauth2/` path is kept under the same domain and failed auth `(status:401)` request will be catched and redirect to the `sign_in` endpoint.
 

--- a/docs/versioned_docs/version-7.6.x/configuration/integration.md
+++ b/docs/versioned_docs/version-7.6.x/configuration/integration.md
@@ -267,9 +267,9 @@ http:
 
 ## Configuring for use with the caddy v2 `forward_auth` directive
 
-The [Caddy `forward_auth` directive](https://caddyserver.com/docs/caddyfile/directives/forward_auth) allowes Caddy to authenticate requests via the oauth2-proxy's `/auth`.
+The [Caddy `forward_auth` directive](https://caddyserver.com/docs/caddyfile/directives/forward_auth) allows Caddy to authenticate requests via the `oauth2-proxy`'s `/auth`.
 
-This example is for a simple reverse proxy setup where the `/oauth2/` path is kept under the same domain and failed auth `(status:401)` request will be catched and redirect to the `sign_in` endpoint.
+This example is for a simple reverse proxy setup where the `/oauth2/` path is kept under the same domain and failed auth requests (401 status returned) will be caught and redirected to the `sign_in` endpoint.
 
 **Following options need to be set on `oauth2-proxy`:**
 - `--reverse-proxy=true`: Enables the use of `X-Forwarded-*` headers to determine redirects correctly

--- a/docs/versioned_docs/version-7.6.x/configuration/integration.md
+++ b/docs/versioned_docs/version-7.6.x/configuration/integration.md
@@ -265,6 +265,42 @@ http:
           - Authorization
 ```
 
+## Configuring for use with the caddy v2 `forward_auth` directive
+
+The [Caddy `forward_auth` directive](caddyserver.com/docs/caddyfile/directives/forward_auth) allowes Caddy to authenticate requests via the oauth2-proxy's `/auth`.
+
+This example is for a simple reverse proxy setup where the `/oauth2/` path is kept under the same domain and failed auth `(status:401)` request will be catched and redirect to the `sign_in` endpoint.
+
+**Following options need to be set on `oauth2-proxy`:**
+- `--reverse-proxy=true`: Enables the use of `X-Forwarded-*` headers to determine redirects correctly
+
+```nginx
+{{ domain }} {
+	# define forward auth for any path under `/`, if not more specific defined
+	forward_auth / {{ oauth.internalIP }}:4180 {
+		uri /oauth2/auth
+		copy_headers Authorization X-Auth-Request-User X-Auth-Request-Email
+
+		@error status 401
+		handle_response @error {
+			redir * /oauth2/sign_in?rd={scheme}://{host}{uri} 302
+		}
+	}
+
+	# define `/oauth2/*` as specific endpoint, to avoid forward auth protection to be able to use service
+	reverse_proxy /oauth2/* {{ oauth.internalIP }}:4180 {
+		header_up X-Real-IP {remote}
+		header_up X-Forwarded-Proto https
+	}
+
+	# unspecific reverse proxy will be protected from `forward_auth /`
+	reverse_proxy {{ endpointIP }} {
+		header_up X-Real-IP {remote}
+		header_up X-Forwarded-Proto https
+	}
+}
+```
+
 :::note
 If you set up your OAuth2 provider to rotate your client secret, you can use the `client-secret-file` option to reload the secret when it is updated.
 :::


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add documentation to integrate oauth2 proxy with a caddy reverse proxy.

## Motivation and Context

It was from the caddy forward_auth example not clear how to use this with oauth2 proxy. Also in the context that this will be work under the same domain. So future people can use this example to faster find the solution.

Markdown syntax highlight is wrong, but the best fitting one for placeholder and comments.

## How Has This Been Tested?

Configuration is currently used with several protected endpoints. But this is only documentation for configuration of 3rd party reverse proxy. So no code changes.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.
