### PR TITLE
fix: use ignore client secret in refresh token flow if its empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Changes since v7.8.2
 
+- [#3032](https://github.com/oauth2-proxy/oauth2-proxy/pull/3032) Allow empty client secrets in Refresh Token Flow. Fixes [#3028](https://github.com/oauth2-proxy/oauth2-proxy/issues/3028) (@Richard87)
 - [#3001](https://github.com/oauth2-proxy/oauth2-proxy/pull/3001) Allow to set non-default authorization request response mode (@stieler-it)
 
 # V7.8.2

--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -144,9 +144,14 @@ func (p *OIDCProvider) RefreshSession(ctx context.Context, s *sessions.SessionSt
 // redeemRefreshToken uses a RefreshToken with the RedeemURL to refresh the
 // Access Token and (probably) the ID Token.
 func (p *OIDCProvider) redeemRefreshToken(ctx context.Context, s *sessions.SessionState) error {
-	clientSecret, err := p.GetClientSecret()
-	if err != nil {
-		return err
+	var clientSecret string
+
+	if p.HasClientSecret() {
+		tmpSecret, err := p.GetClientSecret()
+		if err != nil {
+			return err
+		}
+		clientSecret = tmpSecret
 	}
 
 	c := oauth2.Config{

--- a/providers/provider_data.go
+++ b/providers/provider_data.go
@@ -66,6 +66,10 @@ type ProviderData struct {
 // Data returns the ProviderData
 func (p *ProviderData) Data() *ProviderData { return p }
 
+func (p *ProviderData) HasClientSecret() bool {
+	return p.ClientSecret != "" && p.ClientSecretFile != ""
+}
+
 func (p *ProviderData) GetClientSecret() (clientSecret string, err error) {
 	if p.ClientSecret != "" || p.ClientSecretFile == "" {
 		return p.ClientSecret, nil


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The [The OAuth 2.0 Authorization Framework RFC](https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1:~:text=The%20client%20MAY%20omit%20the%0A%20%20%20%20%20%20%20%20%20parameter%20if%20the%20client%20secret%20is%20an%20empty%20string.) allows ignoring `client_secret` when its empty in a `refresh_token` flow. 

> client_secret
>    REQUIRED. The client secret. **The client MAY omit the parameter if the client secret is an empty string.**

Fixes https://github.com/oauth2-proxy/oauth2-proxy/issues/3028

## Motivation and Context

Until https://github.com/golang/oauth2/issues/744 lands, this could be a okay compromise to avoid lots of entra-specific code, atleast for Refresh Token Flow

## How Has This Been Tested?

- Tested locally and in our development cluster

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.
