### PR TITLE
Introducing OAuth2-Proxy Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 [![Maintainability](https://api.codeclimate.com/v1/badges/a58ff79407212e2beacb/maintainability)](https://codeclimate.com/github/oauth2-proxy/oauth2-proxy/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/a58ff79407212e2beacb/test_coverage)](https://codeclimate.com/github/oauth2-proxy/oauth2-proxy/test_coverage)
-[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20OAuth2-Proxy%20Guru-006BFF)](https://gurubase.io/g/oauth2-proxy)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20OAuth2--Proxy%20Guru-006BFF)](https://gurubase.io/g/oauth2-proxy)
 
 ![OAuth2 Proxy](docs/static/img/logos/OAuth2_Proxy_horizontal.svg)
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 [![Maintainability](https://api.codeclimate.com/v1/badges/a58ff79407212e2beacb/maintainability)](https://codeclimate.com/github/oauth2-proxy/oauth2-proxy/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/a58ff79407212e2beacb/test_coverage)](https://codeclimate.com/github/oauth2-proxy/oauth2-proxy/test_coverage)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20OAuth2-Proxy%20Guru-006BFF)](https://gurubase.io/g/oauth2-proxy)
 
 ![OAuth2 Proxy](docs/static/img/logos/OAuth2_Proxy_horizontal.svg)
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [OAuth2-Proxy Guru](https://gurubase.io/g/oauth2-proxy) to Gurubase. OAuth2-Proxy Guru uses the data from this repo and data from the [docs](https://oauth2-proxy.github.io/oauth2-proxy/) to answer questions by leveraging the LLM.

In this PR, I showcased the "OAuth2-Proxy Guru", which highlights that OAuth2-Proxy now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable OAuth2-Proxy Guru in Gurubase, just let me know that's totally fine.
