### PR TITLE
Correct Go version in DevContainer and Contibution guide

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/go:1-1.21
+FROM mcr.microsoft.com/vscode/devcontainers/go:1-1.22
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/docs/docs/community/contribution.md
+++ b/docs/docs/community/contribution.md
@@ -15,7 +15,7 @@ We suggest using [Visual Studio Code](https://code.visualstudio.com/docs/languag
 
 # Go version
 
-This project is currently still using go 1.19. You can follow the installation guide for go [here.](https://go.dev/doc/install) And you can find go version 1.19 in the archived section [here.](https://go.dev/dl/)
+This project is currently still using go 1.22. You can follow the installation guide for go [here.](https://go.dev/doc/install) And you can find go version 1.22 in the archived section [here.](https://go.dev/dl/)
 
 # Preparing your fork
 Clone your fork, create a feature branch and update the depedencies to get started.

--- a/docs/docs/community/contribution.md
+++ b/docs/docs/community/contribution.md
@@ -44,7 +44,7 @@ For starting oauth2-proxy locally open the debugging tab and create the `launch.
             "program": "${workspaceFolder}",
             "args": [
                 "--config",
-                // The following configuration contains settings for a locally deployed 
+                // The following configuration contains settings for a locally deployed
                 // upstream and dex as an idetity provider
                 "contrib/local-environment/oauth2-proxy.cfg"
             ]
@@ -57,7 +57,7 @@ For starting oauth2-proxy locally open the debugging tab and create the `launch.
             "program": "${workspaceFolder}",
             "args": [
                 "--config",
-                // The following configuration contains settings for a locally deployed 
+                // The following configuration contains settings for a locally deployed
                 // upstream and keycloak as an idetity provider
                 "contrib/local-environment/oauth2-proxy-keycloak.cfg"
             ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`go mod download` will fail on older Go versions than 1.22. It seems like these two places were forgotten in the latest Go updated.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Make the devcontainer work again.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Checking out the project with VSCode and starting the devcontainer no longer fails after these changes.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.
