### PR TITLE
feat: update HashNonce to use crypto/sha256

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - [#2977](https://github.com/oauth2-proxy/oauth2-proxy/pull/2977) Update golang.org/x/net to v0.36.0 to address CVE-2025-22870 (@dsymonds)
 - [#2982](https://github.com/oauth2-proxy/oauth2-proxy/pull/2982) chore(deps): remove go:generate tool from go.mod (@dolmen)
 - [#3011](https://github.com/oauth2-proxy/oauth2-proxy/pull/3011) chore(deps): update golang dependencies and pin to latest golang v1.23.x release (@tuunit)
+- [#2967](https://github.com/oauth2-proxy/oauth2-proxy/pull/2967) Update HashNonce to use crypto/sha256 (@egibs)
 
 # V7.8.1
 

--- a/pkg/encryption/nonce.go
+++ b/pkg/encryption/nonce.go
@@ -3,9 +3,8 @@ package encryption
 import (
 	"crypto/hmac"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
-
-	"golang.org/x/crypto/blake2b"
 )
 
 // Nonce generates a random n-byte slice
@@ -18,16 +17,16 @@ func Nonce(length int) ([]byte, error) {
 	return b, nil
 }
 
-// HashNonce returns the BLAKE2b 256-bit hash of a nonce
-// NOTE: Error checking (G104) is purposefully skipped:
-// - `blake2b.New256` has no error path with a nil signing key
-// - `hash.Hash` interface's `Write` has an error signature, but
-//   `blake2b.digest.Write` does not use it.
-/* #nosec G104 */
+// HashNonce returns the SHA256 hash of a nonce
 func HashNonce(nonce []byte) string {
-	hasher, _ := blake2b.New256(nil)
+	if nonce == nil {
+		return ""
+	}
+
+	hasher := sha256.New()
 	hasher.Write(nonce)
 	sum := hasher.Sum(nil)
+
 	return base64.RawURLEncoding.EncodeToString(sum)
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR replaces the `golang.org/x/crypto/blake2b` usage in `nonce.go` with `crypto/sha256`.

<!--- Describe your changes in detail -->

## Motivation and Context

`blake2b` is not FIPS-compliant and it looks like this is the only instance of its usage within the codebase. If its usage is only for calculating hashes for nonces, sha256 should suffice unless there are major performance concerns (even if sha256 is hardware-accelerated).

## How Has This Been Tested?

`make test` runs cleanly with these changes.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.
