### PR TITLE
fix: jwt regex validation error during skip-jwt-bearer-tokens flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ## Changes since v7.8.0
 
-- [#2887](https://github.com/oauth2-proxy/oauth2-proxy/issues/2887) fix: jwt regex validation during skip-jwt-bearer-tokens flow
+- [#2887](https://github.com/oauth2-proxy/oauth2-proxy/issues/2887) fix: jwt regex validation error during skip-jwt-bearer-tokens flow
 
 # V7.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Changes since v7.8.0
 
+- [#2887](https://github.com/oauth2-proxy/oauth2-proxy/issues/2887) fix: jwt regex validation during skip-jwt-bearer-tokens flow
+
 # V7.8.0
 
 ## Release Highlights

--- a/pkg/middleware/jwt_session.go
+++ b/pkg/middleware/jwt_session.go
@@ -13,7 +13,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
-const jwtRegexFormat = `^ey[IJ][a-zA-Z0-9_-]*\.ey[IJ][a-zA-Z0-9_-]*\.[a-zA-Z0-9_-]+$`
+const jwtRegexFormat = `^ey[a-zA-Z0-9_-]*\.ey[a-zA-Z0-9_-]*\.[a-zA-Z0-9_-]+$`
 
 func NewJwtSessionLoader(sessionLoaders []middlewareapi.TokenToSessionFunc) alice.Constructor {
 	js := &jwtSessionLoader{

--- a/pkg/middleware/jwt_session_test.go
+++ b/pkg/middleware/jwt_session_test.go
@@ -71,6 +71,7 @@ Nnc3a3lGVWFCNUMxQnNJcnJMTWxka1dFaHluYmI4Ongtb2F1dGgtYmFzaWM=`
 	// validToken will pass the token regex so can be used to check token fetching
 	// is valid. It will not pass the OIDC Verifier however.
 	const validToken = "eyJfoobar.eyJfoobar.12345asdf"
+	const validTokenWithSpace = "eyAidHlwIjogIkpXVCIsICJraWQiOiAiRTJlWW5ZMWR1eGttTkpiVGdCRzd4MkVpNVJZPSIsICJhbGciOiAiUlMyNTYiIH0K.eyJfoobar.12345asdf"
 
 	Context("JwtSessionLoader", func() {
 		var verifier middlewareapi.VerifyFunc
@@ -293,6 +294,11 @@ Nnc3a3lGVWFCNUMxQnNJcnJMTWxka1dFaHluYmI4Ongtb2F1dGgtYmFzaWM=`
 				header:        fmt.Sprintf("Bearer %s", validToken),
 				expectedErr:   nil,
 				expectedToken: validToken,
+			}),
+			Entry("Bearer <valid-token-with-whitespace>", findBearerTokenFromHeaderTableInput{
+				header:        fmt.Sprintf("Bearer %s", validTokenWithSpace),
+				expectedErr:   nil,
+				expectedToken: validTokenWithSpace,
 			}),
 			Entry("Basic invalid-base64", findBearerTokenFromHeaderTableInput{
 				header:        "Basic invalid-base64",


### PR DESCRIPTION



<!--- Provide a general summary of your changes in the Title above -->
Change the jwttoken Regex 

## Description

<!--- Describe your changes in detail -->
Update jwt_session.go to just validate if each part of jwt token  with {
## Motivation and Context
Update jwt_session.go to just validate if each part of jwt token  with { 
Solve the issue:
https://github.com/oauth2-proxy/oauth2-proxy/issues/2887


## How Has This Been Tested?

We test this on our local machine by building and running the oauth2-proxy.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.
