### PR TITLE
Entra ID: Workload Identity support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [#2821](https://github.com/oauth2-proxy/oauth2-proxy/pull/2821) feat: add CF-Connecting-IP as supported real ip header (@ondrejsika)
 - [#2620](https://github.com/oauth2-proxy/oauth2-proxy/pull/2620) fix: update code_verifier to use recommended method (@vishvananda)
 - [#2392](https://github.com/oauth2-proxy/oauth2-proxy/pull/2392) chore: extend test cases for oidc provider and documentation regarding implicit setting of the groups scope when no scope was specified in the config (@jjlakis / @tuunit)
+- [#2902](https://github.com/oauth2-proxy/oauth2-proxy/pull/2902) feat(entra): add Workload Identity support for Entra ID (@jjlakis)
 
 # V7.7.1
 

--- a/docs/docs/configuration/alpha_config.md
+++ b/docs/docs/configuration/alpha_config.md
@@ -394,6 +394,7 @@ character.
 | Field | Type | Description |
 | ----- | ---- | ----------- |
 | `allowedTenants` | _[]string_ | AllowedTenants is a list of allowed tenants. In case of multi-tenant apps, incoming tokens are<br/>issued by different issuers and OIDC issuer verification needs to be disabled.<br/>When not specified, all tenants are allowed. Redundant for single-tenant apps<br/>(regular ID token validation matches the issuer). |
+| `federatedTokenAuth` | _bool_ | FederatedTokenAuth enable oAuth2 client authentication with federated token projected<br/>by Entra Workload Identity plugin, instead of client secret. |
 
 ### OIDCOptions
 

--- a/pkg/apis/options/legacy_options.go
+++ b/pkg/apis/options/legacy_options.go
@@ -489,6 +489,7 @@ type LegacyProvider struct {
 	AzureTenant                            string   `flag:"azure-tenant" cfg:"azure_tenant"`
 	AzureGraphGroupField                   string   `flag:"azure-graph-group-field" cfg:"azure_graph_group_field"`
 	EntraIDAllowedTenants                  []string `flag:"entra-id-allowed-tenant" cfg:"entra_id_allowed_tenants"`
+	EntraIDFederatedTokenAuth              bool     `flag:"entra-id-federated-token-auth" cfg:"entra_id_federated_token_auth"`
 	BitbucketTeam                          string   `flag:"bitbucket-team" cfg:"bitbucket_team"`
 	BitbucketRepository                    string   `flag:"bitbucket-repository" cfg:"bitbucket_repository"`
 	GitHubOrg                              string   `flag:"github-org" cfg:"github_org"`
@@ -552,6 +553,7 @@ func legacyProviderFlagSet() *pflag.FlagSet {
 	flagSet.String("azure-tenant", "common", "go to a tenant-specific or common (tenant-independent) endpoint.")
 	flagSet.String("azure-graph-group-field", "", "configures the group field to be used when building the groups list(`id` or `displayName`. Default is `id`) from Microsoft Graph(available only for v2.0 oidc url). Based on this value, the `allowed-group` config values should be adjusted accordingly. If using `id` as group field, `allowed-group` should contains groups IDs, if using `displayName` as group field, `allowed-group` should contains groups name")
 	flagSet.StringSlice("entra-id-allowed-tenant", []string{}, "list of tenants allowed for MS Entra ID multi-tenant application")
+	flagSet.Bool("entra-id-federated-token-auth", false, "enable oAuth client authentication with federated token projected by Azure Workload Identity plugin, instead of client secret.")
 	flagSet.String("bitbucket-team", "", "restrict logins to members of this team")
 	flagSet.String("bitbucket-repository", "", "restrict logins to user with access to this repository")
 	flagSet.String("github-org", "", "restrict logins to members of this organisation")
@@ -760,7 +762,8 @@ func (l *LegacyProvider) convert() (Providers, error) {
 		}
 	case "entra-id":
 		provider.MicrosoftEntraIDConfig = MicrosoftEntraIDOptions{
-			AllowedTenants: l.EntraIDAllowedTenants,
+			AllowedTenants:     l.EntraIDAllowedTenants,
+			FederatedTokenAuth: l.EntraIDFederatedTokenAuth,
 		}
 	}
 

--- a/pkg/apis/options/providers.go
+++ b/pkg/apis/options/providers.go
@@ -166,6 +166,10 @@ type MicrosoftEntraIDOptions struct {
 	// When not specified, all tenants are allowed. Redundant for single-tenant apps
 	// (regular ID token validation matches the issuer).
 	AllowedTenants []string `json:"allowedTenants,omitempty"`
+
+	// FederatedTokenAuth enable oAuth2 client authentication with federated token projected
+	// by Entra Workload Identity plugin, instead of client secret.
+	FederatedTokenAuth bool `json:"federatedTokenAuth,omitempty"`
 }
 
 type ADFSOptions struct {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds additional flag to Entra ID provider - `entra_id_federated_token_auth_enabled`. When enabled, oAuth2 proxy exchanges code for tokens by using federated token projected in the well known place by Entra Workload Identity plugin.

This change introduces a custom implementation of `Redeem()`. When federated auth is enabled, tokens are retrieved by custom query (with different parameters), and passed to generic `p.OIDCProvider.createSession()`. 

<!--- Describe your changes in detail -->

## Motivation and Context
Workload Identity in Entra allows to stop using hardcoded client secret which is a huge benefit for IaaC, reference architectures and secret management.

## How Has This Been Tested?

E2E testing for Entra provider has been extended to perform same 15 cases that are performed with client-secret configuration. Test are passing properly.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
- [x] I have written tests for my code changes.
