### PR TITLE
chore(deps): migrate golangci-lint to v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Get dependencies
       env:
         # renovate: datasource=github-tags depName=golangci/golangci-lint
-        GOLANGCI_LINT_VERSION: v1.64.8
+        GOLANGCI_LINT_VERSION: v2.1.6
       run: |
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin ${GOLANGCI_LINT_VERSION}
         curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Get dependencies
       env:
         # renovate: datasource=github-tags depName=golangci/golangci-lint
-        GOLANGCI_LINT_VERSION: v1.64.8
+        GOLANGCI_LINT_VERSION: v2.1.6
       run: |
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin ${GOLANGCI_LINT_VERSION}
         curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,50 +1,65 @@
-run:
-  timeout: 120s
+version: "2"
 linters:
+  default: none
   enable:
+    - bodyclose
+    - copyloopvar
+    - dogsled
+    - goconst
+    - gocritic
+    - goprintffuncname
+    - gosec
     - govet
     - ineffassign
-    - goconst
-    - gofmt
-    - goimports
-    - gosec
-    - gosimple
-    - staticcheck
-    - typecheck
-    - unused
-    - bodyclose
-    - dogsled
-    - goprintffuncname
     - misspell
     - prealloc
-    - copyloopvar
-    - stylecheck
-    - unconvert
-    - gocritic
     - revive
-  disable-all: true
-issues:
-  exclude:
-    # To ease migration to golangci-lint v2.1
-    # https://staticcheck.dev/docs/checks/#QF1008
-    - QF1008
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - scopelint
-        - bodyclose
-        - unconvert
-        - gocritic
-        - gosec
-        - goconst
-        - revive
-    - path: _test\.go
-      linters:
-        - revive
-      text: "dot-imports:"
-    # If we have tests in shared test folders, these can be less strictly linted
-    - path: tests/.*_tests\.go
-      linters:
-        - revive
-        - bodyclose
-        - stylecheck
+    - staticcheck
+    - unconvert
+    - unused
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - bodyclose
+          - goconst
+          - gocritic
+          - gosec
+          - revive
+          - scopelint
+          - unconvert
+        path: _test\.go
+      - linters:
+          - revive
+        path: _test\.go
+        text: 'dot-imports:'
+      # # If we have tests in shared test folders, these can be less strictly linted
+      - linters:
+          - bodyclose
+          - revive
+          - staticcheck
+        path: tests/.*_tests\.go
+      # See https://github.com/oauth2-proxy/oauth2-proxy/issues/3060
+      # https://staticcheck.dev/docs/checks/#QF1008
+      - linters:
+          - staticcheck
+        text: QF1008
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
## Description

Upgrade golangci-lint to v2. This require migrating the configuation file in addition to the usual

Note: #3061 has been merged to fix all issues reported by v2.

## Motivation and Context

golangci-lint got a major upgrade that requires a migration of the configuration.

## How Has This Been Tested?

```console
$ golangci-lint --version
golangci-lint has version 2.1.6 built with go1.24.2 from eabc2638 on 2025-05-04T15:41:19Z
$ make lint
GO111MODULE=on golangci-lint run
0 issues.
```

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.
