### PR TITLE
docs: fix insecure Caddy configuration example

### DIFF
--- a/docs/docs/configuration/integration.md
+++ b/docs/docs/configuration/integration.md
@@ -303,7 +303,7 @@ example.com {
 			# If oauth2-proxy returns a 401 status, redirect the client to the sign-in page.
 			@error status 401
 			handle_response @error {
-				redir * /oauth2/sign_in?rd={scheme}://{host}{uri}
+				redir * /oauth2/sign_in?rd={uri}
 			}
 		}
 

--- a/docs/docs/configuration/integration.md
+++ b/docs/docs/configuration/integration.md
@@ -274,7 +274,7 @@ This example is for a simple reverse proxy setup where the `/oauth2/` path is ke
 **Following options need to be set on `oauth2-proxy`:**
 - `--reverse-proxy=true`: Enables the use of `X-Forwarded-*` headers to determine redirects correctly
 
-```nginx
+```nginx title="Caddyfile"
 example.com {
 	# Requests to /oauth2/* are proxied to oauth2-proxy without authentication.
 	# You can't use `reverse_proxy /oauth2/* oauth2-proxy.internal:4180` here because the reverse_proxy directive has lower precedence than the handle directive.

--- a/docs/docs/configuration/integration.md
+++ b/docs/docs/configuration/integration.md
@@ -102,7 +102,7 @@ You have to substitute *name* with the actual cookie name you configured via --c
 
 **This option requires `--reverse-proxy` option to be set.**
 
-## ForwardAuth with 401 errors middleware
+### ForwardAuth with 401 errors middleware
 
 The [Traefik v2 `ForwardAuth` middleware](https://doc.traefik.io/traefik/middlewares/http/forwardauth/) allows Traefik to authenticate requests via the oauth2-proxy's `/oauth2/auth` endpoint on every request, which only returns a 202 Accepted response or a 401 Unauthorized response without proxying the whole request through. For example, on Dynamic File (YAML) Configuration:
 
@@ -167,7 +167,7 @@ http:
         query: "/oauth2/sign_in?rd={url}"
 ```
 
-## ForwardAuth with static upstreams configuration
+### ForwardAuth with static upstreams configuration
 
 Redirect to sign_in functionality provided without the use of `errors` middleware with [Traefik v2 `ForwardAuth` middleware](https://doc.traefik.io/traefik/middlewares/http/forwardauth/) pointing to oauth2-proxy service's `/` endpoint
 
@@ -265,7 +265,7 @@ http:
           - Authorization
 ```
 
-## Configuring for use with the caddy v2 `forward_auth` directive
+## Configuring for use with the Caddy (v2) `forward_auth` directive
 
 The [Caddy `forward_auth` directive](https://caddyserver.com/docs/caddyfile/directives/forward_auth) allows Caddy to authenticate requests via the `oauth2-proxy`'s `/auth`.
 

--- a/docs/docs/configuration/integration.md
+++ b/docs/docs/configuration/integration.md
@@ -303,7 +303,7 @@ example.com {
 			# If oauth2-proxy returns a 401 status, redirect the client to the sign-in page.
 			@error status 401
 			handle_response @error {
-				redir * /oauth2/sign_in?rd={uri}
+				redir * /oauth2/sign_in?rd={scheme}://{host}{uri}
 			}
 		}
 

--- a/docs/docs/configuration/integration.md
+++ b/docs/docs/configuration/integration.md
@@ -275,28 +275,40 @@ This example is for a simple reverse proxy setup where the `/oauth2/` path is ke
 - `--reverse-proxy=true`: Enables the use of `X-Forwarded-*` headers to determine redirects correctly
 
 ```nginx
-{{ domain }} {
-	# define forward auth for any path under `/`, if not more specific defined
-	forward_auth / {{ oauth.internalIP }}:4180 {
-		uri /oauth2/auth
-		copy_headers Authorization X-Auth-Request-User X-Auth-Request-Email
-
-		@error status 401
-		handle_response @error {
-			redir * /oauth2/sign_in?rd={scheme}://{host}{uri} 302
+example.com {
+	# Requests to /oauth2/* are proxied to oauth2-proxy without authentication.
+	# You can't use `reverse_proxy /oauth2/* oauth2-proxy.internal:4180` here because the reverse_proxy directive has lower precedence than the handle directive.
+	handle /oauth2/* {
+		reverse_proxy oauth2-proxy.internal:4180 {
+			# oauth2-proxy requires the X-Real-IP and X-Forwarded-{Proto,Host,Uri} headers.
+			# The reverse_proxy directive automatically sets X-Forwarded-{For,Proto,Host} headers.
+			header_up X-Real-IP {remote_host}
+			header_up X-Forwarded-Uri {uri}
 		}
 	}
 
-	# define `/oauth2/*` as specific endpoint, to avoid forward auth protection to be able to use service
-	reverse_proxy /oauth2/* {{ oauth.internalIP }}:4180 {
-		header_up X-Real-IP {remote}
-		header_up X-Forwarded-Proto https
-	}
+	# Requests to other paths are first processed by oauth2-proxy for authentication.
+	handle {
+		forward_auth oauth2-proxy.internal:4180 {
+			uri /oauth2/auth
 
-	# unspecific reverse proxy will be protected from `forward_auth /`
-	reverse_proxy {{ endpointIP }} {
-		header_up X-Real-IP {remote}
-		header_up X-Forwarded-Proto https
+			# oauth2-proxy requires the X-Real-IP and X-Forwarded-{Proto,Host,Uri} headers.
+			# The forward_auth directive automatically sets the X-Forwarded-{For,Proto,Host,Method,Uri} headers.
+			header_up X-Real-IP {remote_host}
+
+			# If needed, you can copy headers from the oauth2-proxy response to the request sent to the upstream.
+			# Make sure to configure the --set-xauthrequest flag to enable this feature.
+			#copy_headers X-Auth-Request-User X-Auth-Request-Email
+
+			# If oauth2-proxy returns a 401 status, redirect the client to the sign-in page.
+			@error status 401
+			handle_response @error {
+				redir * /oauth2/sign_in?rd={scheme}://{host}{uri}
+			}
+		}
+
+		# If oauth2-proxy returns a 2xx status, the request is then proxied to the upstream.
+		reverse_proxy upstream.internal:3000
 	}
 }
 ```

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -123,7 +123,7 @@ const config = {
       prism: {
         theme: prismThemes.github,
         darkTheme: prismThemes.dracula,
-        additionalLanguages: ['hcl', 'powershell'],
+        additionalLanguages: ['hcl', 'nginx', 'powershell'],
       },
     }),
 };

--- a/docs/versioned_docs/version-7.6.x/configuration/integration.md
+++ b/docs/versioned_docs/version-7.6.x/configuration/integration.md
@@ -303,7 +303,7 @@ example.com {
 			# If oauth2-proxy returns a 401 status, redirect the client to the sign-in page.
 			@error status 401
 			handle_response @error {
-				redir * /oauth2/sign_in?rd={scheme}://{host}{uri}
+				redir * /oauth2/sign_in?rd={uri}
 			}
 		}
 

--- a/docs/versioned_docs/version-7.6.x/configuration/integration.md
+++ b/docs/versioned_docs/version-7.6.x/configuration/integration.md
@@ -274,7 +274,7 @@ This example is for a simple reverse proxy setup where the `/oauth2/` path is ke
 **Following options need to be set on `oauth2-proxy`:**
 - `--reverse-proxy=true`: Enables the use of `X-Forwarded-*` headers to determine redirects correctly
 
-```nginx
+```nginx title="Caddyfile"
 example.com {
 	# Requests to /oauth2/* are proxied to oauth2-proxy without authentication.
 	# You can't use `reverse_proxy /oauth2/* oauth2-proxy.internal:4180` here because the reverse_proxy directive has lower precedence than the handle directive.

--- a/docs/versioned_docs/version-7.6.x/configuration/integration.md
+++ b/docs/versioned_docs/version-7.6.x/configuration/integration.md
@@ -102,7 +102,7 @@ You have to substitute *name* with the actual cookie name you configured via --c
 
 **This option requires `--reverse-proxy` option to be set.**
 
-## ForwardAuth with 401 errors middleware
+### ForwardAuth with 401 errors middleware
 
 The [Traefik v2 `ForwardAuth` middleware](https://doc.traefik.io/traefik/middlewares/http/forwardauth/) allows Traefik to authenticate requests via the oauth2-proxy's `/oauth2/auth` endpoint on every request, which only returns a 202 Accepted response or a 401 Unauthorized response without proxying the whole request through. For example, on Dynamic File (YAML) Configuration:
 
@@ -167,7 +167,7 @@ http:
         query: "/oauth2/sign_in?rd={url}"
 ```
 
-## ForwardAuth with static upstreams configuration
+### ForwardAuth with static upstreams configuration
 
 Redirect to sign_in functionality provided without the use of `errors` middleware with [Traefik v2 `ForwardAuth` middleware](https://doc.traefik.io/traefik/middlewares/http/forwardauth/) pointing to oauth2-proxy service's `/` endpoint
 
@@ -265,7 +265,7 @@ http:
           - Authorization
 ```
 
-## Configuring for use with the caddy v2 `forward_auth` directive
+## Configuring for use with the Caddy (v2) `forward_auth` directive
 
 The [Caddy `forward_auth` directive](https://caddyserver.com/docs/caddyfile/directives/forward_auth) allows Caddy to authenticate requests via the `oauth2-proxy`'s `/auth`.
 

--- a/docs/versioned_docs/version-7.6.x/configuration/integration.md
+++ b/docs/versioned_docs/version-7.6.x/configuration/integration.md
@@ -303,7 +303,7 @@ example.com {
 			# If oauth2-proxy returns a 401 status, redirect the client to the sign-in page.
 			@error status 401
 			handle_response @error {
-				redir * /oauth2/sign_in?rd={uri}
+				redir * /oauth2/sign_in?rd={scheme}://{host}{uri}
 			}
 		}
 

--- a/docs/versioned_docs/version-7.6.x/configuration/integration.md
+++ b/docs/versioned_docs/version-7.6.x/configuration/integration.md
@@ -275,28 +275,40 @@ This example is for a simple reverse proxy setup where the `/oauth2/` path is ke
 - `--reverse-proxy=true`: Enables the use of `X-Forwarded-*` headers to determine redirects correctly
 
 ```nginx
-{{ domain }} {
-	# define forward auth for any path under `/`, if not more specific defined
-	forward_auth / {{ oauth.internalIP }}:4180 {
-		uri /oauth2/auth
-		copy_headers Authorization X-Auth-Request-User X-Auth-Request-Email
-
-		@error status 401
-		handle_response @error {
-			redir * /oauth2/sign_in?rd={scheme}://{host}{uri} 302
+example.com {
+	# Requests to /oauth2/* are proxied to oauth2-proxy without authentication.
+	# You can't use `reverse_proxy /oauth2/* oauth2-proxy.internal:4180` here because the reverse_proxy directive has lower precedence than the handle directive.
+	handle /oauth2/* {
+		reverse_proxy oauth2-proxy.internal:4180 {
+			# oauth2-proxy requires the X-Real-IP and X-Forwarded-{Proto,Host,Uri} headers.
+			# The reverse_proxy directive automatically sets X-Forwarded-{For,Proto,Host} headers.
+			header_up X-Real-IP {remote_host}
+			header_up X-Forwarded-Uri {uri}
 		}
 	}
 
-	# define `/oauth2/*` as specific endpoint, to avoid forward auth protection to be able to use service
-	reverse_proxy /oauth2/* {{ oauth.internalIP }}:4180 {
-		header_up X-Real-IP {remote}
-		header_up X-Forwarded-Proto https
-	}
+	# Requests to other paths are first processed by oauth2-proxy for authentication.
+	handle {
+		forward_auth oauth2-proxy.internal:4180 {
+			uri /oauth2/auth
 
-	# unspecific reverse proxy will be protected from `forward_auth /`
-	reverse_proxy {{ endpointIP }} {
-		header_up X-Real-IP {remote}
-		header_up X-Forwarded-Proto https
+			# oauth2-proxy requires the X-Real-IP and X-Forwarded-{Proto,Host,Uri} headers.
+			# The forward_auth directive automatically sets the X-Forwarded-{For,Proto,Host,Method,Uri} headers.
+			header_up X-Real-IP {remote_host}
+
+			# If needed, you can copy headers from the oauth2-proxy response to the request sent to the upstream.
+			# Make sure to configure the --set-xauthrequest flag to enable this feature.
+			#copy_headers X-Auth-Request-User X-Auth-Request-Email
+
+			# If oauth2-proxy returns a 401 status, redirect the client to the sign-in page.
+			@error status 401
+			handle_response @error {
+				redir * /oauth2/sign_in?rd={scheme}://{host}{uri}
+			}
+		}
+
+		# If oauth2-proxy returns a 2xx status, the request is then proxied to the upstream.
+		reverse_proxy upstream.internal:3000
 	}
 }
 ```

--- a/docs/versioned_docs/version-7.7.x/configuration/integration.md
+++ b/docs/versioned_docs/version-7.7.x/configuration/integration.md
@@ -303,7 +303,7 @@ example.com {
 			# If oauth2-proxy returns a 401 status, redirect the client to the sign-in page.
 			@error status 401
 			handle_response @error {
-				redir * /oauth2/sign_in?rd={scheme}://{host}{uri}
+				redir * /oauth2/sign_in?rd={uri}
 			}
 		}
 

--- a/docs/versioned_docs/version-7.7.x/configuration/integration.md
+++ b/docs/versioned_docs/version-7.7.x/configuration/integration.md
@@ -274,7 +274,7 @@ This example is for a simple reverse proxy setup where the `/oauth2/` path is ke
 **Following options need to be set on `oauth2-proxy`:**
 - `--reverse-proxy=true`: Enables the use of `X-Forwarded-*` headers to determine redirects correctly
 
-```nginx
+```nginx title="Caddyfile"
 example.com {
 	# Requests to /oauth2/* are proxied to oauth2-proxy without authentication.
 	# You can't use `reverse_proxy /oauth2/* oauth2-proxy.internal:4180` here because the reverse_proxy directive has lower precedence than the handle directive.

--- a/docs/versioned_docs/version-7.7.x/configuration/integration.md
+++ b/docs/versioned_docs/version-7.7.x/configuration/integration.md
@@ -102,7 +102,7 @@ You have to substitute *name* with the actual cookie name you configured via --c
 
 **This option requires `--reverse-proxy` option to be set.**
 
-## ForwardAuth with 401 errors middleware
+### ForwardAuth with 401 errors middleware
 
 The [Traefik v2 `ForwardAuth` middleware](https://doc.traefik.io/traefik/middlewares/http/forwardauth/) allows Traefik to authenticate requests via the oauth2-proxy's `/oauth2/auth` endpoint on every request, which only returns a 202 Accepted response or a 401 Unauthorized response without proxying the whole request through. For example, on Dynamic File (YAML) Configuration:
 
@@ -167,7 +167,7 @@ http:
         query: "/oauth2/sign_in?rd={url}"
 ```
 
-## ForwardAuth with static upstreams configuration
+### ForwardAuth with static upstreams configuration
 
 Redirect to sign_in functionality provided without the use of `errors` middleware with [Traefik v2 `ForwardAuth` middleware](https://doc.traefik.io/traefik/middlewares/http/forwardauth/) pointing to oauth2-proxy service's `/` endpoint
 
@@ -265,7 +265,7 @@ http:
           - Authorization
 ```
 
-## Configuring for use with the caddy v2 `forward_auth` directive
+## Configuring for use with the Caddy (v2) `forward_auth` directive
 
 The [Caddy `forward_auth` directive](https://caddyserver.com/docs/caddyfile/directives/forward_auth) allows Caddy to authenticate requests via the `oauth2-proxy`'s `/auth`.
 

--- a/docs/versioned_docs/version-7.7.x/configuration/integration.md
+++ b/docs/versioned_docs/version-7.7.x/configuration/integration.md
@@ -303,7 +303,7 @@ example.com {
 			# If oauth2-proxy returns a 401 status, redirect the client to the sign-in page.
 			@error status 401
 			handle_response @error {
-				redir * /oauth2/sign_in?rd={uri}
+				redir * /oauth2/sign_in?rd={scheme}://{host}{uri}
 			}
 		}
 

--- a/docs/versioned_docs/version-7.7.x/configuration/integration.md
+++ b/docs/versioned_docs/version-7.7.x/configuration/integration.md
@@ -275,28 +275,40 @@ This example is for a simple reverse proxy setup where the `/oauth2/` path is ke
 - `--reverse-proxy=true`: Enables the use of `X-Forwarded-*` headers to determine redirects correctly
 
 ```nginx
-{{ domain }} {
-	# define forward auth for any path under `/`, if not more specific defined
-	forward_auth / {{ oauth.internalIP }}:4180 {
-		uri /oauth2/auth
-		copy_headers Authorization X-Auth-Request-User X-Auth-Request-Email
-
-		@error status 401
-		handle_response @error {
-			redir * /oauth2/sign_in?rd={scheme}://{host}{uri} 302
+example.com {
+	# Requests to /oauth2/* are proxied to oauth2-proxy without authentication.
+	# You can't use `reverse_proxy /oauth2/* oauth2-proxy.internal:4180` here because the reverse_proxy directive has lower precedence than the handle directive.
+	handle /oauth2/* {
+		reverse_proxy oauth2-proxy.internal:4180 {
+			# oauth2-proxy requires the X-Real-IP and X-Forwarded-{Proto,Host,Uri} headers.
+			# The reverse_proxy directive automatically sets X-Forwarded-{For,Proto,Host} headers.
+			header_up X-Real-IP {remote_host}
+			header_up X-Forwarded-Uri {uri}
 		}
 	}
 
-	# define `/oauth2/*` as specific endpoint, to avoid forward auth protection to be able to use service
-	reverse_proxy /oauth2/* {{ oauth.internalIP }}:4180 {
-		header_up X-Real-IP {remote}
-		header_up X-Forwarded-Proto https
-	}
+	# Requests to other paths are first processed by oauth2-proxy for authentication.
+	handle {
+		forward_auth oauth2-proxy.internal:4180 {
+			uri /oauth2/auth
 
-	# unspecific reverse proxy will be protected from `forward_auth /`
-	reverse_proxy {{ endpointIP }} {
-		header_up X-Real-IP {remote}
-		header_up X-Forwarded-Proto https
+			# oauth2-proxy requires the X-Real-IP and X-Forwarded-{Proto,Host,Uri} headers.
+			# The forward_auth directive automatically sets the X-Forwarded-{For,Proto,Host,Method,Uri} headers.
+			header_up X-Real-IP {remote_host}
+
+			# If needed, you can copy headers from the oauth2-proxy response to the request sent to the upstream.
+			# Make sure to configure the --set-xauthrequest flag to enable this feature.
+			#copy_headers X-Auth-Request-User X-Auth-Request-Email
+
+			# If oauth2-proxy returns a 401 status, redirect the client to the sign-in page.
+			@error status 401
+			handle_response @error {
+				redir * /oauth2/sign_in?rd={scheme}://{host}{uri}
+			}
+		}
+
+		# If oauth2-proxy returns a 2xx status, the request is then proxied to the upstream.
+		reverse_proxy upstream.internal:3000
 	}
 }
 ```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR corrects the Caddy configuration example on the "Integration" page.

It also includes minor improvements, such as fixes for syntax highlighting and heading levels.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The original example only protected the root (`/`) path, leaving other routes accessible without authentication.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I tested my configurations using the following `compose.yaml` and `Caddyfile`.

```yaml
services:
  caddy:
    image: caddy:2.8.4
    restart: unless-stopped
    volumes:
      - ./Caddyfile:/etc/caddy/Caddyfile:ro
      - caddy_data:/data
    ports:
      - 80:80

  oauth2_proxy:
    image: quay.io/oauth2-proxy/oauth2-proxy:v7.7.1
    command: ["--config=/etc/oauth2-proxy.cfg"]
    restart: unless-stopped
    volumes:
      - ./oauth2-proxy.cfg:/etc/oauth2-proxy.cfg:ro

  whoami:
    image: traefik/whoami
    restart: unless-stopped

volumes:
  caddy_data:
```

```nginx
:80 {
	handle /oauth2/* {
		reverse_proxy oauth2_proxy:4180 {
			header_up X-Real-IP {remote_host}
			header_up X-Forwarded-Uri {uri}
		}
	}

	handle {
		forward_auth oauth2_proxy:4180 {
			uri /oauth2/auth

			header_up X-Real-IP {remote_host}

			@error status 401
			handle_response @error {
				redir * /oauth2/sign_in?rd={uri}
			}
		}

		reverse_proxy whoami:80
	}
}
```

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.
