### PR TITLE
Nonce should not be validated on refresh

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/go:1-1.22
+FROM mcr.microsoft.com/vscode/devcontainers/go:1.23
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -915,6 +915,11 @@ func (p *OAuthProxy) OAuthCallback(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	csrf.SetSessionNonce(session)
+	if !p.provider.ValidateCallback(session) {
+		logger.PrintAuthf(session.Email, req, logger.AuthFailure, "Session callback validation failed: %s", session)
+		p.ErrorPage(rw, req, http.StatusForbidden, "Session callback validation failed")
+		return
+	}
 	if !p.provider.ValidateSession(req.Context(), session) {
 		logger.PrintAuthf(session.Email, req, logger.AuthFailure, "Session validation failed: %s", session)
 		p.ErrorPage(rw, req, http.StatusForbidden, "Session validation failed")

--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -114,10 +114,16 @@ func (p *OIDCProvider) ValidateSession(ctx context.Context, s *sessions.SessionS
 		return false
 	}
 
+	return true
+}
+
+// ValidateSession checks that the session's callback response is valid
+func (p *OIDCProvider) ValidateCallback(s *sessions.SessionState) bool {
 	if p.SkipNonce {
 		return true
 	}
-	err = p.checkNonce(s)
+
+	err := p.checkNonce(s)
 	if err != nil {
 		logger.Errorf("nonce verification failed: %v", err)
 		return false

--- a/providers/provider_default.go
+++ b/providers/provider_default.go
@@ -146,3 +146,7 @@ func (p *ProviderData) CreateSessionFromToken(ctx context.Context, token string)
 	}
 	return nil, ErrNotImplemented
 }
+
+func (p *ProviderData) ValidateCallback(_ *sessions.SessionState) bool {
+	return true
+}

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -27,6 +27,7 @@ type Provider interface {
 	EnrichSession(ctx context.Context, s *sessions.SessionState) error
 	Authorize(ctx context.Context, s *sessions.SessionState) (bool, error)
 	ValidateSession(ctx context.Context, s *sessions.SessionState) bool
+	ValidateCallback(s *sessions.SessionState) bool
 	RefreshSession(ctx context.Context, s *sessions.SessionState) (bool, error)
 	CreateSessionFromToken(ctx context.Context, token string) (*sessions.SessionState, error)
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR modifies the application to only validate the Nonce parameter on the initial callback where sessions are established.

## Motivation and Context

https://openid.net/specs/openid-connect-core-1_0.html#RefreshTokenResponse

^ From the OIDC refresh spec:

> If an ID Token is returned as a result of a token refresh request, the following requirements apply:
> ...
> it SHOULD NOT have a nonce Claim, even when the ID Token issued at the time of the original authentication contained nonce
 


Fixes https://github.com/oauth2-proxy/oauth2-proxy/issues/2876

## How Has This Been Tested?

Tested against a locally running keycloak instance.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.
