### PR TITLE
chore(deps): upgrade to latest golang v1.23.x release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## Changes since v7.8.2
 
 - [#3001](https://github.com/oauth2-proxy/oauth2-proxy/pull/3001) Allow to set non-default authorization request response mode (@stieler-it)
+- [#3041](https://github.com/oauth2-proxy/oauth2-proxy/pull/3041) chore(deps): upgrade to latest golang v1.23.x release (@TheImplementer)
 
 # V7.8.2
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/oauth2-proxy/oauth2-proxy/v7
 
-go 1.23.7
+go 1.23.8
 
 require (
 	cloud.google.com/go/compute/metadata v0.6.0


### PR DESCRIPTION
## Description

Upgrade golang to the latest v1.23.8 release.

## Motivation and Context

Fix for a critical vulnerability in net/http. [#71988](https://github.com/golang/go/issues/71988)

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
