### PR TITLE
feat: add ProConnect provider

### DIFF
--- a/docs/docs/configuration/providers/proconnect.md
+++ b/docs/docs/configuration/providers/proconnect.md
@@ -1,0 +1,42 @@
+---
+id: proconnect
+title: ProConnect
+---
+
+ProConnect is an OIDC provider for the French Government.
+If you are a French government agency, you can contact the ProConnect team through the contact information
+that you can find on https://www.proconnect.gouv.fr/ and work with them to understand how to get ProConnect
+accounts for integration/test and production access.
+
+An integration guide is available here: https://github.com/numerique-gouv/proconnect-documentation, though this proxy handles everything but the data you need to create to register your application in ProConnect.
+
+As a demo, we will assume that you are running your application that you want to secure locally on
+http://localhost:3000/, that you will be starting your proxy up on http://localhost:4180/, and that
+you have an agency integration account for testing.
+
+First, register your application in ProConnect.
+
+- Return to App URL: Make this be `http://localhost:4180/`
+- Redirect URIs: Make this be `http://localhost:4180/oauth2/callback`.
+- Attribute Bundle: Make sure that email is selected.
+
+Now start the proxy up with the following options:
+
+```
+./oauth2-proxy -provider proconnect \
+  -client-id=YOUR_PROCONNECT_CLIENT_ID \
+  -client-secret=YOUR_PROCONNECT_CLIENT_SECRET \
+  -redirect-url=http://localhost:4180/oauth2/callback \
+  -oidc-issuer-url=https://fca.integ01.dev-agentconnect.fr/api/v2 \
+  -cookie-secure=false \
+  -upstream=http://localhost:3000/ \
+  -cookie-secret=somerandomstring12341234567890AB \
+  -cookie-domain=localhost \
+  -skip-provider-button=true
+```
+
+Once it is running, you should be able to go to `http://localhost:4180/` in your browser,
+get authenticated by the ProConnect integration server, and then get proxied on to your
+application running on `http://localhost:3000/`. In a real deployment, you would secure
+your application with a firewall or something so that it was only accessible from the
+proxy, and you would use real hostnames everywhere.

--- a/docs/docs/configuration/providers/proconnect.md
+++ b/docs/docs/configuration/providers/proconnect.md
@@ -32,7 +32,9 @@ Now start the proxy up with the following options:
   -upstream=http://localhost:3000/ \
   -cookie-secret=somerandomstring12341234567890AB \
   -cookie-domain=localhost \
-  -skip-provider-button=true
+  -skip-provider-button=true \
+  -prompt=login \
+  -skip_claims_from_profile_url=true
 ```
 
 Once it is running, you should be able to go to `http://localhost:4180/` in your browser,

--- a/pkg/apis/options/providers.go
+++ b/pkg/apis/options/providers.go
@@ -141,6 +141,9 @@ const (
 
 	// OIDCProvider is the provider type for OIDC
 	OIDCProvider ProviderType = "oidc"
+
+	// OIDCProvider is the provider type for OIDC
+	ProConnectOIDCProvider ProviderType = "proconnect"
 )
 
 type KeycloakOptions struct {

--- a/providers/proconnect.go
+++ b/providers/proconnect.go
@@ -1,0 +1,76 @@
+package providers
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/go-jose/go-jose/v3"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/sessions"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/logger"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/requests"
+)
+
+const ProConnectOIDCProviderName = "ProConnect OIDC"
+
+// ProConnectOIDCProvider creates a Keycloak provider based on OIDCProvider
+type ProConnectOIDCProvider struct {
+	*OIDCProvider
+}
+
+// NewProConnectOIDCProvider makes a ProConnectOIDCProvider using the ProviderData
+func NewProConnectOIDCProvider(p *ProviderData, opts options.OIDCOptions) *ProConnectOIDCProvider {
+	p.setProviderDefaults(providerDefaults{
+		name: ProConnectOIDCProviderName,
+	})
+
+	provider := &ProConnectOIDCProvider{
+		OIDCProvider: NewOIDCProvider(p, opts),
+	}
+
+	return provider
+}
+
+var _ Provider = (*ProConnectOIDCProvider)(nil)
+
+// EnrichSession is called after Redeem to allow providers to enrich session fields
+// such as User, Email, Groups with provider specific API calls.
+func (p *ProConnectOIDCProvider) EnrichSession(ctx context.Context, s *sessions.SessionState) error {
+
+	profileURL := p.ValidateURL.String()
+	if p.ProfileURL.String() != "" {
+		profileURL = p.ProfileURL.String()
+	}
+
+	jwtResponse := requests.New(profileURL).
+		WithContext(ctx).
+		SetHeader("Authorization", tokenTypeBearer+" "+s.AccessToken).
+		Do().Body()
+
+	jws, err := jose.ParseSigned(string(jwtResponse[:]))
+	if err != nil {
+		logger.Errorf("parse profileURL failed: %v", err)
+	}
+
+	// todo: verify the signature
+	/*
+		payload, err := jws.Verify(s.PublicKey)
+		if err != nil {
+			return err
+		}
+	*/
+
+	payload := jws.UnsafePayloadWithoutVerification()
+
+	type EmailData struct {
+		Email string `json:"email"`
+	}
+
+	var response EmailData
+	if err := json.Unmarshal(payload, &response); err != nil {
+		return err
+	}
+	s.Email = response.Email
+
+	return nil
+}

