### PR TITLE
feat: ability to parse JWT encoded profile claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [#3001](https://github.com/oauth2-proxy/oauth2-proxy/pull/3001) Allow to set non-default authorization request response mode (@stieler-it)
 - [#3041](https://github.com/oauth2-proxy/oauth2-proxy/pull/3041) chore(deps): upgrade to latest golang v1.23.x release (@TheImplementer)
 - [#1916](https://github.com/oauth2-proxy/oauth2-proxy/pull/1916) fix: role extraction from access token in keycloak oidc (@Elektordi / @tuunit)
+- [#3014](https://github.com/oauth2-proxy/oauth2-proxy/pull/3014) feat: ability to parse JWT encoded profile claims (@ikarius)
 
 # V7.8.2
 

--- a/pkg/providers/util/claim_extractor.go
+++ b/pkg/providers/util/claim_extractor.go
@@ -105,7 +105,7 @@ func (c *claimExtractor) loadProfileClaims() (*simplejson.Json, error) {
 	mediaType, _, parseErr := mime.ParseMediaType(builder.Headers().Get("Content-Type"))
 
 	if parseErr == nil && mediaType == "application/jwt" {
-		// Decode and use JWT payload as profile claims 
+		// Decode and use JWT payload as profile claims
 		if pl, err := parseJWT(string(builder.Body())); err == nil {
 			return simplejson.NewJson(pl)
 		}

--- a/pkg/providers/util/claim_extractor.go
+++ b/pkg/providers/util/claim_extractor.go
@@ -101,7 +101,7 @@ func (c *claimExtractor) loadProfileClaims() (*simplejson.Json, error) {
 		Do()
 
 	// We first check if the result is a JWT token
-	// i.e. `application/jwt; charset=utf-8` mime-type
+	// https://openid.net/specs/openid-connect-core-1_0-final.html#UserInfoResponse
 	mediaType, _, parseErr := mime.ParseMediaType(builder.Headers().Get("Content-Type"))
 
 	if parseErr == nil && mediaType == "application/jwt" {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Ability to parse claims from a JWT encoded payload, fixes #2906.

## Motivation and Context

Some providers, like OIDC, are allowing profile claims to be encoded as JWT.

The actual implementation of claims extraction is only able to extract data from a JSON payload.

See OpenID Connect UserInfo description : https://openid.net/specs/openid-connect-core-1_0-final.html#UserInfoResponse

## How Has This Been Tested?

Added a simple test in `claim_extractor_test.go`.

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
- [x] I have written tests for my code changes.
