### PR TITLE
feat: Enrich session created from token with groups (#2698)

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -133,7 +133,7 @@ func NewOAuthProxy(opts *options.Options, validator func(string) bool) (*OAuthPr
 		}
 	}
 
-	provider, err := providers.NewProvider(opts.Providers[0])
+	provider, err := providers.NewProvider(opts, opts.Providers[0])
 	if err != nil {
 		return nil, fmt.Errorf("error initialising provider: %v", err)
 	}

--- a/providers/provider_data.go
+++ b/providers/provider_data.go
@@ -48,6 +48,7 @@ type ProviderData struct {
 	EmailClaim               string
 	GroupsClaim              string
 	Verifier                 internaloidc.IDTokenVerifier
+	JWTVerifiers             []internaloidc.IDTokenVerifier
 	SkipClaimsFromProfileURL bool
 
 	// Universal Group authorization data structure

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -31,8 +31,8 @@ type Provider interface {
 	CreateSessionFromToken(ctx context.Context, token string) (*sessions.SessionState, error)
 }
 
-func NewProvider(providerConfig options.Provider) (Provider, error) {
-	providerData, err := newProviderDataFromConfig(providerConfig)
+func NewProvider(opts *options.Options, providerConfig options.Provider) (Provider, error) {
+	providerData, err := newProviderDataFromConfig(opts, providerConfig)
 	if err != nil {
 		return nil, fmt.Errorf("could not create provider data: %v", err)
 	}
@@ -72,7 +72,7 @@ func NewProvider(providerConfig options.Provider) (Provider, error) {
 	}
 }
 
-func newProviderDataFromConfig(providerConfig options.Provider) (*ProviderData, error) {
+func newProviderDataFromConfig(opts *options.Options, providerConfig options.Provider) (*ProviderData, error) {
 	p := &ProviderData{
 		Scope:            providerConfig.Scope,
 		ClientID:         providerConfig.ClientID,
@@ -101,6 +101,7 @@ func newProviderDataFromConfig(providerConfig options.Provider) (*ProviderData, 
 		}
 
 		p.Verifier = pv.Verifier()
+		p.JWTVerifiers = opts.GetJWTBearerVerifiers()
 		if pv.DiscoveryEnabled() {
 			// Use the discovered values rather than any specified values
 			endpoints := pv.Provider().Endpoints()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Yet another PR about [Groups Overage Claims](https://learn.microsoft.com/en-us/entra/identity-platform/id-token-claims-reference#groups-overage-claim) mechanism.
> [!NOTE]  
> TLDR Groups Overage Claims is the mechanism that calls Azure Graph API to get groups instead of relying on the token's ``groups`` claim as :
> - header size may be limited in size
> - when you have +200 groups, Entra ID is just giving a URL instead of the complete list

This mechanism is well in place in Entra ID and Azure AD providers with auth code flow and is working well. 

But **when you give a bearer token directly** to oauth2-proxy to authenticate users (generated from device code flow or client credentials flow for example) you may not have the groups in your session. 
This PR makes sure that the **Groups Overage Claim Mechansim** is executed also when generating the session from token.

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #2698

## How Has This Been Tested?

TODO
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.
