### PR TITLE
fix: missing oauth2-proxy version for docker builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Changes since v7.8.0
 
+- [#2920](https://github.com/oauth2-proxy/oauth2-proxy/pull/2920) fix: setting version during docker built
+
 # V7.8.0
 
 ## Release Highlights

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ COPY . .
 #  sources have changed.
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
+ARG VERSION
 
 # Build binary and make sure there is at least an empty key file.
 #  This is useful for GCP App Engine custom runtime builds, because


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Because of changes done as part of introducing opencointainer labels https://github.com/oauth2-proxy/oauth2-proxy/pull/2800 a `VERSION` argument was removed in the wrong area of the Dockerfile leading to an empty Version field inside the docker builds. 

Causing the version to be missing on the sign_in.html page:

<img width="406" alt="Screenshot 2025-01-14 at 16 15 36" src="https://github.com/user-attachments/assets/86a22aa8-6be0-49c7-b8a6-c77a00115eac" />

Expected behaviour like in version v7.7.0:

<img width="406" alt="Screenshot 2025-01-14 at 16 15 26" src="https://github.com/user-attachments/assets/c64be634-abf6-4a06-bff0-f5529320fe15" />


Fixes #2919

## How Has This Been Tested?

Local build and visual confirmation. Needs to be covered by an e2e test in the future.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.
