### PR TITLE
chore: removed duplicate image line in docker-compose

### DIFF
--- a/contrib/local-environment/docker-compose-nginx.yaml
+++ b/contrib/local-environment/docker-compose-nginx.yaml
@@ -27,7 +27,6 @@ services:
     hostname: oauth2-proxy
     container_name: oauth2-proxy
     command: --config /oauth2-proxy.cfg
-    image: quay.io/oauth2-proxy/oauth2-proxy:v7.7.1
     volumes:
       - "./oauth2-proxy-nginx.cfg:/oauth2-proxy.cfg"
     networks:


### PR DESCRIPTION
## Description

removed a duplicate image line that was preventing docker compose from running.

## Motivation and Context

make nginx-up <-- was broken

## How Has This Been Tested?

removed the line now `make nginx-up` is working

## Checklist:

no change to documentation necessary, this is a quick bug fix