### PR TITLE
feat: pass along oidc config to verifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## Changes since v7.13.0
 
 - [#3197](https://github.com/oauth2-proxy/oauth2-proxy/pull/3197) fix: NewRemoteKeySet is not using DefaultHTTPClient (@rsrdesarrollo / @tuunit)
+- [#2869](https://github.com/oauth2-proxy/oauth2-proxy/pull/2869) feat: pass along oidc config to verifier (@brian-mcnamara)
 
 # V7.13.0
 

--- a/pkg/providers/oidc/provider_verifier.go
+++ b/pkg/providers/oidc/provider_verifier.go
@@ -17,6 +17,7 @@ import (
 // ProviderVerifier represents the OIDC discovery and verification process
 type ProviderVerifier interface {
 	DiscoveryEnabled() bool
+	JwksURL() string
 	Provider() DiscoveryProvider
 	Verifier() IDTokenVerifier
 }
@@ -120,6 +121,7 @@ func NewProviderVerifier(ctx context.Context, opts ProviderVerifierOptions) (Pro
 
 	return &providerVerifier{
 		discoveryEnabled: !opts.SkipDiscovery,
+		jwksURL:          opts.JWKsURL,
 		provider:         provider,
 		verifier:         verifier,
 	}, nil
@@ -215,6 +217,7 @@ func newVerifierBuilder(issuerURL string, keySet oidc.KeySet, supportedSigningAl
 // providerVerifier is an implementation of the ProviderVerifier interface
 type providerVerifier struct {
 	discoveryEnabled bool
+	jwksURL          string
 	provider         DiscoveryProvider
 	verifier         IDTokenVerifier
 }
@@ -233,4 +236,9 @@ func (p *providerVerifier) Provider() DiscoveryProvider {
 // Verifier returns the ID token verifier
 func (p *providerVerifier) Verifier() IDTokenVerifier {
 	return p.verifier
+}
+
+// JwksURL retuns the jwks url used for the provider
+func (p *providerVerifier) JwksURL() string {
+	return p.jwksURL
 }

--- a/pkg/validation/options.go
+++ b/pkg/validation/options.go
@@ -58,8 +58,7 @@ func Validate(o *options.Options) error {
 			jwtIssuers, msgs = parseJwtIssuers(o.ExtraJwtIssuers, msgs)
 			for _, jwtIssuer := range jwtIssuers {
 				verifier, err := newVerifierFromJwtIssuer(
-					o.Providers[0].OIDCConfig.AudienceClaims,
-					o.Providers[0].OIDCConfig.ExtraAudiences,
+					o.Providers[0].OIDCConfig,
 					jwtIssuer,
 				)
 				if err != nil {
@@ -142,12 +141,14 @@ func parseJwtIssuers(issuers []string, msgs []string) ([]jwtIssuer, []string) {
 
 // newVerifierFromJwtIssuer takes in issuer information in jwtIssuer info and returns
 // a verifier for that issuer.
-func newVerifierFromJwtIssuer(audienceClaims []string, extraAudiences []string, jwtIssuer jwtIssuer) (internaloidc.IDTokenVerifier, error) {
+func newVerifierFromJwtIssuer(odicOptions options.OIDCOptions, jwtIssuer jwtIssuer) (internaloidc.IDTokenVerifier, error) {
 	pvOpts := internaloidc.ProviderVerifierOptions{
-		AudienceClaims: audienceClaims,
+		AudienceClaims: odicOptions.AudienceClaims,
 		ClientID:       jwtIssuer.audience,
-		ExtraAudiences: extraAudiences,
+		ExtraAudiences: odicOptions.ExtraAudiences,
 		IssuerURL:      jwtIssuer.issuerURI,
+		SkipDiscovery:  odicOptions.SkipDiscovery,
+		JWKsURL:        odicOptions.JwksURL,
 	}
 
 	pv, err := internaloidc.NewProviderVerifier(context.TODO(), pvOpts)

--- a/pkg/validation/options.go
+++ b/pkg/validation/options.go
@@ -142,6 +142,18 @@ func parseJwtIssuers(issuers []string, msgs []string) ([]jwtIssuer, []string) {
 // newVerifierFromJwtIssuer takes in issuer information in jwtIssuer info and returns
 // a verifier for that issuer.
 func newVerifierFromJwtIssuer(odicOptions options.OIDCOptions, jwtIssuer jwtIssuer) (internaloidc.IDTokenVerifier, error) {
+	pv, err := newProviderVerifierFromJwtIssuer(odicOptions, jwtIssuer)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return pv.Verifier(), nil
+}
+
+// newProviderVerifierFromJwtIssuer takes in issuer information in jwtIssuer info and returns
+// a ProviderVerifier for that issuer.
+func newProviderVerifierFromJwtIssuer(odicOptions options.OIDCOptions, jwtIssuer jwtIssuer) (internaloidc.ProviderVerifier, error) {
 	pvOpts := internaloidc.ProviderVerifierOptions{
 		AudienceClaims: odicOptions.AudienceClaims,
 		ClientID:       jwtIssuer.audience,
@@ -163,7 +175,7 @@ func newVerifierFromJwtIssuer(odicOptions options.OIDCOptions, jwtIssuer jwtIssu
 		}
 	}
 
-	return pv.Verifier(), nil
+	return pv, nil
 }
 
 // jwtIssuer hold parsed JWT issuer info that's used to construct a verifier.

--- a/pkg/validation/options_test.go
+++ b/pkg/validation/options_test.go
@@ -235,3 +235,39 @@ func TestProviderCAFilesError(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unable to load provider CA file(s)")
 }
+
+func TestProviderVerifierSkipsDiscoveryWhenConfigured(t *testing.T) {
+	jwksUrl := "https://examle.com/auth/certs"
+	o := testOptions()
+	o.Providers[0].OIDCConfig.SkipDiscovery = true
+	o.Providers[0].OIDCConfig.JwksURL = jwksUrl
+
+	jwtIssuer := jwtIssuer{
+		issuerURI: "https://example.com",
+		audience:  "aud",
+	}
+
+	pv, err := newProviderVerifierFromJwtIssuer(o.Providers[0].OIDCConfig, jwtIssuer)
+	assert.Equal(t, nil, err)
+	assert.NotEqual(t, nil, pv)
+
+	assert.Equal(t, jwksUrl, pv.JwksURL())
+	assert.False(t, pv.DiscoveryEnabled())
+}
+
+func TestProviderVerifierUsesFallback(t *testing.T) {
+	issuerURI := "https://example.com"
+	o := testOptions()
+
+	jwtIssuer := jwtIssuer{
+		issuerURI: issuerURI,
+		audience:  "aud",
+	}
+
+	pv, err := newProviderVerifierFromJwtIssuer(o.Providers[0].OIDCConfig, jwtIssuer)
+	assert.Equal(t, nil, err)
+	assert.NotEqual(t, nil, pv)
+
+	assert.Equal(t, issuerURI+"/.well-known/jwks.json", pv.JwksURL())
+	assert.False(t, pv.DiscoveryEnabled())
+}


### PR DESCRIPTION
Include additional user configuration to the jwt verifier as a mechanism to fix #2649 

## Description

Before this change, while constructing a verifier, discovery is initially performed because the value is not passed from the configuration into ProviderVerifierOptions. However, if the Idp is down, or fails during the request, the logic falls into permanently setting the JWKsURL to .well-known, disabling discovery, which will cause all downstream attempts to verify the token to fail if the idp does not support the assumed .well-known url.

This change passes down JWKsURL and skipDiscovery as a workaround to issue #2649. 
I will confess, I do not know this code well enough to suggest a proper refactor. I feel it is very strange that the fallback logic, when discovery fails, is to change the JWKsURL and skipDiscovery which prevents errors while fetching JWKs from being identified until runtime. In order to prevent regressions, I decided to choose a path that would allow this logic to continue to operate, and, based on my understanding, pass along configuration which should be applied to the verifier.

While I feel these changes are backwards compatible, please let me know if that is not the case. 

## Motivation and Context

Fixes #2649 

## How Has This Been Tested?

Currently testing this in my environment. Need to follow up with testing.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [X] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.
