### PR TITLE
docs: clear up multiple-providers is unimplemented

### DIFF
--- a/docs/docs/configuration/alpha_config.md
+++ b/docs/docs/configuration/alpha_config.md
@@ -168,7 +168,7 @@ They may change between releases without notice.
 | `injectResponseHeaders` | _[[]Header](#header)_ | InjectResponseHeaders is used to configure headers that should be added<br/>to responses from the proxy.<br/>This is typically used when using the proxy as an external authentication<br/>provider in conjunction with another proxy such as NGINX and its<br/>auth_request module.<br/>Headers may source values from either the authenticated user's session<br/>or from a static secret value. |
 | `server` | _[Server](#server)_ | Server is used to configure the HTTP(S) server for the proxy application.<br/>You may choose to run both HTTP and HTTPS servers simultaneously.<br/>This can be done by setting the BindAddress and the SecureBindAddress simultaneously.<br/>To use the secure server you must configure a TLS certificate and key. |
 | `metricsServer` | _[Server](#server)_ | MetricsServer is used to configure the HTTP(S) server for metrics.<br/>You may choose to run both HTTP and HTTPS servers simultaneously.<br/>This can be done by setting the BindAddress and the SecureBindAddress simultaneously.<br/>To use the secure server you must configure a TLS certificate and key. |
-| `providers` | _[Providers](#providers)_ | Providers is used to configure multiple providers. |
+| `providers` | _[Providers](#providers)_ | Providers is used to configure your provider. **Multiple-providers is not<br/>yet working.** [This feature is tracked in<br/>#925](https://github.com/oauth2-proxy/oauth2-proxy/issues/926) |
 
 ### AzureOptions
 
@@ -472,7 +472,11 @@ and oidc.
 
 (**Appears on:** [AlphaOptions](#alphaoptions))
 
-Providers is a collection of definitions for providers.
+The provider can be selected using the `provider` configuration value, or
+set in the [`providers` array using
+AlphaConfig](https://oauth2-proxy.github.io/oauth2-proxy/configuration/alpha-config#providers).
+However, [**the feature to implement multiple providers is not
+complete**](https://github.com/oauth2-proxy/oauth2-proxy/issues/926).
 
 ### SecretSource
 

--- a/docs/docs/configuration/providers/index.md
+++ b/docs/docs/configuration/providers/index.md
@@ -25,7 +25,7 @@ Valid providers are :
 - [Nextcloud](nextcloud.md)
 - [OpenID Connect](openid_connect.md)
 
-The provider can be selected using the `provider` configuration value.
+The provider can be selected using the `provider` configuration value, or set in the [`providers` array using AlphaConfig](https://oauth2-proxy.github.io/oauth2-proxy/configuration/alpha-config#providers). However, [**the feature to implement multiple providers is not complete**](https://github.com/oauth2-proxy/oauth2-proxy/issues/926).
 
 Please note that not all providers support all claims. The `preferred_username` claim is currently only supported by the 
 OpenID Connect provider.

--- a/docs/versioned_docs/version-7.8.x/configuration/alpha_config.md
+++ b/docs/versioned_docs/version-7.8.x/configuration/alpha_config.md
@@ -168,7 +168,7 @@ They may change between releases without notice.
 | `injectResponseHeaders` | _[[]Header](#header)_ | InjectResponseHeaders is used to configure headers that should be added<br/>to responses from the proxy.<br/>This is typically used when using the proxy as an external authentication<br/>provider in conjunction with another proxy such as NGINX and its<br/>auth_request module.<br/>Headers may source values from either the authenticated user's session<br/>or from a static secret value. |
 | `server` | _[Server](#server)_ | Server is used to configure the HTTP(S) server for the proxy application.<br/>You may choose to run both HTTP and HTTPS servers simultaneously.<br/>This can be done by setting the BindAddress and the SecureBindAddress simultaneously.<br/>To use the secure server you must configure a TLS certificate and key. |
 | `metricsServer` | _[Server](#server)_ | MetricsServer is used to configure the HTTP(S) server for metrics.<br/>You may choose to run both HTTP and HTTPS servers simultaneously.<br/>This can be done by setting the BindAddress and the SecureBindAddress simultaneously.<br/>To use the secure server you must configure a TLS certificate and key. |
-| `providers` | _[Providers](#providers)_ | Providers is used to configure multiple providers. |
+| `providers` | _[Providers](#providers)_ | Providers is used to configure your provider. **Multiple-providers is not<br/>yet working.** [This feature is tracked in<br/>#925](https://github.com/oauth2-proxy/oauth2-proxy/issues/926) |
 
 ### AzureOptions
 
@@ -471,7 +471,11 @@ and oidc.
 
 (**Appears on:** [AlphaOptions](#alphaoptions))
 
-Providers is a collection of definitions for providers.
+The provider can be selected using the `provider` configuration value, or
+set in the [`providers` array using
+AlphaConfig](https://oauth2-proxy.github.io/oauth2-proxy/configuration/alpha-config#providers).
+However, [**the feature to implement multiple providers is not
+complete**](https://github.com/oauth2-proxy/oauth2-proxy/issues/926).
 
 ### SecretSource
 

--- a/docs/versioned_docs/version-7.8.x/configuration/providers/index.md
+++ b/docs/versioned_docs/version-7.8.x/configuration/providers/index.md
@@ -25,7 +25,7 @@ Valid providers are :
 - [Nextcloud](nextcloud.md)
 - [OpenID Connect](openid_connect.md)
 
-The provider can be selected using the `provider` configuration value.
+The provider can be selected using the `provider` configuration value, or set in the [`providers` array using AlphaConfig](https://oauth2-proxy.github.io/oauth2-proxy/configuration/alpha-config#providers). However, [**the feature to implement multiple providers is not complete**](https://github.com/oauth2-proxy/oauth2-proxy/issues/926).
 
 Please note that not all providers support all claims. The `preferred_username` claim is currently only supported by the 
 OpenID Connect provider.

--- a/docs/versioned_docs/version-7.9.x/configuration/alpha_config.md
+++ b/docs/versioned_docs/version-7.9.x/configuration/alpha_config.md
@@ -168,7 +168,7 @@ They may change between releases without notice.
 | `injectResponseHeaders` | _[[]Header](#header)_ | InjectResponseHeaders is used to configure headers that should be added<br/>to responses from the proxy.<br/>This is typically used when using the proxy as an external authentication<br/>provider in conjunction with another proxy such as NGINX and its<br/>auth_request module.<br/>Headers may source values from either the authenticated user's session<br/>or from a static secret value. |
 | `server` | _[Server](#server)_ | Server is used to configure the HTTP(S) server for the proxy application.<br/>You may choose to run both HTTP and HTTPS servers simultaneously.<br/>This can be done by setting the BindAddress and the SecureBindAddress simultaneously.<br/>To use the secure server you must configure a TLS certificate and key. |
 | `metricsServer` | _[Server](#server)_ | MetricsServer is used to configure the HTTP(S) server for metrics.<br/>You may choose to run both HTTP and HTTPS servers simultaneously.<br/>This can be done by setting the BindAddress and the SecureBindAddress simultaneously.<br/>To use the secure server you must configure a TLS certificate and key. |
-| `providers` | _[Providers](#providers)_ | Providers is used to configure multiple providers. |
+| `providers` | _[Providers](#providers)_ | Providers is used to configure your provider. **Multiple-providers is not<br/>yet working.** [This feature is tracked in<br/>#925](https://github.com/oauth2-proxy/oauth2-proxy/issues/926) |
 
 ### AzureOptions
 
@@ -472,7 +472,11 @@ and oidc.
 
 (**Appears on:** [AlphaOptions](#alphaoptions))
 
-Providers is a collection of definitions for providers.
+The provider can be selected using the `provider` configuration value, or
+set in the [`providers` array using
+AlphaConfig](https://oauth2-proxy.github.io/oauth2-proxy/configuration/alpha-config#providers).
+However, [**the feature to implement multiple providers is not
+complete**](https://github.com/oauth2-proxy/oauth2-proxy/issues/926).
 
 ### SecretSource
 

--- a/docs/versioned_docs/version-7.9.x/configuration/providers/index.md
+++ b/docs/versioned_docs/version-7.9.x/configuration/providers/index.md
@@ -25,7 +25,7 @@ Valid providers are :
 - [Nextcloud](nextcloud.md)
 - [OpenID Connect](openid_connect.md)
 
-The provider can be selected using the `provider` configuration value.
+The provider can be selected using the `provider` configuration value, or set in the [`providers` array using AlphaConfig](https://oauth2-proxy.github.io/oauth2-proxy/configuration/alpha-config#providers). However, [**the feature to implement multiple providers is not complete**](https://github.com/oauth2-proxy/oauth2-proxy/issues/926).
 
 Please note that not all providers support all claims. The `preferred_username` claim is currently only supported by the 
 OpenID Connect provider.

--- a/pkg/apis/options/alpha_options.go
+++ b/pkg/apis/options/alpha_options.go
@@ -41,7 +41,9 @@ type AlphaOptions struct {
 	// To use the secure server you must configure a TLS certificate and key.
 	MetricsServer Server `json:"metricsServer,omitempty"`
 
-	// Providers is used to configure multiple providers.
+	// Providers is used to configure your provider. **Multiple-providers is not
+	// yet working.** [This feature is tracked in
+	// #925](https://github.com/oauth2-proxy/oauth2-proxy/issues/926)
 	Providers Providers `json:"providers,omitempty"`
 }
 

--- a/pkg/apis/options/providers.go
+++ b/pkg/apis/options/providers.go
@@ -11,7 +11,11 @@ const (
 // OIDCAudienceClaims is the generic audience claim list used by the OIDC provider.
 var OIDCAudienceClaims = []string{"aud"}
 
-// Providers is a collection of definitions for providers.
+// The provider can be selected using the `provider` configuration value, or
+// set in the [`providers` array using
+// AlphaConfig](https://oauth2-proxy.github.io/oauth2-proxy/configuration/alpha-config#providers).
+// However, [**the feature to implement multiple providers is not
+// complete**](https://github.com/oauth2-proxy/oauth2-proxy/issues/926).
 type Providers []Provider
 
 // Provider holds all configuration for a single provider


### PR DESCRIPTION
Currently this configuration option is held up by #926. So users don't assume this solution will work for them, and later find the feature is not yet implemented -- own the shortcoming clearly.

[Blog entry about finding this out the hard way](https://substack.evancarroll.com/p/own-your-product-shortcomings)