### PR TITLE
Azure/Entra Id uses expires_in

### DIFF
--- a/providers/azure.go
+++ b/providers/azure.go
@@ -161,7 +161,7 @@ func (p *AzureProvider) Redeem(ctx context.Context, redirectURL, code, codeVerif
 	var jsonResponse struct {
 		AccessToken  string `json:"access_token"`
 		RefreshToken string `json:"refresh_token"`
-		ExpiresOn    int64  `json:"expires_on,string"`
+		ExpiresIn    int64  `json:"expires_in"`
 		IDToken      string `json:"id_token"`
 	}
 
@@ -182,7 +182,7 @@ func (p *AzureProvider) Redeem(ctx context.Context, redirectURL, code, codeVerif
 		RefreshToken: jsonResponse.RefreshToken,
 	}
 	session.CreatedAtNow()
-	session.SetExpiresOn(time.Unix(jsonResponse.ExpiresOn, 0))
+	session.ExpiresIn(time.Duration(jsonResponse.ExpiresIn) * time.Second)
 
 	err = p.extractClaimsIntoSession(ctx, session)
 
@@ -329,7 +329,7 @@ func (p *AzureProvider) redeemRefreshToken(ctx context.Context, s *sessions.Sess
 	var jsonResponse struct {
 		AccessToken  string `json:"access_token"`
 		RefreshToken string `json:"refresh_token"`
-		ExpiresOn    int64  `json:"expires_on,string"`
+		ExpiresIn    int64  `json:"expires_in"`
 		IDToken      string `json:"id_token"`
 	}
 
@@ -349,7 +349,7 @@ func (p *AzureProvider) redeemRefreshToken(ctx context.Context, s *sessions.Sess
 	s.RefreshToken = jsonResponse.RefreshToken
 
 	s.CreatedAtNow()
-	s.SetExpiresOn(time.Unix(jsonResponse.ExpiresOn, 0))
+	s.ExpiresIn(time.Duration(jsonResponse.ExpiresIn) * time.Second)
 
 	err = p.extractClaimsIntoSession(ctx, s)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Entra Id/Azure uses JSON response expires_in in v1 + v2

"expires_in" -> How long the access token is valid, in seconds. (MS docs)

"expires_on" was in v1 but "expires_in" is in both v1 + v2 (no "expires_on" in v2 - breaking change from v1 to v2)

Docs: https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow

## Motivation and Context

This will allow the refresh token flow to work in Azure/Entra Id v1 + v2 for the ones using the azure provider.

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.
