### PR TITLE
Change redirect code from 302 to 307

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -688,7 +688,7 @@ func (p *OAuthProxy) SignIn(rw http.ResponseWriter, req *http.Request) {
 			p.ErrorPage(rw, req, http.StatusInternalServerError, err.Error())
 			return
 		}
-		http.Redirect(rw, req, redirect, http.StatusFound)
+		http.Redirect(rw, req, redirect, http.StatusTemporaryRedirect)
 	} else {
 		if p.SkipProviderButton {
 			p.OAuthStart(rw, req)
@@ -752,7 +752,7 @@ func (p *OAuthProxy) SignOut(rw http.ResponseWriter, req *http.Request) {
 
 	p.backendLogout(rw, req)
 
-	http.Redirect(rw, req, redirect, http.StatusFound)
+	http.Redirect(rw, req, redirect, http.StatusTemporaryRedirect)
 }
 
 func (p *OAuthProxy) backendLogout(rw http.ResponseWriter, req *http.Request) {
@@ -848,7 +848,7 @@ func (p *OAuthProxy) doOAuthStart(rw http.ResponseWriter, req *http.Request, ove
 		return
 	}
 
-	http.Redirect(rw, req, loginURL, http.StatusFound)
+	http.Redirect(rw, req, loginURL, http.StatusTemporaryRedirect)
 }
 
 // OAuthCallback is the OAuth2 authentication flow callback that finishes the
@@ -938,7 +938,7 @@ func (p *OAuthProxy) OAuthCallback(rw http.ResponseWriter, req *http.Request) {
 			p.ErrorPage(rw, req, http.StatusInternalServerError, err.Error())
 			return
 		}
-		http.Redirect(rw, req, appRedirect, http.StatusFound)
+		http.Redirect(rw, req, appRedirect, http.StatusTemporaryRedirect)
 	} else {
 		logger.PrintAuthf(session.Email, req, logger.AuthFailure, "Invalid authentication via OAuth2: unauthorized")
 		p.ErrorPage(rw, req, http.StatusForbidden, "Invalid session: unauthorized")

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -484,9 +484,7 @@ func TestForwardAccessTokenUpstream(t *testing.T) {
 
 	// A successful validation will redirect and set the auth cookie.
 	code, cookie := patTest.getCallbackEndpoint()
-	if code != 302 {
-		t.Fatalf("expected 302; got %d", code)
-	}
+	assert.Equal(t, 307, code)
 	assert.NotNil(t, cookie)
 
 	// Now we make a regular request; the access_token from the cookie is
@@ -516,9 +514,7 @@ func TestStaticProxyUpstream(t *testing.T) {
 
 	// A successful validation will redirect and set the auth cookie.
 	code, cookie := patTest.getCallbackEndpoint()
-	if code != 302 {
-		t.Fatalf("expected 302; got %d", code)
-	}
+	assert.Equal(t, 307, code)
 	assert.NotEqual(t, nil, cookie)
 
 	// Now we make a regular request against the upstream proxy; And validate
@@ -542,9 +538,7 @@ func TestDoNotForwardAccessTokenUpstream(t *testing.T) {
 
 	// A successful validation will redirect and set the auth cookie.
 	code, cookie := patTest.getCallbackEndpoint()
-	if code != 302 {
-		t.Fatalf("expected 302; got %d", code)
-	}
+	assert.Equal(t, 307, code)
 	assert.NotEqual(t, nil, cookie)
 
 	// Now we make a regular request, but the access token header should
@@ -644,7 +638,7 @@ func TestManualSignInStoresUserGroupsInTheSession(t *testing.T) {
 	signInReq.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	proxy.ServeHTTP(rw, signInReq)
 
-	assert.Equal(t, http.StatusFound, rw.Code)
+	assert.Equal(t, http.StatusTemporaryRedirect, rw.Code)
 
 	req, _ := http.NewRequest(http.MethodGet, "/something", strings.NewReader(formData.Encode()))
 	for _, c := range rw.Result().Cookies() {
@@ -708,7 +702,7 @@ func TestManualSignInInvalidCredentialsAlert(t *testing.T) {
 
 func TestManualSignInCorrectCredentials(t *testing.T) {
 	statusCode := ManualSignInWithCredentials(t, "admin", "adminPass")
-	assert.Equal(t, http.StatusFound, statusCode)
+	assert.Equal(t, http.StatusTemporaryRedirect, statusCode)
 }
 
 func TestSignInPageIncludesTargetRedirect(t *testing.T) {
@@ -770,7 +764,7 @@ func TestSignInPageSkipProvider(t *testing.T) {
 	endpoint := "/some/random/endpoint"
 
 	code, body := sipTest.GetEndpoint(endpoint)
-	assert.Equal(t, 302, code)
+	assert.Equal(t, 307, code)
 
 	match := sipTest.signInProviderRegexp.FindStringSubmatch(body)
 	if match == nil {
@@ -788,7 +782,7 @@ func TestSignInPageSkipProviderDirect(t *testing.T) {
 	endpoint := "/sign_in"
 
 	code, body := sipTest.GetEndpoint(endpoint)
-	assert.Equal(t, 302, code)
+	assert.Equal(t, 307, code)
 
 	match := sipTest.signInProviderRegexp.FindStringSubmatch(body)
 	if match == nil {
@@ -2525,7 +2519,7 @@ func TestApiRoutes(t *testing.T) {
 			proxy.ServeHTTP(rw, req)
 
 			if tc.shouldRedirect {
-				assert.Equal(t, 302, rw.Code)
+				assert.Equal(t, 307, rw.Code)
 			} else {
 				assert.Equal(t, 401, rw.Code)
 			}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

oauth-proxy should return 307 redirect code to prevent the original request method loss by browsers.

## Motivation and Context

Fixes #2903 

## How Has This Been Tested?

Tested locally with the provided `docker-compose` in contrib and keycloak environment. 

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
- [x] I have written tests for my code changes.
