### PR TITLE
doc: fix relative URLs to configuration page

### DIFF
--- a/docs/docs/features/endpoints.md
+++ b/docs/docs/features/endpoints.md
@@ -14,7 +14,7 @@ OAuth2 Proxy responds directly to the following endpoints. All other endpoints w
 - /oauth2/start - a URL that will redirect to start the OAuth cycle
 - /oauth2/callback - the URL used at the end of the OAuth cycle. The oauth app will be configured with this as the callback url.
 - /oauth2/userinfo - the URL is used to return user's email from the session in JSON format.
-- /oauth2/auth - only returns a 202 Accepted response or a 401 Unauthorized response; for use with the [Nginx `auth_request` directive](../configuration/overview.md#configuring-for-use-with-the-nginx-auth_request-directive)
+- /oauth2/auth - only returns a 202 Accepted response or a 401 Unauthorized response; for use with the [Nginx `auth_request` directive](../configuration/integration#configuring-for-use-with-the-nginx-auth_request-directive)
 - /oauth2/static/\* - stylesheets and other dependencies used in the sign_in and error pages
 
 ### Sign out

--- a/docs/versioned_docs/version-7.6.x/features/endpoints.md
+++ b/docs/versioned_docs/version-7.6.x/features/endpoints.md
@@ -14,7 +14,7 @@ OAuth2 Proxy responds directly to the following endpoints. All other endpoints w
 - /oauth2/start - a URL that will redirect to start the OAuth cycle
 - /oauth2/callback - the URL used at the end of the OAuth cycle. The oauth app will be configured with this as the callback url.
 - /oauth2/userinfo - the URL is used to return user's email from the session in JSON format.
-- /oauth2/auth - only returns a 202 Accepted response or a 401 Unauthorized response; for use with the [Nginx `auth_request` directive](../configuration/overview.md#configuring-for-use-with-the-nginx-auth_request-directive)
+- /oauth2/auth - only returns a 202 Accepted response or a 401 Unauthorized response; for use with the [Nginx `auth_request` directive](../configuration/integration#configuring-for-use-with-the-nginx-auth_request-directive)
 - /oauth2/static/\* - stylesheets and other dependencies used in the sign_in and error pages
 
 ### Sign out

--- a/docs/versioned_docs/version-7.7.x/features/endpoints.md
+++ b/docs/versioned_docs/version-7.7.x/features/endpoints.md
@@ -14,7 +14,7 @@ OAuth2 Proxy responds directly to the following endpoints. All other endpoints w
 - /oauth2/start - a URL that will redirect to start the OAuth cycle
 - /oauth2/callback - the URL used at the end of the OAuth cycle. The oauth app will be configured with this as the callback url.
 - /oauth2/userinfo - the URL is used to return user's email from the session in JSON format.
-- /oauth2/auth - only returns a 202 Accepted response or a 401 Unauthorized response; for use with the [Nginx `auth_request` directive](../configuration/overview.md#configuring-for-use-with-the-nginx-auth_request-directive)
+- /oauth2/auth - only returns a 202 Accepted response or a 401 Unauthorized response; for use with the [Nginx `auth_request` directive](../configuration/integration#configuring-for-use-with-the-nginx-auth_request-directive)
 - /oauth2/static/\* - stylesheets and other dependencies used in the sign_in and error pages
 
 ### Sign out


### PR DESCRIPTION
## Description

Fixes relative links to the configuration page from https://oauth2-proxy.github.io/oauth2-proxy/features/endpoints/

## Motivation and Context

Links are broken and return 404 pages.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.
