### PR TITLE
fix: don't require client secret if PKCE is enabled

### DIFF
--- a/contrib/local-environment/dex.yaml
+++ b/contrib/local-environment/dex.yaml
@@ -1,7 +1,7 @@
 # This configuration is intended to be used with the docker-compose testing
 # environment.
-# This should configure Dex to run on port 4190 and provides a static login
-issuer: http://dex.localtest.me:4190/dex
+# This should configure Dex to run on port 4195 and provides a static login
+issuer: http://dex.localtest.me:4195/dex
 storage:
   type: etcd
   config:
@@ -9,7 +9,7 @@ storage:
     - http://etcd:2379
     namespace: dex/
 web:
-  http: 0.0.0.0:4190
+  http: 0.0.0.0:4195
 oauth2:
   skipApprovalScreen: true
 expiry:
@@ -21,8 +21,9 @@ staticClients:
   # These redirect URIs point to the `--redirect-url` for OAuth2 proxy.
   - 'http://oauth2-proxy.localtest.me:4180/oauth2/callback' # For basic proxy example.
   - 'http://oauth2-proxy.oauth2-proxy.localhost/oauth2/callback' # For nginx and traefik example.
+  - 'http://localhost:/oauth2/callback' # For nginx and traefik example.
   name: 'OAuth2 Proxy'
-  secret: b2F1dGgyLXByb3h5LWNsaWVudC1zZWNyZXQK
+  public: true
 enablePasswordDB: true
 staticPasswords:
 - email: "admin@example.com"

--- a/contrib/local-environment/docker-compose.yaml
+++ b/contrib/local-environment/docker-compose.yaml
@@ -9,13 +9,19 @@
 #    make <command> (eg. make up, make down)
 #
 # Access http://oauth2-proxy.localtest.me:4180 to initiate a login cycle
-version: '3.0'
 services:
   oauth2-proxy:
     container_name: oauth2-proxy
     image: quay.io/oauth2-proxy/oauth2-proxy:v7.8.1
     command: --config /oauth2-proxy.cfg
     hostname: oauth2-proxy
+    build:
+      context: ../../
+      dockerfile: Dockerfile
+      args:
+        BUILD_IMAGE: "docker.io/library/golang:1.23"
+        RUNTIME_IMAGE: "gcr.io/distroless/static:nonroot"
+        BUILDPLATFORM: "linux/arm64"
     volumes:
       - "./oauth2-proxy.cfg:/oauth2-proxy.cfg"
     restart: unless-stopped
@@ -36,7 +42,7 @@ services:
       - "./dex.yaml:/dex.yaml"
     restart: unless-stopped
     ports:
-      - 4190:4190/tcp
+      - 4195:4195/tcp
     networks:
       dex:
         aliases:

--- a/contrib/local-environment/oauth2-proxy.cfg
+++ b/contrib/local-environment/oauth2-proxy.cfg
@@ -7,10 +7,11 @@ cookie_domains=[".localtest.me"] # Required so cookie can be read on all subdoma
 whitelist_domains=[".localtest.me"] # Required to allow redirection back to original requested target.
 
 # dex provider
-client_secret="b2F1dGgyLXByb3h5LWNsaWVudC1zZWNyZXQK"
+# client_secret="b2F1dGgyLXByb3h5LWNsaWVudC1zZWNyZXQK"
+code_challenge_method = "S256"
 client_id="oauth2-proxy"
 redirect_url="http://oauth2-proxy.localtest.me:4180/oauth2/callback"
 
-oidc_issuer_url="http://dex.localtest.me:4190/dex"
+oidc_issuer_url="http://dex.localtest.me:4195/dex"
 provider="oidc"
 provider_display_name="Dex"

