### PR TITLE
feat: implementation of Discord provider

### DIFF
--- a/docs/docs/configuration/alpha_config.md
+++ b/docs/docs/configuration/alpha_config.md
@@ -204,6 +204,16 @@ ClaimSource allows loading a header value from a claim within the session
 | `prefix` | _string_ | Prefix is an optional prefix that will be prepended to the value of the<br/>claim if it is non-empty. |
 | `basicAuthPassword` | _[SecretSource](#secretsource)_ | BasicAuthPassword converts this claim into a basic auth header.<br/>Note the value of claim will become the basic auth username and the<br/>basicAuthPassword will be used as the password value. |
 
+### DiscordOptions
+
+(**Appears on:** [Provider](#provider))
+
+DiscordOptions holds configuration options for Discord provider
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `restricted_user_ids` | _[]string_ |  |
+
 ### Duration
 #### (`string` alias)
 
@@ -433,6 +443,7 @@ Provider holds all configuration for a single provider
 | `microsoftEntraIDConfig` | _[MicrosoftEntraIDOptions](#microsoftentraidoptions)_ | MicrosoftEntraIDConfig holds all configurations for Entra ID provider. |
 | `ADFSConfig` | _[ADFSOptions](#adfsoptions)_ | ADFSConfig holds all configurations for ADFS provider. |
 | `bitbucketConfig` | _[BitbucketOptions](#bitbucketoptions)_ | BitbucketConfig holds all configurations for Bitbucket provider. |
+| `discordConfig` | _[DiscordOptions](#discordoptions)_ | DiscordConfig holds all configurations for Discord provider. |
 | `githubConfig` | _[GitHubOptions](#githuboptions)_ | GitHubConfig holds all configurations for GitHubC provider. |
 | `gitlabConfig` | _[GitLabOptions](#gitlaboptions)_ | GitLabConfig holds all configurations for GitLab provider. |
 | `googleConfig` | _[GoogleOptions](#googleoptions)_ | GoogleConfig holds all configurations for Google provider. |

--- a/docs/docs/configuration/providers/discord.md
+++ b/docs/docs/configuration/providers/discord.md
@@ -22,6 +22,12 @@ title: Discord
 
 To find a user's Discord ID (including your own), right-click their profile picture and select Copy ID.
 
+***Scopes***
+
+Scopes are defined on [Discord's OAuth2 documentation page](https://discord.com/developers/docs/topics/oauth2#shared-resources).
+The default scope is **identify**, meaning you will only ensure the user is a valid Discord user, and will receive its ID only.
+If you require any other information, you will need to parametrized the scope used.
+
 ***Using the provider***
 
 To use the provider, pass the following options:
@@ -35,3 +41,7 @@ To use the provider, pass the following options:
 
 The `--discord-restricted-user-id` arg can be specified multiple times with different guild IDs to allow multiple guilds 
 to authenticate.
+
+Note: by default, the email retrieved and forwarded by oauth2-proxy will be a dummy email. A valid email can be retrieved
+using discord, but requires a specific scope. Please refer to
+[Discord's oauth2 documentation](https://discord.com/developers/docs/topics/oauth2#shared-resources) for more details.

--- a/docs/docs/configuration/providers/discord.md
+++ b/docs/docs/configuration/providers/discord.md
@@ -20,7 +20,8 @@ title: Discord
 
 ***Finding discord user identifiers***
 
-To find a user's Discord ID (including your own), right-click their profile picture and select Copy ID.
+To find a user's Discord ID (including your own), first activate the developer mode,
+then right-click their profile picture and select Copy ID.
 
 ***Scopes***
 

--- a/docs/docs/configuration/providers/discord.md
+++ b/docs/docs/configuration/providers/discord.md
@@ -1,0 +1,37 @@
+---
+id: discord
+title: Discord
+---
+
+## Config Options
+
+| Flag                 | Toml Field          | Type           | Description                                              | Default |
+| -------------------- | ------------------- | -------------- | -------------------------------------------------------- | ------- |
+| `--discord-restricted-user-id` | `discord_restricted_user_ids` | string \| list | restricts logins to a specific list of discord users. Not specifying a list of users means every one is allowed to access. |         |
+
+## Usage
+
+***Application Setup***
+1.  Create a new Discord App from https://discord.com/developers/applications/
+    * The Application Name will be what appears when users attempt to authenticate.
+2.  On the left hand side of the application information page, navigate to "OAuth2".
+3.  On this page, keep track of the Client ID and reset the Client Secret to generate a new secret.
+4.  Under Redirects, add your Valid OAuth redirect URIs to `https://<proxied host>oauth2/callback`
+
+***Finding discord user identifiers***
+
+To find a user's Discord ID (including your own), right-click their profile picture and select Copy ID.
+
+***Using the provider***
+
+To use the provider, pass the following options:
+
+```
+   --provider=discord
+   --client-id=<Client ID from Step 3>
+   --client-secret=<Client Secret from Step 3>
+   --discord-restricted-user-id=<user_id> 
+```
+
+The `--discord-restricted-user-id` arg can be specified multiple times with different guild IDs to allow multiple guilds 
+to authenticate.

--- a/docs/docs/configuration/providers/index.md
+++ b/docs/docs/configuration/providers/index.md
@@ -11,6 +11,7 @@ Valid providers are :
 - [ADFS](adfs.md)
 - [Bitbucket](bitbucket.md)
 - [DigitalOcean](digitalocean.md)
+- [Discord](discord.md)
 - [Facebook](facebook.md)
 - [Gitea](gitea.md)
 - [GitHub](github.md)

--- a/pkg/apis/options/legacy_options.go
+++ b/pkg/apis/options/legacy_options.go
@@ -492,6 +492,7 @@ type LegacyProvider struct {
 	EntraIDFederatedTokenAuth              bool     `flag:"entra-id-federated-token-auth" cfg:"entra_id_federated_token_auth"`
 	BitbucketTeam                          string   `flag:"bitbucket-team" cfg:"bitbucket_team"`
 	BitbucketRepository                    string   `flag:"bitbucket-repository" cfg:"bitbucket_repository"`
+	DiscordRestrictedUserIDs               []string `flag:"discord-restricted-user-id" cfg:"discord_restricted_user_ids"`
 	GitHubOrg                              string   `flag:"github-org" cfg:"github_org"`
 	GitHubTeam                             string   `flag:"github-team" cfg:"github_team"`
 	GitHubRepo                             string   `flag:"github-repo" cfg:"github_repo"`
@@ -558,6 +559,7 @@ func legacyProviderFlagSet() *pflag.FlagSet {
 	flagSet.Bool("entra-id-federated-token-auth", false, "enable oAuth client authentication with federated token projected by Azure Workload Identity plugin, instead of client secret.")
 	flagSet.String("bitbucket-team", "", "restrict logins to members of this team")
 	flagSet.String("bitbucket-repository", "", "restrict logins to user with access to this repository")
+	flagSet.StringSlice("discord-restricted-user-id", []string{}, "restrict login to a list of discord user identifiers")
 	flagSet.String("github-org", "", "restrict logins to members of this organisation")
 	flagSet.String("github-team", "", "restrict logins to members of this team")
 	flagSet.String("github-repo", "", "restrict logins to collaborators of this repository")
@@ -718,6 +720,10 @@ func (l *LegacyProvider) convert() (Providers, error) {
 	}
 
 	switch provider.Type {
+	case "discord":
+		provider.DiscordConfig = DiscordOptions{
+			RestrictedUserIDs: l.DiscordRestrictedUserIDs,
+		}
 	case "github":
 		provider.GitHubConfig = GitHubOptions{
 			Org:   l.GitHubOrg,

--- a/pkg/apis/options/providers.go
+++ b/pkg/apis/options/providers.go
@@ -40,6 +40,8 @@ type Provider struct {
 	ADFSConfig ADFSOptions `json:"ADFSConfig,omitempty"`
 	// BitbucketConfig holds all configurations for Bitbucket provider.
 	BitbucketConfig BitbucketOptions `json:"bitbucketConfig,omitempty"`
+	// DiscordConfig holds all configurations for Discord provider.
+	DiscordConfig DiscordOptions `json:"discordConfig,omitempty"`
 	// GitHubConfig holds all configurations for GitHubC provider.
 	GitHubConfig GitHubOptions `json:"githubConfig,omitempty"`
 	// GitLabConfig holds all configurations for GitLab provider.
@@ -118,6 +120,9 @@ const (
 	// DigitalOceanProvider is the provider type for DigitalOcean
 	DigitalOceanProvider ProviderType = "digitalocean"
 
+	// DiscordProvider is the provider type for Discord
+	DiscordProvider ProviderType = "discord"
+
 	// FacebookProvider is the provider type for Facebook
 	FacebookProvider ProviderType = "facebook"
 
@@ -189,6 +194,11 @@ type BitbucketOptions struct {
 	Team string `json:"team,omitempty"`
 	// Repository sets restrict logins to user with access to this repository
 	Repository string `json:"repository,omitempty"`
+}
+
+// DiscordOptions holds configuration options for Discord provider
+type DiscordOptions struct {
+	RestrictedUserIDs []string `json:"restricted_user_ids,omitempty"`
 }
 
 type GitHubOptions struct {

--- a/providers/discord.go
+++ b/providers/discord.go
@@ -1,0 +1,130 @@
+package providers
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/sessions"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/requests"
+)
+
+// DiscordProvider represents a Discord based Identity Provider
+type DiscordProvider struct {
+	*ProviderData
+	restrictedUserIDs map[string]bool
+}
+
+var _ Provider = (*DiscordProvider)(nil)
+
+const (
+	discordProviderName = "Discord"
+	discordDefaultScope = "identify"
+)
+
+var (
+	// Default Login URL for Discord.
+	// Pre-parsed URL of https://discord.com/api/oauth2/authorize.
+	discordDefaultLoginURL = &url.URL{
+		Scheme: "https",
+		Host:   "discord.com",
+		Path:   "/api/oauth2/authorize",
+	}
+
+	// Default Redeem URL for Discord.
+	// Pre-parsed URL of https://discord.com/api/oauth2/token
+	discordDefaultRedeemURL = &url.URL{
+		Scheme: "https",
+		Host:   "discord.com",
+		Path:   "/api/oauth2/token",
+	}
+
+	// Profile URL for Discord.
+	// Pre-parsed URL of https://discord.com/api/oauth2/@me
+	discordDefaultProfileURL = &url.URL{
+		Scheme: "https",
+		Host:   "discord.com",
+		Path:   "/api/oauth2/@me",
+	}
+)
+
+// NewDiscordProvider initiates a new DiscordProvider
+func NewDiscordProvider(p *ProviderData, opts options.DiscordOptions) *DiscordProvider {
+	p.setProviderDefaults(providerDefaults{
+		name:        discordProviderName,
+		loginURL:    discordDefaultLoginURL,
+		redeemURL:   discordDefaultRedeemURL,
+		profileURL:  discordDefaultProfileURL,
+		validateURL: discordDefaultProfileURL,
+		scope:       discordDefaultScope,
+	})
+	restrictedUserIDs := make(map[string]bool, len(opts.RestrictedUserIDs))
+	for _, userID := range opts.RestrictedUserIDs {
+		restrictedUserIDs[userID] = true
+	}
+	return &DiscordProvider{
+		ProviderData:      p,
+		restrictedUserIDs: restrictedUserIDs,
+	}
+}
+
+func (p *DiscordProvider) Authorize(ctx context.Context, s *sessions.SessionState) (bool, error) {
+	if ok, err := p.ProviderData.Authorize(ctx, s); err != nil {
+		// error while validating authorization
+		return false, err
+	} else if !ok {
+		// not authorized
+		return false, nil
+	}
+	return p.validateUserID(s), nil
+}
+
+func (p *DiscordProvider) validateUserID(s *sessions.SessionState) bool {
+	// check custom parameters
+	if len(p.restrictedUserIDs) == 0 {
+		// no restrictedUserIDs parametered, user is allowed to access
+		return true
+	}
+	return p.restrictedUserIDs[s.User]
+}
+
+// ValidateSession validates the AccessToken.
+// Discord requires 'Accept' header to be set to 'application/json'
+func (p *DiscordProvider) ValidateSession(ctx context.Context, s *sessions.SessionState) bool {
+	return validateToken(ctx, p, s.AccessToken, makeOIDCHeader(s.AccessToken))
+}
+
+// EnrichSession enriches the session with user information
+func (p *DiscordProvider) EnrichSession(ctx context.Context, s *sessions.SessionState) error {
+	token, err := p.getTokenInfo(ctx, s)
+	if err != nil {
+		return err
+	}
+	s.User = token.User.ID
+	s.PreferredUsername = token.User.Username
+	return nil
+}
+
+type discordTokenInfo struct {
+	User struct {
+		ID       string `json:"id"`
+		Username string `json:"username"`
+	} `json:"user"`
+}
+
+// Retrieve current token Info
+// https://discord.com/developers/docs/topics/oauth2#get-current-authorization-information
+func (p *DiscordProvider) getTokenInfo(ctx context.Context, s *sessions.SessionState) (*discordTokenInfo, error) {
+	var tokenInfo discordTokenInfo
+	err := requests.New(discordDefaultProfileURL.String()).
+		WithContext(ctx).
+		SetHeader("Authorization", "Bearer "+s.AccessToken).
+		Do().
+		UnmarshalInto(&tokenInfo)
+	if err != nil {
+		return nil, fmt.Errorf("error getting token info: %w", err)
+	}
+
+	return &tokenInfo, nil
+}

--- a/providers/discord_test.go
+++ b/providers/discord_test.go
@@ -1,0 +1,181 @@
+package providers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/sessions"
+	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
+)
+
+func testDiscordProvider(t testing.TB, hostname string, restrictedUserIDs []string) *DiscordProvider {
+	p := NewDiscordProvider(
+		&ProviderData{
+			ProviderName: "",
+			LoginURL:     &url.URL{},
+			RedeemURL:    &url.URL{},
+			ProfileURL:   &url.URL{},
+			ValidateURL:  &url.URL{},
+			Scope:        ""},
+		options.DiscordOptions{
+			RestrictedUserIDs: restrictedUserIDs,
+		})
+
+	if hostname != "" {
+		updateURL(p.Data().LoginURL, hostname)
+		updateURL(p.Data().RedeemURL, hostname)
+		updateURL(p.Data().ProfileURL, hostname)
+		originalProfileURL := discordDefaultProfileURL
+		t.Cleanup(func() { discordDefaultProfileURL = originalProfileURL })
+		updateURL(originalProfileURL, hostname)
+	}
+	return p
+}
+
+func testDiscordBackend(payload string) *httptest.Server {
+	profilePath := discordDefaultProfileURL.Path
+
+	return httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != profilePath {
+				w.WriteHeader(404)
+			} else if !IsAuthorizedInHeader(r.Header) {
+				w.WriteHeader(403)
+			} else {
+				w.WriteHeader(200)
+				w.Write([]byte(payload))
+			}
+		}))
+}
+
+func TestNewDiscordProvider(t *testing.T) {
+	g := NewWithT(t)
+
+	// Test that defaults are set when calling for a new provider with nothing set
+	providerData := NewDiscordProvider(&ProviderData{}, options.DiscordOptions{}).Data()
+	g.Expect(providerData.ProviderName).To(Equal("Discord"))
+	g.Expect(providerData.LoginURL.String()).To(Equal("https://discord.com/api/oauth2/authorize"))
+	g.Expect(providerData.RedeemURL.String()).To(Equal("https://discord.com/api/oauth2/token"))
+	g.Expect(providerData.ProfileURL.String()).To(Equal("https://discord.com/api/oauth2/@me"))
+	g.Expect(providerData.ValidateURL.String()).To(Equal("https://discord.com/api/oauth2/@me"))
+	g.Expect(providerData.Scope).To(Equal("identify"))
+}
+
+func TestDiscordProviderOverrides(t *testing.T) {
+	p := NewDiscordProvider(
+		&ProviderData{
+			LoginURL: &url.URL{
+				Scheme: "https",
+				Host:   "example.com",
+				Path:   "/oauth/auth"},
+			RedeemURL: &url.URL{
+				Scheme: "https",
+				Host:   "example.com",
+				Path:   "/oauth/token"},
+			ProfileURL: &url.URL{
+				Scheme: "https",
+				Host:   "example.com",
+				Path:   "/oauth/profile"},
+			ValidateURL: &url.URL{
+				Scheme: "https",
+				Host:   "example.com",
+				Path:   "/oauth/tokeninfo"},
+			Scope: "profile"},
+		options.DiscordOptions{})
+	assert.NotEqual(t, nil, p)
+	assert.Equal(t, "Discord", p.Data().ProviderName)
+	assert.Equal(t, "https://example.com/oauth/auth",
+		p.Data().LoginURL.String())
+	assert.Equal(t, "https://example.com/oauth/token",
+		p.Data().RedeemURL.String())
+	assert.Equal(t, "https://example.com/oauth/profile",
+		p.Data().ProfileURL.String())
+	assert.Equal(t, "https://example.com/oauth/tokeninfo",
+		p.Data().ValidateURL.String())
+	assert.Equal(t, "profile", p.Data().Scope)
+}
+
+func TestDiscordProviderGetTokenInfo(t *testing.T) {
+	b := testDiscordBackend(`{"user":{"id":"1234","username":"john"}}`)
+	defer b.Close()
+
+	bURL, _ := url.Parse(b.URL)
+	p := testDiscordProvider(t, bURL.Host, []string{})
+
+	session := CreateAuthorizedSession()
+	token, err := p.getTokenInfo(context.Background(), session)
+	assert.NoError(t, err)
+	assert.Equal(t, "1234", token.User.ID)
+	assert.Equal(t, "john", token.User.Username)
+}
+
+func TestDiscordProviderEnrichSession(t *testing.T) {
+	b := testDiscordBackend(`{"user":{"id":"1234","username":"john"}}`)
+	defer b.Close()
+
+	bURL, _ := url.Parse(b.URL)
+	p := testDiscordProvider(t, bURL.Host, []string{})
+
+	session := CreateAuthorizedSession()
+	assert.NoError(t, p.EnrichSession(context.Background(), session))
+	assert.Equal(t, "1234", session.User)
+	assert.Equal(t, "john", session.PreferredUsername)
+}
+
+func TestDiscordProviderValidateUserID(t *testing.T) {
+	userID := "1234"
+	b := testDiscordBackend(`{"user":{"id":"` + userID + `","username":"john"}}`)
+	defer b.Close()
+
+	bURL, _ := url.Parse(b.URL)
+	for _, testCase := range []struct {
+		Name              string
+		RestrictedUserIDs []string
+		ExpectedAccess    bool
+	}{
+		{
+			Name:              "no restriction defined",
+			RestrictedUserIDs: []string{},
+			ExpectedAccess:    true,
+		},
+		{
+			Name:              "user ID in restricted list",
+			RestrictedUserIDs: []string{userID},
+			ExpectedAccess:    true,
+		},
+		{
+			Name:              "user ID not in restricted list",
+			RestrictedUserIDs: []string{"not our user ID"},
+			ExpectedAccess:    false,
+		},
+	} {
+		t.Run(testCase.Name, func(t *testing.T) {
+			p := testDiscordProvider(t, bURL.Host, testCase.RestrictedUserIDs)
+
+			session := CreateAuthorizedSession()
+			assert.NoError(t, p.EnrichSession(context.Background(), session))
+			assert.Equal(t, testCase.ExpectedAccess, p.validateUserID(session))
+		})
+	}
+}
+
+func TestDiscordProviderTokenInfoFailedRequest(t *testing.T) {
+	b := testDiscordBackend("unused payload")
+	defer b.Close()
+
+	bURL, _ := url.Parse(b.URL)
+	p := testDiscordProvider(t, bURL.Host, []string{})
+
+	// We'll trigger a request failure by using an unexpected access
+	// token. Alternatively, we could allow the parsing of the payload as
+	// JSON to fail.
+	session := &sessions.SessionState{AccessToken: "unexpected_access_token"}
+	token, err := p.getTokenInfo(context.Background(), session)
+	assert.Error(t, err)
+	assert.Nil(t, token)
+}

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -47,6 +47,8 @@ func NewProvider(providerConfig options.Provider) (Provider, error) {
 		return NewBitbucketProvider(providerData, providerConfig.BitbucketConfig), nil
 	case options.DigitalOceanProvider:
 		return NewDigitalOceanProvider(providerData), nil
+	case options.DiscordProvider:
+		return NewDiscordProvider(providerData, providerConfig.DiscordConfig), nil
 	case options.FacebookProvider:
 		return NewFacebookProvider(providerData), nil
 	case options.GitHubProvider:
@@ -182,7 +184,7 @@ func parseCodeChallengeMethod(providerConfig options.Provider) string {
 
 func providerRequiresOIDCProviderVerifier(providerType options.ProviderType) (bool, error) {
 	switch providerType {
-	case options.BitbucketProvider, options.DigitalOceanProvider, options.FacebookProvider, options.GitHubProvider,
+	case options.BitbucketProvider, options.DigitalOceanProvider, options.DiscordProvider, options.FacebookProvider, options.GitHubProvider,
 		options.GoogleProvider, options.KeycloakProvider, options.LinkedInProvider, options.LoginGovProvider, options.NextCloudProvider:
 		return false, nil
 	case options.ADFSProvider, options.AzureProvider, options.GitLabProvider, options.KeycloakOIDCProvider, options.OIDCProvider, options.MicrosoftEntraIDProvider:


### PR DESCRIPTION
This changes is inspired from what has already been done within #2113 and #2741.
The author of #2113 seems to be using his own fork, updated from time to time.
The author of #2741 does not seem to be active on Github since the commits were first added.

Most of the code has been rewritten, some parts were copied/adapted. Let me know how you want to proceed and if you want me to add their commit as a base, even if my own commits introduce a partial-to-full-rewrite of their own.

## Description

The bare minimum to be able to use discord as an authentication provider has been added through this commit, including a user restriction capacity.
The authentication through discord uses the oauth2 mechanism as described in Discord's documentation.
Once the authentication succeeds, we use the discord API in order to fetch specific information.

By default, scope is limited to a minimal identification of the user. Scopes must be enriched within the configuration in order to access more capabilities:

- [x] Restriction by "user" identifier
- [ ] Restriction by "guild" (server)
- [ ] Restriction by "guild" role

(more implementations will be added to this PR, it acts as a draft in order to fetch feedback and suggest better commits afterwards)

## Motivation and Context

For a personal project, I am looking for a way to provide discord auth and restrict access to a few users.

## How Has This Been Tested?

Simple tests have been added to the code, based off existing providers.
Manual tests will be conducted soon against the current setup (which is a very simple reverse proxy with an authentication middleware) to validate the behavior

## Checklist:

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
- [x] I have written tests for my code changes.
