### PR TITLE
feat: use non-default authorization request response mode in OIDC providers

### DIFF
--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -61,6 +61,11 @@ func (p *OIDCProvider) GetLoginURL(redirectURI, state, nonce string, extraParams
 	if !p.SkipNonce {
 		extraParams.Add("nonce", nonce)
 	}
+	// Response mode should only be set if a non default mode is requested
+	if p.AuthRequestResponseMode != "" {
+		extraParams.Add("response_mode", p.AuthRequestResponseMode)
+	}
+
 	loginURL := makeLoginURL(p.Data(), redirectURI, state, extraParams)
 	return loginURL.String()
 }

--- a/providers/oidc_test.go
+++ b/providers/oidc_test.go
@@ -275,3 +275,32 @@ func TestOIDCProviderCreateSessionFromToken(t *testing.T) {
 		})
 	}
 }
+
+func TestOIDCProviderResponseModeConfigured(t *testing.T) {
+	providerData := &ProviderData{
+		LoginURL: &url.URL{
+			Scheme: "http",
+			Host:   "my.test.idp",
+			Path:   "/oauth/authorize",
+		},
+		AuthRequestResponseMode: "form_post",
+	}
+	p := NewOIDCProvider(providerData, options.OIDCOptions{})
+
+	result := p.GetLoginURL("https://my.test.app/oauth", "", "", url.Values{})
+	assert.Contains(t, result, "response_mode=form_post")
+}
+
+func TestOIDCProviderResponseModeNotConfigured(t *testing.T) {
+	providerData := &ProviderData{
+		LoginURL: &url.URL{
+			Scheme: "http",
+			Host:   "my.test.idp",
+			Path:   "/oauth/authorize",
+		},
+	}
+	p := NewOIDCProvider(providerData, options.OIDCOptions{})
+
+	result := p.GetLoginURL("https://my.test.app/oauth", "", "", url.Values{})
+	assert.NotContains(t, result, "response_mode")
+}


### PR DESCRIPTION
## Description

If `auth-request-response-mode` is configured it will also apply for OIDC (and derived) providers.

## Motivation and Context

It is possible to define `auth-request-response-mode` in the configuration to ask for a non-default response mode (mainly form_post). Entra ID supports it, but is based on the OIDC provider where the flag is currently not processed.

Fixes https://github.com/oauth2-proxy/oauth2-proxy/issues/3054

## How Has This Been Tested?

Tested with developer tools in browser to verify the paramter is added.

## Checklist:

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
- [x] I have written tests for my code changes.
