### PR TITLE
fix dex chart values uses with k8s local-environment sample within contrib folder 

### DIFF
--- a/contrib/local-environment/kubernetes/README.md
+++ b/contrib/local-environment/kubernetes/README.md
@@ -16,6 +16,8 @@ Then:
 * `make deploy`
 
 Visit http://httpbin.localtest.me or http://hello-world.localtest.me/
+Note: When accessing the service for the first time, dex will authenticate the user.
+Dex deployment is setup with static local credentials of user as `admin@example.com` with password as `password`
 
 ## Uninstall
 

--- a/contrib/local-environment/kubernetes/values.yaml
+++ b/contrib/local-environment/kubernetes/values.yaml
@@ -2,8 +2,12 @@ dex:
   ingress:
     enabled: true
     hosts:
-      - dex.localtest.me
-  grpc: false
+      - host: dex.localtest.me
+        paths:
+        - path: /
+          pathType: ImplementationSpecific
+  grpc: 
+    enabled: false
   certs:
     grpc:
       create: false
@@ -12,6 +16,11 @@ dex:
 
   config:
     issuer: http://dex.localtest.me
+    storage:
+      type: kubernetes
+      config:
+        inCluster: true
+    enablePasswordDB: true
     expiry:
       signingKeys: "4h"
       idTokens: "1h"
@@ -35,9 +44,6 @@ oauth2-proxy:
     enabled: true
     hosts:
       - oauth2-proxy.localtest.me
-    annotations:
-      nginx.ingress.kubernetes.io/server-snippet: |
-        large_client_header_buffers 4 32k;
   # pick up client_id and client_secret from configFile as opposed to helm .Values.config.clientID and .Values.config.clientSecret
   proxyVarsAsSecrets: false
   config:


### PR DESCRIPTION
Currently local kubernetes sample fails because of invalid dex chart values

## Description

fixed dex chart values

## Motivation and Context

local k8s sample is a well container example and having a working version will make it easier to understand the end2end flow


## How Has This Been Tested?

Using instructions within README that uses local kind cluster to setup the services