### PR TITLE
fix: propagate errors during route building

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Changes since v7.12.0
 
+- [#2767](https://github.com/oauth2-proxy/oauth2-proxy/pull/2767) Propagate errors during route building (@sybereal)
+
 # V7.12.0
 
 ## Release Highlights

--- a/pkg/upstream/proxy.go
+++ b/pkg/upstream/proxy.go
@@ -57,7 +57,9 @@ func NewProxy(upstreams options.UpstreamConfig, sigData *options.SignatureData, 
 		}
 	}
 
-	registerTrailingSlashHandler(m.serveMux)
+	if err := registerTrailingSlashHandler(m.serveMux); err != nil {
+		return nil, fmt.Errorf("could not register trailing slash handler: %w", err)
+	}
 	return m, nil
 }
 
@@ -93,8 +95,7 @@ func (m *multiUpstreamProxy) registerHTTPUpstreamProxy(upstream options.Upstream
 // registerHandler ensures the given handler is regiestered with the serveMux.
 func (m *multiUpstreamProxy) registerHandler(upstream options.Upstream, handler http.Handler, writer pagewriter.Writer) error {
 	if upstream.RewriteTarget == "" {
-		m.registerSimpleHandler(upstream.Path, handler)
-		return nil
+		return m.registerSimpleHandler(upstream.Path, handler)
 	}
 
 	return m.registerRewriteHandler(upstream, handler, writer)
@@ -102,12 +103,12 @@ func (m *multiUpstreamProxy) registerHandler(upstream options.Upstream, handler 
 
 // registerSimpleHandler maintains the behaviour of the go standard serveMux
 // by ensuring any path with a trailing `/` matches all paths under that prefix.
-func (m *multiUpstreamProxy) registerSimpleHandler(path string, handler http.Handler) {
+func (m *multiUpstreamProxy) registerSimpleHandler(path string, handler http.Handler) error {
 	if strings.HasSuffix(path, "/") {
-		m.serveMux.PathPrefix(path).Handler(handler)
-	} else {
-		m.serveMux.Path(path).Handler(handler)
+		return m.serveMux.PathPrefix(path).Handler(handler).GetError()
 	}
+
+	return m.serveMux.Path(path).Handler(handler).GetError()
 }
 
 // registerRewriteHandler ensures the handler is registered for all paths
@@ -122,19 +123,18 @@ func (m *multiUpstreamProxy) registerRewriteHandler(upstream options.Upstream, h
 
 	rewrite := newRewritePath(rewriteRegExp, upstream.RewriteTarget, writer)
 	h := alice.New(rewrite).Then(handler)
-	m.serveMux.MatcherFunc(func(req *http.Request, _ *mux.RouteMatch) bool {
-		return rewriteRegExp.MatchString(req.URL.Path)
-	}).Handler(h)
 
-	return nil
+	return m.serveMux.MatcherFunc(func(req *http.Request, _ *mux.RouteMatch) bool {
+		return rewriteRegExp.MatchString(req.URL.Path)
+	}).Handler(h).GetError()
 }
 
 // registerTrailingSlashHandler creates a new matcher that will check if the
 // requested path would match if it had a trailing slash appended.
 // If the path matches with a trailing slash, we send back a redirect.
 // This allows us to be consistent with the built in go servemux implementation.
-func registerTrailingSlashHandler(serveMux *mux.Router) {
-	serveMux.MatcherFunc(func(req *http.Request, _ *mux.RouteMatch) bool {
+func registerTrailingSlashHandler(serveMux *mux.Router) error {
+	return serveMux.MatcherFunc(func(req *http.Request, _ *mux.RouteMatch) bool {
 		if strings.HasSuffix(req.URL.Path, "/") {
 			return false
 		}
@@ -148,7 +148,7 @@ func registerTrailingSlashHandler(serveMux *mux.Router) {
 		return serveMux.Match(slashReq, m)
 	}).Handler(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		http.Redirect(rw, req, req.URL.String()+"/", http.StatusMovedPermanently)
-	}))
+	})).GetError()
 }
 
 // sortByPathLongest ensures that the upstreams are sorted by longest path.


### PR DESCRIPTION
This fixes cases such as invalid paths being silently discarded after creation by throwing a visible error in such cases. Due to the way gorilla/mux's fluent API is designed, it is necessary to manually call `.GetError()` to check for errors while building routes.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Catch errors that occur while building the route configuration for upstreams, such as syntactically invalid paths, instead of silently discarding them.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Previously, when entering an invalid path as part of a `upstreamConfig.upstreams` element, such as a regex matcher without a `rewriteTarget`, the logs would imply that everything was fine. However, the requests would end up with the next most specific upstream instead.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tried starting oauth2-proxy with this `upstreamConfig` block:

```yaml
upstreamConfig:
  upstreams:
    - id: api
      passHostHeader: false
      path: ^/api/$
      uri: http://example.com
    - id: ui
      passHostHeader: false
      path: /
      uri: http://example.net
```

This fails startup with `[main.go:59] ERROR: Failed to initialise OAuth2 Proxy: error initialising upstream proxy: could not register https upstream "api": mux: path must start with a slash, got "^/api/$"`.

I wanted to write a unit test to expect an error when passing an invalid path, but I wasn't sure how to best integrate it into the existing test suite, since the current setup is built around testing the success case and assumes that it's always possible to successfully create a proxy object.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
- [x] I have written tests for my code changes.