--- a/providers/proconnect.go
+++ b/providers/proconnect.go
@@ -47,7 +47,7 @@ func (p *ProConnectOIDCProvider) EnrichSession(ctx context.Context, s *sessions.
 		SetHeader("Authorization", tokenTypeBearer+" "+s.AccessToken).
 		Do().Body()
 
-	jws, err := jose.ParseSigned(string(jwtResponse[:]))
+	jws, err := jose.ParseSigned(string(jwtResponse))
 	if err != nil {
 		logger.Errorf("parse profileURL failed: %v", err)
 	}

--- a/providers/proconnect_test.go
+++ b/providers/proconnect_test.go
@@ -1,0 +1,27 @@
+package providers
+
+import (
+	"testing"
+
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
+	. "github.com/onsi/gomega"
+)
+
+func testProConnectOIDCProvider() *ProConnectOIDCProvider {
+	p := NewProConnectOIDCProvider(
+		&ProviderData{}, options.OIDCOptions{})
+	return p
+}
+
+func TestProConnectOIDCProviderDefaults(t *testing.T) {
+	g := NewWithT(t)
+	providerData := testProConnectOIDCProvider().Data()
+	g.Expect(providerData.ProviderName).To(Equal("ProConnect OIDC"))
+	g.Expect(providerData.LoginURL.String()).To(Equal(""))
+	g.Expect(providerData.RedeemURL.String()).To(Equal(""))
+	g.Expect(providerData.ProfileURL.String()).To(Equal(""))
+	g.Expect(providerData.ValidateURL.String()).To(Equal(""))
+	g.Expect(providerData.Scope).To(Equal("openid email profile"))
+}
+
+// todo: add test that check EnrichSession

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -67,6 +67,8 @@ func NewProvider(providerConfig options.Provider) (Provider, error) {
 		return NewNextcloudProvider(providerData), nil
 	case options.OIDCProvider:
 		return NewOIDCProvider(providerData, providerConfig.OIDCConfig), nil
+	case options.ProConnectOIDCProvider:
+		return NewProConnectOIDCProvider(providerData, providerConfig.OIDCConfig), nil
 	default:
 		return nil, fmt.Errorf("unknown provider type %q", providerConfig.Type)
 	}
@@ -183,7 +185,7 @@ func providerRequiresOIDCProviderVerifier(providerType options.ProviderType) (bo
 	case options.BitbucketProvider, options.DigitalOceanProvider, options.FacebookProvider, options.GitHubProvider,
 		options.GoogleProvider, options.KeycloakProvider, options.LinkedInProvider, options.LoginGovProvider, options.NextCloudProvider:
 		return false, nil
-	case options.ADFSProvider, options.AzureProvider, options.GitLabProvider, options.KeycloakOIDCProvider, options.OIDCProvider, options.MicrosoftEntraIDProvider:
+	case options.ADFSProvider, options.AzureProvider, options.GitLabProvider, options.KeycloakOIDCProvider, options.OIDCProvider, options.ProConnectOIDCProvider, options.MicrosoftEntraIDProvider:
 		return true, nil
 	default:
 		return false, fmt.Errorf("unknown provider type: %s", providerType)


### PR DESCRIPTION
## Description

Add a [ProConnect](https://www.proconnect.gouv.fr) provider

## Motivation and Context

While ProConnect is OIDC compliant, look like we need a special method to fetch the user email. looks like this is due to the fact that the "user info" page is encrypted and needs special treatment to get the claims.

(related issue : https://github.com/oauth2-proxy/oauth2-proxy/issues/2906)

## How Has This Been Tested?

This has been tested manually with VSCode debugging. thanks for such a great setup !

## Checklist:

Need help:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
- [x] I have written tests for my code changes.
