### PR TITLE
Update ms_entra_id.md to correct toml field in sample

### DIFF
--- a/docs/docs/configuration/providers/ms_entra_id.md
+++ b/docs/docs/configuration/providers/ms_entra_id.md
@@ -192,6 +192,6 @@ client_id="<client-id>"
 client_secret="<client-secret>"
 insecure_oidc_skip_issuer_verification=true
 scope="openid profile email User.Read"
-entra_id_allowed_tenant=["9188040d-6c67-4c5b-b112-36a304b66dad","<my-tenant-id>"] # Allow only <my-tenant-id> and Personal MS Accounts tenant 
+entra_id_allowed_tenants=["9188040d-6c67-4c5b-b112-36a304b66dad","<my-tenant-id>"] # Allow only <my-tenant-id> and Personal MS Accounts tenant 
 email_domains="*"
 ```


### PR DESCRIPTION
## Description

The Toml field required is the plural "entra_id_allowed_tenants" as listed in the top section under Config Options. However, the sample at the bottom lists the singular "entra_id_allwed_tenant" which has a parse failure. Fix this so folks doing copy/paste like I was don't have to trip over this.

## Motivation and Context

Tripped across this while following the directions. Decided to fix it for future folks.

## How Has This Been Tested?

It's a doc update, so the test was "I tried the plural version in my local deployment and that one worked."

## Checklist:
- [ ] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.
