### PR TITLE
Token issue engbugs 52663

### DIFF
--- a/pkg/validation/options.go
+++ b/pkg/validation/options.go
@@ -369,7 +369,8 @@ func parseJwtIssuers(issuers []string, msgs []string) ([]jwtIssuer, []string) {
 // a verifier for that issuer.
 func newVerifierFromJwtIssuer(jwtIssuer jwtIssuer) (*oidc.IDTokenVerifier, error) {
 	config := &oidc.Config{
-		ClientID: jwtIssuer.audience,
+		ClientID:        jwtIssuer.audience,
+		SkipExpiryCheck: true,
 	}
 	// Try as an OpenID Connect Provider first
 	var verifier *oidc.IDTokenVerifier

--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -155,6 +155,12 @@ func (p *OIDCProvider) RefreshSessionIfNeeded(ctx context.Context, s *sessions.S
 		return false, fmt.Errorf("unable to redeem refresh token: %v", err)
 	}
 
+	err = p.EnrichSession(ctx, s)
+	if err != nil {
+		// Non critical, use unenriched session
+		logger.Errorf("Warning: unable to enrich session, error %s", err)
+	}
+
 	logger.Printf("refreshed session: %s", s)
 	return true, nil
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Access token stored in redis is getting reverified after okta access token verification.
In corner case of 59m to 1m, this local token re-verification is getting failed.
We do not need this token to be reverified, hence skipping Expiry Token check.
So, setting SkipExpiryCheck: true, in newVerifierFromJwtIssuer. 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

We we deploy this to staging and test before pushing to production
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
- [x] I have written tests for my code changes.