--- a/docs/docs/configuration/providers/openid_connect.md
+++ b/docs/docs/configuration/providers/openid_connect.md
@@ -20,15 +20,15 @@ To configure the OIDC provider for Dex, perform the following steps:
 
    See the [getting started guide](https://dexidp.io/docs/getting-started/) for more details.
 
-2. Setup oauth2-proxy with the correct provider and using the default ports and callbacks. Add a configuration block to 
+2. Setup oauth2-proxy with the correct provider and using the default ports and callbacks. Add a configuration block to
    the `staticClients` section of `examples/config-dev.yaml`:
 
-    ```
+    ```yaml
     - id: oauth2-proxy
     redirectURIs:
     - 'http://127.0.0.1:4180/oauth2/callback'
     name: 'oauth2-proxy'
-    secret: proxy
+    public: true
     ```
 
 3. Launch Dex: from `$GOPATH/github.com/dexidp/dex`, run:
@@ -47,7 +47,7 @@ To configure the OIDC provider for Dex, perform the following steps:
     --redirect-url http://127.0.0.1:4180/oauth2/callback
     --oidc-issuer-url http://127.0.0.1:5556/dex
     --cookie-secure=false
-    --cookie-secret=secret
+    --code-challenge-method=S256
     --email-domain kilgore.trout
     ```
 
@@ -57,7 +57,7 @@ To configure the OIDC provider for Dex, perform the following steps:
     --upstream file://$PWD/#/static/
     ```
 
-5. Test the setup by visiting http://127.0.0.1:4180 or http://127.0.0.1:4180/static .
+5. Test the setup by visiting <http://127.0.0.1:4180> or <http://127.0.0.1:4180/static> .
 
 See also [our local testing environment](https://github.com/oauth2-proxy/oauth2-proxy/blob/master/contrib/local-environment) for a self-contained example using Docker and etcd as storage for Dex.
 
@@ -69,10 +69,10 @@ To configure the OIDC provider for Okta, perform the following steps:
 2. (OPTIONAL) If you want to configure authorization scopes and claims to be passed on to multiple applications,
    you may wish to configure an authorization server for each application. Otherwise, the provided `default` will work.
    * Navigate to **Security** then select **API**
-   * Click **Add Authorization Server**, if this option is not available you may require an additional license for a custom 
+   * Click **Add Authorization Server**, if this option is not available you may require an additional license for a custom
      authorization server.
    * Fill out the **Name** with something to describe the application you are protecting. e.g. 'Example App'.
-   * For **Audience**, pick the URL of the application you wish to protect: https://example.corp.com
+   * For **Audience**, pick the URL of the application you wish to protect: <https://example.corp.com>
    * Fill out a **Description**
    * Add any **Access Policies** you wish to configure to limit application access.
    * The default settings will work for other options.
@@ -104,27 +104,28 @@ To configure the OIDC provider for Okta, perform the following steps:
     skip_provider_button = true
     ```
 
-The `oidc_issuer_url` is based on URL from your **Authorization Server**'s **Issuer** field in step 2, or simply 
-https://corp.okta.com. The `client_id` and `client_secret` are configured in the application settings.
+The `oidc_issuer_url` is based on URL from your **Authorization Server**'s **Issuer** field in step 2, or simply
+<https://corp.okta.com>. The `client_id` and `client_secret` are configured in the application settings.
 Generate a unique `cookie_secret` to encrypt the cookie.
 
 Then you can start the oauth2-proxy with `./oauth2-proxy --config /etc/example.cfg`
 
 #### Okta - localhost
 
-1. Signup for developer account: https://developer.okta.com/signup/
+1. Signup for developer account: <https://developer.okta.com/signup/>
 2. Create New `Web` Application: https://$\{your-okta-domain\}/dev/console/apps/new
 3. Example Application Settings for localhost:
     * **Name:** My Web App
-    * **Base URIs:** http://localhost:4180/
-    * **Login redirect URIs:** http://localhost:4180/oauth2/callback
-    * **Logout redirect URIs:** http://localhost:4180/
+    * **Base URIs:** <http://localhost:4180/>
+    * **Login redirect URIs:** <http://localhost:4180/oauth2/callback>
+    * **Logout redirect URIs:** <http://localhost:4180/>
     * **Group assignments:** `Everyone`
     * **Grant type allowed:** `Authorization Code` and `Refresh Token`
 4. Make note of the `Client ID` and `Client secret`, they are needed in a future step
 5. Make note of the **default** Authorization Server Issuer URI from: https://$\{your-okta-domain\}/admin/oauth2/as
 6. Example config file `/etc/localhost.cfg`
-    ```shell
+
+    ```toml
     provider = "oidc"
     redirect_url = "http://localhost:4180/oauth2/callback"
     oidc_issuer_url = "https://$\{your-okta-domain\}/oauth2/default"
@@ -143,4 +144,5 @@ Then you can start the oauth2-proxy with `./oauth2-proxy --config /etc/example.c
     # Note: use the following for testing within a container
     # http_address = "0.0.0.0:4180"
     ```
+
 7. Then you can start the oauth2-proxy with `./oauth2-proxy --config /etc/localhost.cfg`

--- a/pkg/validation/providers.go
+++ b/pkg/validation/providers.go
@@ -72,19 +72,23 @@ func providerRequiresClientSecret(provider options.Provider) bool {
 		return false
 	}
 
+	if provider.Type == "oidc" && provider.CodeChallengeMethod == "S256" {
+		// PKCE with S256 doesn't require client secret
+		return false
+	}
+
 	return true
 }
 
 func validateClientSecret(provider options.Provider) []string {
 	msgs := []string{}
-
 	if provider.ClientSecret == "" && provider.ClientSecretFile == "" {
 		msgs = append(msgs, "missing setting: client-secret or client-secret-file")
-	}
-	if provider.ClientSecret == "" && provider.ClientSecretFile != "" {
-		_, err := os.ReadFile(provider.ClientSecretFile)
-		if err != nil {
-			msgs = append(msgs, "could not read client secret file: "+provider.ClientSecretFile)
+		if provider.ClientSecret == "" && provider.ClientSecretFile != "" {
+			_, err := os.ReadFile(provider.ClientSecretFile)
+			if err != nil {
+				msgs = append(msgs, "could not read client secret file: "+provider.ClientSecretFile)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description

Fixes #1714, not requiring or configuring a client secret if PKCE is enabled.

## Motivation and Context

It's required for secure use of public clients.

## How Has This Been Tested?

See the modified config files for Dex in the branch, which I'll remove before it's merged. Basically - set `public:true` instead of setting a secret, then configure `code_challenge_method=S256` for oauth2-proxy

## Checklist:

I don't know how to write much golang, if someone can provide guidance on the testing methods I'll happily add them!

- [x] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
  - [x] well, the documentation
- [ ] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.
