### PR TITLE
fix(entra-id): use federated credentials for refresh token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Changes since v7.8.2
 
+- [#3031](https://github.com/oauth2-proxy/oauth2-proxy/pull/3031) Fixes Refresh Token bug with Entra ID and Workload Identity (#3027)[https://github.com/oauth2-proxy/oauth2-proxy/issues/3028] by using client assertion when redeeming the token (@richard87)
 - [#3001](https://github.com/oauth2-proxy/oauth2-proxy/pull/3001) Allow to set non-default authorization request response mode (@stieler-it)
 - [#3041](https://github.com/oauth2-proxy/oauth2-proxy/pull/3041) chore(deps): upgrade to latest golang v1.23.x release (@TheImplementer)
 

--- a/providers/ms_entra_id.go
+++ b/providers/ms_entra_id.go
@@ -157,7 +157,7 @@ func (p *MicrosoftEntraIDProvider) RefreshSession(ctx context.Context, s *sessio
 }
 
 // redeemRefreshTokenWithFederatedToken uses a RefreshToken and federated credentials with the RedeemURL to refresh the
-// Access Token and (probably) the ID Token.
+// Refresh Token, Access Token and (probably) the ID Token.
 func (p *MicrosoftEntraIDProvider) redeemRefreshTokenWithFederatedToken(ctx context.Context, s *sessions.SessionState) error {
 	federatedTokenPath := os.Getenv("AZURE_FEDERATED_TOKEN_FILE")
 	federatedToken, err := os.ReadFile(federatedTokenPath)

--- a/providers/ms_entra_id.go
+++ b/providers/ms_entra_id.go
@@ -56,7 +56,7 @@ func NewMicrosoftEntraIDProvider(p *ProviderData, opts options.Provider) *Micros
 	}
 }
 
-// // EnrichSession checks for group overage after calling generic EnrichSession
+// EnrichSession checks for group overage after calling generic EnrichSession
 func (p *MicrosoftEntraIDProvider) EnrichSession(ctx context.Context, session *sessions.SessionState) error {
 	if err := p.OIDCProvider.EnrichSession(ctx, session); err != nil {
 		return fmt.Errorf("unable to enrich session: %v", err)
@@ -156,7 +156,7 @@ func (p *MicrosoftEntraIDProvider) RefreshSession(ctx context.Context, s *sessio
 	return true, nil
 }
 
-// redeemRefreshTokenWithFederatedToken uses a RefreshToken and federacted credentials with the RedeemURL to refresh the
+// redeemRefreshTokenWithFederatedToken uses a RefreshToken and federated credentials with the RedeemURL to refresh the
 // Access Token and (probably) the ID Token.
 func (p *MicrosoftEntraIDProvider) redeemRefreshTokenWithFederatedToken(ctx context.Context, s *sessions.SessionState) error {
 	federatedTokenPath := os.Getenv("AZURE_FEDERATED_TOKEN_FILE")
@@ -183,9 +183,8 @@ func (p *MicrosoftEntraIDProvider) redeemRefreshTokenWithFederatedToken(ctx cont
 		return fmt.Errorf("unable create new session state from response: %v", err)
 	}
 
-	// It's possible that if the refresh token isn't in the token response the
-	// session will not contain an id token.
-	// If it doesn't it's probably better to retain the old one
+	// Optionally update the ID Token if it's returned
+	// ref. https://openid.net/specs/openid-connect-core-1_0.html#RefreshTokenResponse
 	if newSession.IDToken != "" {
 		s.IDToken = newSession.IDToken
 		s.Email = newSession.Email


### PR DESCRIPTION
## Description

This upgrades the Entra ID Provider to refresh tokens with federated credentials when activated.

Fixes https://github.com/oauth2-proxy/oauth2-proxy/issues/3028

## Motivation and Context

To avoid using long term client secrets, and instead use short term federated tokens

## How Has This Been Tested?

Tested in our development environment against Entra ID 

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.


