### PR TITLE
Pass Access Token in Bearer Header

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ OAuth2-Proxy's [Installation Docs](https://oauth2-proxy.github.io/oauth2-proxy/i
 
 ## Releases
 
+This reporsitory add extra config setting for our usage. By able to pass access token to Upstream Authentication header under Bearer.
+example in config file: pass_access_token_to_bearer = true
+
+
+flag: --pass-access-token-to-bearer
+
+toml: pass_access_token_to_bearer
+
 ### Binaries
 We publish oauth2-proxy as compiled binaries on GitHub for all major architectures as well as more exotic ones like `ppc64le` as well as `s390x`.
 

--- a/pkg/apis/options/legacy_options.go
+++ b/pkg/apis/options/legacy_options.go
@@ -187,11 +187,11 @@ func (l *LegacyUpstreams) convert() (UpstreamConfig, error) {
 }
 
 type LegacyHeaders struct {
-	PassBasicAuth     bool `flag:"pass-basic-auth" cfg:"pass_basic_auth"`
-	PassAccessToken   bool `flag:"pass-access-token" cfg:"pass_access_token"`
+	PassBasicAuth           bool `flag:"pass-basic-auth" cfg:"pass_basic_auth"`
+	PassAccessToken         bool `flag:"pass-access-token" cfg:"pass_access_token"`
 	PassAccessTokenToBearer bool `flag:"pass-access-token-to-bearer" cfg:"pass_access_token_to_bearer"`
-	PassUserHeaders   bool `flag:"pass-user-headers" cfg:"pass_user_headers"`
-	PassAuthorization bool `flag:"pass-authorization-header" cfg:"pass_authorization_header"`
+	PassUserHeaders         bool `flag:"pass-user-headers" cfg:"pass_user_headers"`
+	PassAuthorization       bool `flag:"pass-authorization-header" cfg:"pass_authorization_header"`
 
 	SetBasicAuth     bool `flag:"set-basic-auth" cfg:"set_basic_auth"`
 	SetXAuthRequest  bool `flag:"set-xauthrequest" cfg:"set_xauthrequest"`
@@ -375,8 +375,8 @@ func getPassAccessTokenHeaderToBearer() Header {
 		Values: []HeaderValue{
 			{
 				ClaimSource: &ClaimSource{
-					Claim: "access_token",
-					Prefix: "Bearer",
+					Claim:  "access_token",
+					Prefix: "Bearer ",
 				},
 			},
 		},

--- a/pkg/apis/options/legacy_options.go
+++ b/pkg/apis/options/legacy_options.go
@@ -189,6 +189,7 @@ func (l *LegacyUpstreams) convert() (UpstreamConfig, error) {
 type LegacyHeaders struct {
 	PassBasicAuth     bool `flag:"pass-basic-auth" cfg:"pass_basic_auth"`
 	PassAccessToken   bool `flag:"pass-access-token" cfg:"pass_access_token"`
+	PassAccessTokenToBearer bool `flag:"pass-access-token-to-bearer" cfg:"pass_access_token_to_bearer"`
 	PassUserHeaders   bool `flag:"pass-user-headers" cfg:"pass_user_headers"`
 	PassAuthorization bool `flag:"pass-authorization-header" cfg:"pass_authorization_header"`
 
@@ -206,6 +207,7 @@ func legacyHeadersFlagSet() *pflag.FlagSet {
 
 	flagSet.Bool("pass-basic-auth", true, "pass HTTP Basic Auth, X-Forwarded-User and X-Forwarded-Email information to upstream")
 	flagSet.Bool("pass-access-token", false, "pass OAuth access_token to upstream via X-Forwarded-Access-Token header")
+	flagSet.Bool("pass-access-token-to-bearer", false, "pass OAuth access_token to upstream via Authorization Header Bearer")
 	flagSet.Bool("pass-user-headers", true, "pass X-Forwarded-User and X-Forwarded-Email information to upstream")
 	flagSet.Bool("pass-authorization-header", false, "pass the Authorization Header to upstream")
 
@@ -241,6 +243,10 @@ func (l *LegacyHeaders) getRequestHeaders() []Header {
 
 	if l.PassAccessToken {
 		requestHeaders = append(requestHeaders, getPassAccessTokenHeader())
+	}
+
+	if l.PassAccessTokenToBearer {
+		requestHeaders = append(requestHeaders, getPassAccessTokenHeaderToBearer())
 	}
 
 	if l.PassAuthorization {
@@ -357,6 +363,20 @@ func getPassAccessTokenHeader() Header {
 			{
 				ClaimSource: &ClaimSource{
 					Claim: "access_token",
+				},
+			},
+		},
+	}
+}
+
+func getPassAccessTokenHeaderToBearer() Header {
+	return Header{
+		Name: "Authorization",
+		Values: []HeaderValue{
+			{
+				ClaimSource: &ClaimSource{
+					Claim: "access_token",
+					Prefix: "Bearer",
 				},
 			},
 		},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Enable pass Access Token in Authorization Bearer Header

<!--- Describe your changes in detail -->

## There is a need to pass Access Token to Bearer header instead of ID Token.
Some request can be seen from this issue https://github.com/oauth2-proxy/oauth2-proxy/issues/2825

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on local oauth2-proxy instance.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.
