### PR TITLE
feat: support for multiple github orgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Changes since v7.9.0
 
+- [#3072](https://github.com/oauth2-proxy/oauth2-proxy/pull/3072) feat: support for multiple github orgs #3072 (@daniel-mersch)
+
 # V7.9.0
 
 ## Release Highlights

--- a/docs/docs/configuration/providers/github.md
+++ b/docs/docs/configuration/providers/github.md
@@ -39,7 +39,7 @@ To restrict within an organization to specific teams, include the following flag
 To restrict to teams within different organizations, just leave out the flag `--github-org` and use `--github-teams` alone:
 
 ```shell
-    --github-team=""  # restrict logins to members of any of these teams in any organization (format <org>:<slug>, like octo:team1), separated by a comma
+    --github-team=""  # restrict logins to members of any of these teams in any organization (format <org>:<slug> or <legacy team id>, like octo:team1 or octo:123456789), separated by a comma
 ```
 
 If you would rather restrict access to collaborators of a repository, those users must either have push access to a 

--- a/docs/docs/configuration/providers/github.md
+++ b/docs/docs/configuration/providers/github.md
@@ -8,7 +8,7 @@ title: GitHub
 | Flag             | Toml Field     | Type           | Description                                                                                                   | Default |
 | ---------------- | -------------- | -------------- | ------------------------------------------------------------------------------------------------------------- | ------- |
 | `--github-org`   | `github_org`   | string         | restrict logins to members of this organisation                                                               |         |
-| `--github-team`  | `github_team`  | string         | restrict logins to members of any of these teams (slug), separated by a comma                                 |         |
+| `--github-team`  | `github_team`  | string         | restrict logins to members of any of these teams (slug) or (org:team), comma separated                        |         |
 | `--github-repo`  | `github_repo`  | string         | restrict logins to collaborators of this repository formatted as `orgname/repo`                               |         |
 | `--github-token` | `github_token` | string         | the token to use when verifying repository collaborators (must have push access to the repository)            |         |
 | `--github-user`  | `github_users` | string \| list | To allow users to login by username even if they do not belong to the specified org and team or collaborators |         |
@@ -24,29 +24,36 @@ team level access, or to collaborators of a repository. Restricting by these opt
 NOTE: When `--github-user` is set, the specified users are allowed to log in even if they do not belong to the specified 
 org and team or collaborators.
 
-To restrict by organization only, include the following flag:
+To restrict access to your organization:
 
 ```shell
-    --github-org=""  # restrict logins to members of this organisation
+    # restrict logins to members of this organisation
+    --github-org="your-org"
 ```
 
-To restrict within an organization to specific teams, include the following flag in addition to `-github-org`:
+To restrict access to specific teams within an organization:
 
 ```shell
-    --github-team=""  # restrict logins to members of any of these teams (slug), separated by a comma
+    --github-org="your-org"
+    # restrict logins to members of any of these teams (slug), comma separated
+    --github-team="team1,team2,team3"
 ```
 
-To restrict to teams within different organizations, just leave out the flag `--github-org` and use `--github-teams` alone:
+To restrict to teams within different organizations, keep the organization flag empty and use `--github-team` like so:
 
 ```shell
-    --github-team=""  # restrict logins to members of any of these teams in any organization (format <org>:<slug>, like octo:team1), separated by a comma
+    # keep empty
+    --github-org=""
+    # restrict logins to members to any of the following teams (format <org>:<slug>, like octo:team1), comma separated
+    --github-team="org1:team1,org2:team1,org3:team42,octo:cat"
 ```
 
 If you would rather restrict access to collaborators of a repository, those users must either have push access to a 
 public repository or any access to a private repository:
 
 ```shell
-    --github-repo=""  # restrict logins to collaborators of this repository formatted as orgname/repo
+    # restrict logins to collaborators of this repository formatted as orgname/repo
+    --github-repo=""
 ```
 
 If you'd like to allow access to users with **read only** access to a **public** repository you will need to provide a 
@@ -54,14 +61,15 @@ If you'd like to allow access to users with **read only** access to a **public**
 created with at least the `public_repo` scope:
 
 ```shell
-    --github-token=""  # the token to use when verifying repository collaborators
+    # the token to use when verifying repository collaborators
+    --github-token=""
 ```
 
-To allow a user to log in with their username even if they do not belong to the specified org and team or collaborators, 
-separated by a comma
+To allow a user to log in with their username even if they do not belong to the specified org and team or collaborators:
 
 ```shell
-    --github-user="" #allow logins by username, separated by a comma
+    # allow logins by username, comma separated
+    --github-user=""
 ```
 
 If you are using GitHub enterprise, make sure you set the following to the appropriate url:

--- a/docs/docs/configuration/providers/github.md
+++ b/docs/docs/configuration/providers/github.md
@@ -39,7 +39,7 @@ To restrict within an organization to specific teams, include the following flag
 To restrict to teams within different organizations, just leave out the flag `--github-org` and use `--github-teams` alone:
 
 ```shell
-    --github-team=""  # restrict logins to members of any of these teams in any organization (format <org>:<slug> or <legacy team id>, like octo:team1 or octo:123456789), separated by a comma
+    --github-team=""  # restrict logins to members of any of these teams in any organization (format <org>:<slug>, like octo:team1), separated by a comma
 ```
 
 If you would rather restrict access to collaborators of a repository, those users must either have push access to a 

--- a/docs/docs/configuration/providers/github.md
+++ b/docs/docs/configuration/providers/github.md
@@ -36,6 +36,12 @@ To restrict within an organization to specific teams, include the following flag
     --github-team=""  # restrict logins to members of any of these teams (slug), separated by a comma
 ```
 
+To restrict to teams within different organizations, just leave out the flag `--github-org` and use `--github-teams` alone:
+
+```shell
+    --github-team=""  # restrict logins to members of any of these teams in any organization (format <org>:<slug>, like octo:team1), separated by a comma
+```
+
 If you would rather restrict access to collaborators of a repository, those users must either have push access to a 
 public repository or any access to a private repository:
 

--- a/providers/github.go
+++ b/providers/github.go
@@ -409,8 +409,18 @@ func (p *GitHubProvider) checkRestrictions(ctx context.Context, s *sessions.Sess
 		return err
 	}
 
-	if err := p.hasOrgAndTeamAccess(s); err != nil {
-		return err
+	if p.Org != "" && p.Team != "" {
+		if err := p.hasOrgAndTeam(s); err != nil {
+			return err
+		}
+	} else if p.Org != "" {
+		if err := p.hasOrg(s); err != nil {
+			return err
+		}
+	} else if p.Team != "" {
+		if err := p.hasTeam(s); err != nil {
+			return err
+		}
 	}
 
 	if p.Org == "" && p.Repo != "" && p.Token == "" {
@@ -437,22 +447,6 @@ func (p *GitHubProvider) checkUserRestriction(ctx context.Context, s *sessions.S
 	}
 
 	return verifiedUser, nil
-}
-
-func (p *GitHubProvider) hasOrgAndTeamAccess(s *sessions.SessionState) error {
-	if p.Org != "" && p.Team != "" {
-		return p.hasOrgAndTeam(s)
-	}
-
-	if p.Org != "" {
-		return p.hasOrg(s)
-	}
-
-	if p.Team != "" {
-		return p.hasTeam(s)
-	}
-
-	return nil
 }
 
 func (p *GitHubProvider) getOrgAndTeam(ctx context.Context, s *sessions.SessionState) error {

--- a/providers/github.go
+++ b/providers/github.go
@@ -409,20 +409,17 @@ func (p *GitHubProvider) checkRestrictions(ctx context.Context, s *sessions.Sess
 		return err
 	}
 
+	var err error
 	if p.Org != "" && p.Team != "" {
-		if err := p.hasOrgAndTeam(s); err != nil {
-			return err
-		}
+		err = p.hasOrgAndTeam(s)
 	} else if p.Org != "" {
-		if err := p.hasOrg(s); err != nil {
-			return err
-		}
+		err = p.hasOrg(s)
 	} else if p.Team != "" {
-		if err := p.hasTeam(s); err != nil {
-			return err
-		}
+		err = p.hasTeam(s)
 	}
-
+	if err != nil {
+		return err
+	}
 	if p.Org == "" && p.Repo != "" && p.Token == "" {
 		// If we have a token we'll do the collaborator check in GetUserName
 		return p.hasRepoAccess(ctx, s.AccessToken)

--- a/providers/github.go
+++ b/providers/github.go
@@ -417,9 +417,11 @@ func (p *GitHubProvider) checkRestrictions(ctx context.Context, s *sessions.Sess
 	} else if p.Team != "" {
 		err = p.hasTeam(s)
 	}
+
 	if err != nil {
 		return err
 	}
+
 	if p.Org == "" && p.Repo != "" && p.Token == "" {
 		// If we have a token we'll do the collaborator check in GetUserName
 		return p.hasRepoAccess(ctx, s.AccessToken)
@@ -531,6 +533,7 @@ func (p *GitHubProvider) getTeams(ctx context.Context, s *sessions.SessionState)
 		for _, team := range teams {
 			logger.Printf("Member of Github Organization/Team:%q/%q", team.Org.Login, team.Slug)
 			s.Groups = append(s.Groups, team.Org.Login+orgTeamSeparator+team.Slug)
+			s.Groups = append(s.Groups, "group"+orgTeamSeparator+strconv.Itoa(team.Id))
 		}
 
 		pn++

--- a/providers/github.go
+++ b/providers/github.go
@@ -425,7 +425,7 @@ func (p *GitHubProvider) checkRestrictions(ctx context.Context, s *sessions.Sess
 	}
 
 	if p.Org == "" && p.Repo != "" && p.Token == "" {
-		// If we have a token we'll do the collaborator check in GetUserName
+		// If we have a token we'll do the collaborator check
 		return p.hasRepoAccess(ctx, s.AccessToken)
 	}
 
@@ -533,7 +533,7 @@ func (p *GitHubProvider) getTeams(ctx context.Context, s *sessions.SessionState)
 		}
 
 		for _, team := range teams {
-			logger.Printf("Member of Github Organization/Team/ID:%q/%q", team.Org.Login, team.Slug)
+			logger.Printf("Member of Github Organization/Team: %q/%q", team.Org.Login, team.Slug)
 			s.Groups = append(s.Groups, fmt.Sprintf("%s%s%s", team.Org.Login, orgTeamSeparator, team.Slug))
 		}
 

--- a/providers/github.go
+++ b/providers/github.go
@@ -504,7 +504,6 @@ func (p *GitHubProvider) getTeams(ctx context.Context, s *sessions.SessionState)
 	type Team struct {
 		Name string `json:"name"`
 		Slug string `json:"slug"`
-		ID   int    `json:"id"`
 		Org  struct {
 			Login string `json:"login"`
 		} `json:"organization"`
@@ -534,9 +533,8 @@ func (p *GitHubProvider) getTeams(ctx context.Context, s *sessions.SessionState)
 		}
 
 		for _, team := range teams {
-			logger.Printf("Member of Github Organization/Team/ID:%q/%q/%d", team.Org.Login, team.Slug, team.ID)
+			logger.Printf("Member of Github Organization/Team/ID:%q/%q", team.Org.Login, team.Slug)
 			s.Groups = append(s.Groups, fmt.Sprintf("%s%s%s", team.Org.Login, orgTeamSeparator, team.Slug))
-			s.Groups = append(s.Groups, fmt.Sprintf("group%s%d", orgTeamSeparator, team.ID))
 		}
 
 		pn++

--- a/providers/github.go
+++ b/providers/github.go
@@ -535,8 +535,8 @@ func (p *GitHubProvider) getTeams(ctx context.Context, s *sessions.SessionState)
 
 		for _, team := range teams {
 			logger.Printf("Member of Github Organization/Team/ID:%q/%q/%d", team.Org.Login, team.Slug, team.ID)
-			s.Groups = append(s.Groups, team.Org.Login+orgTeamSeparator+team.Slug)
-			s.Groups = append(s.Groups, "group"+orgTeamSeparator+strconv.Itoa(team.ID))
+			s.Groups = append(s.Groups, fmt.Sprintf("%s%s%s", team.Org.Login, orgTeamSeparator, team.Slug))
+			s.Groups = append(s.Groups, fmt.Sprintf("group%s%d", orgTeamSeparator, team.ID))
 		}
 
 		pn++

--- a/providers/github.go
+++ b/providers/github.go
@@ -222,35 +222,24 @@ func (p *GitHubProvider) hasOrgAndTeam(s *sessions.SessionState) error {
 }
 
 func (p *GitHubProvider) hasTeam(s *sessions.SessionState) error {
-	type orgTeam struct {
-		Org  string `json:"org"`
-		Team string `json:"team"`
-		OrgTeam string `json:"org-team"`
-	}
-
-	var presentOrgTeams []orgTeam
+	var teams []string
 
 	for _, group := range s.Groups {
 		if strings.Contains(group, orgTeamSeparator) {
-			ot := strings.Split(group, orgTeamSeparator)
-			presentOrgTeams = append(presentOrgTeams, orgTeam{ot[0], ot[1], group})
+			teams = append(teams, strings.TrimSpace(group))
 		}
 	}
-
-	presentOrgs := make(map[string]bool)
 	var presentTeams []string
 
-	for _, ot := range presentOrgTeams {
-		presentOrgs[ot.Org] = true
-
-			teams := strings.Split(p.Team, ",")
-			for _, team := range teams {
-				if strings.EqualFold(strings.TrimSpace(team), ot.OrgTeam) {
-					logger.Printf("Found Github Organization/Team:%q/%q", ot.Org, ot.Team)
-					return nil
-				}
+	for _, ot := range teams {
+		allowed_teams := strings.Split(p.Team, ",")
+		for _, team := range allowed_teams {
+			if strings.EqualFold(strings.TrimSpace(team), ot) {
+				logger.Printf("Found Github Organization/Team:%s", ot)
+				return nil
 			}
-			presentTeams = append(presentTeams, ot.OrgTeam)
+		}
+		presentTeams = append(presentTeams, ot)
 	}
 
 	logger.Printf("Missing Team:%q in teams: %v", p.Team, presentTeams)

--- a/providers/github.go
+++ b/providers/github.go
@@ -34,10 +34,6 @@ const (
 	githubProviderName = "GitHub"
 	githubDefaultScope = "user:email read:org"
 	orgTeamSeparator   = ":"
-
-	accessLevelOrg int = 1;
-	accessLevelOrgTeams int = 2;
-	accessLevelTeams int = 3;
 )
 
 var (
@@ -156,104 +152,103 @@ func (p *GitHubProvider) ValidateSession(ctx context.Context, s *sessions.Sessio
 	return validateToken(ctx, p, s.AccessToken, makeGitHubHeader(s.AccessToken))
 }
 
-func (p *GitHubProvider) hasAccess(accessLevel int, s *sessions.SessionState) error {
-	switch accessLevel {
-	case accessLevelOrg :
-		// https://developer.github.com/v3/orgs/#list-your-organizations
-		var orgs []string
+func (p *GitHubProvider) hasOrg(s *sessions.SessionState) error {
+	// https://developer.github.com/v3/orgs/#list-your-organizations
+	var orgs []string
 
-		for _, group := range s.Groups {
-			if !strings.Contains(group, ":") {
-				orgs = append(orgs, group)
-			}
+	for _, group := range s.Groups {
+		if !strings.Contains(group, ":") {
+			orgs = append(orgs, group)
 		}
+	}
 
-		presentOrgs := make([]string, 0, len(orgs))
-		for _, org := range orgs {
-			if p.Org == org {
-				logger.Printf("Found Github Organization:%q", org)
-				return nil
-			}
-			presentOrgs = append(presentOrgs, org)
+	presentOrgs := make([]string, 0, len(orgs))
+	for _, org := range orgs {
+		if p.Org == org {
+			logger.Printf("Found Github Organization:%q", org)
+			return nil
 		}
+		presentOrgs = append(presentOrgs, org)
+	}
 
-		logger.Printf("Missing Organization:%q in %v", p.Org, presentOrgs)
-		return errors.New("user is missing required organization")
-	case accessLevelOrgTeams:
-		type orgTeam struct {
-			Org  string `json:"org"`
-			Team string `json:"team"`
+	logger.Printf("Missing Organization:%q in %v", p.Org, presentOrgs)
+	return errors.New("user is missing required organization")
+}
+
+func (p *GitHubProvider) hasOrgAndTeam(s *sessions.SessionState) error {
+	type orgTeam struct {
+		Org  string `json:"org"`
+		Team string `json:"team"`
+	}
+
+	var presentOrgTeams []orgTeam
+
+	for _, group := range s.Groups {
+		if strings.Contains(group, orgTeamSeparator) {
+			ot := strings.Split(group, orgTeamSeparator)
+			presentOrgTeams = append(presentOrgTeams, orgTeam{ot[0], ot[1]})
 		}
+	}
 
-		var presentOrgTeams []orgTeam
+	var hasOrg bool
 
-		for _, group := range s.Groups {
-			if strings.Contains(group, orgTeamSeparator) {
-				ot := strings.Split(group, orgTeamSeparator)
-				presentOrgTeams = append(presentOrgTeams, orgTeam{ot[0], ot[1]})
-			}
-		}
+	presentOrgs := make(map[string]bool)
+	var presentTeams []string
 
-		var hasOrg bool
+	for _, ot := range presentOrgTeams {
+		presentOrgs[ot.Org] = true
 
-		presentOrgs := make(map[string]bool)
-		var presentTeams []string
-
-		for _, ot := range presentOrgTeams {
-			presentOrgs[ot.Org] = true
-
-			if strings.EqualFold(p.Org, ot.Org) {
-				hasOrg = true
-				
-				teams := strings.Split(p.Team, ",")
-				for _, team := range teams {
-					if strings.EqualFold(strings.TrimSpace(team), ot.Team) {
-						logger.Printf("Found Github Organization/Team:%q/%q", ot.Org, ot.Team)
-						return nil
-					}
-				}
-				presentTeams = append(presentTeams, ot.Team)
-			}
-		}
-
-		if hasOrg {
-			logger.Printf("Missing Team:%q from Org:%q in teams: %v", p.Team, p.Org, presentTeams)
-			return errors.New("user is missing required team")
-		}
-
-		logger.Printf("Missing Organization:%q in %#v", p.Org, maps.Keys(presentOrgs))
-		return errors.New("user is missing required organization")
-	case accessLevelTeams:
-		var teams []string
-
-		for _, group := range s.Groups {
-			if strings.Contains(group, orgTeamSeparator) {
-				teams = append(teams, strings.TrimSpace(group))
-			}
-		}
-		var presentTeams []string
-
-		for _, ot := range teams {
-			allowed_teams := strings.Split(p.Team, ",")
-			for _, team := range allowed_teams {
-				if !strings.Contains(team, orgTeamSeparator) {
-					logger.Printf("Please use fully qualified team names (org:team-slug) if you omit the organisation. Current Team name: %s", team)
-					return errors.New("team name is invalid")
-				}			
-
-				if strings.EqualFold(strings.TrimSpace(team), ot) {
-					logger.Printf("Found Github Organization/Team:%s", ot)
+		if strings.EqualFold(p.Org, ot.Org) {
+			hasOrg = true
+			
+			teams := strings.Split(p.Team, ",")
+			for _, team := range teams {
+				if strings.EqualFold(strings.TrimSpace(team), ot.Team) {
+					logger.Printf("Found Github Organization/Team:%q/%q", ot.Org, ot.Team)
 					return nil
 				}
 			}
-			presentTeams = append(presentTeams, ot)
+			presentTeams = append(presentTeams, ot.Team)
 		}
+	}
 
-		logger.Printf("Missing Team:%q in teams: %v", p.Team, presentTeams)
+	if hasOrg {
+		logger.Printf("Missing Team:%q from Org:%q in teams: %v", p.Team, p.Org, presentTeams)
 		return errors.New("user is missing required team")
 	}
 
-	return errors.New("no accesslevel chosen.")
+	logger.Printf("Missing Organization:%q in %#v", p.Org, maps.Keys(presentOrgs))
+	return errors.New("user is missing required organization")
+}
+
+func (p *GitHubProvider) hasTeam(s *sessions.SessionState) error {
+	var teams []string
+
+	for _, group := range s.Groups {
+		if strings.Contains(group, orgTeamSeparator) {
+			teams = append(teams, strings.TrimSpace(group))
+		}
+	}
+	var presentTeams []string
+
+	for _, ot := range teams {
+		allowed_teams := strings.Split(p.Team, ",")
+		for _, team := range allowed_teams {
+			if !strings.Contains(team, orgTeamSeparator) {
+				logger.Printf("Please use fully qualified team names (org:team-slug) if you omit the organisation. Current Team name: %s", team)
+				return errors.New("team name is invalid")
+			}			
+
+			if strings.EqualFold(strings.TrimSpace(team), ot) {
+				logger.Printf("Found Github Organization/Team:%s", ot)
+				return nil
+			}
+		}
+		presentTeams = append(presentTeams, ot)
+	}
+
+	logger.Printf("Missing Team:%q in teams: %v", p.Team, presentTeams)
+	return errors.New("user is missing required team")
 }
 
 func (p *GitHubProvider) hasRepoAccess(ctx context.Context, accessToken string) error {
@@ -446,15 +441,15 @@ func (p *GitHubProvider) checkUserRestriction(ctx context.Context, s *sessions.S
 
 func (p *GitHubProvider) hasOrgAndTeamAccess(s *sessions.SessionState) error {
 	if p.Org != "" && p.Team != "" {
-		return p.hasAccess ( accessLevelOrgTeams, s )
+		return p.hasOrgAndTeam(s)
 	}
 
 	if p.Org != "" {
-		return p.hasAccess ( accessLevelOrg, s )
+		return p.hasOrg(s)
 	}
 
 	if p.Team != "" {
-		return p.hasAccess ( accessLevelTeams, s )
+		return p.hasTeam(s)
 	}
 
 	return nil

--- a/providers/github.go
+++ b/providers/github.go
@@ -234,6 +234,11 @@ func (p *GitHubProvider) hasTeam(s *sessions.SessionState) error {
 	for _, ot := range teams {
 		allowed_teams := strings.Split(p.Team, ",")
 		for _, team := range allowed_teams {
+			if !strings.Contains(team, orgTeamSeparator) {
+				logger.Printf("Please use fully qualified team names (org:team-slug) if you omit the organisation. Current Team name: %s", team)
+				return errors.New("team name is invalid")
+			}			
+
 			if strings.EqualFold(strings.TrimSpace(team), ot) {
 				logger.Printf("Found Github Organization/Team:%s", ot)
 				return nil

--- a/providers/github_test.go
+++ b/providers/github_test.go
@@ -39,6 +39,7 @@ func testGitHubBackend(payloads map[string][]string) *httptest.Server {
 		"/repos/oauth2-proxy/oauth2-proxy/collaborators/mbland": {""},
 		"/user":        {""},
 		"/user/emails": {""},
+		"/user/teams":  {"page=1&per_page=100", "page=2&per_page=100", "page=3&per_page=100"},
 		"/user/orgs":   {"page=1&per_page=100", "page=2&per_page=100", "page=3&per_page=100"},
 		// GitHub Enterprise Server API
 		"/api/v3":             {""},
@@ -166,6 +167,144 @@ func TestGitHubProvider_getEmailWithOrg(t *testing.T) {
 	err := p.getEmail(context.Background(), session)
 	assert.NoError(t, err)
 	assert.Equal(t, "michael.bland@gsa.gov", session.Email)
+}
+
+func TestGitHubProvider_checkRestrictionsOrg(t *testing.T) {
+	b := testGitHubBackend(map[string][]string{
+		"/user/emails": {`[ {"email": "john.doe@example", "verified": true, "primary": true} ]`},
+		"/user/orgs": {
+			`[ { "login": "test-org-1" } ]`,
+			`[ { "login": "test-org-2" } ]`,
+			`[ ]`,
+		},
+		"/user/teams": {
+			`[ { "name":"test-team-1", "slug":"test-team-1", "id": 12345600, "organization": { "login": "test-org-1" } } ]`,
+			`[ { "name":"test-team-2", "slug":"test-team-2", "id": 12345601, "organization": { "login": "test-org-2" } } ]`,
+			`[ ]`,
+		},
+	})
+	defer b.Close()
+
+	// This test should succeed, because of the valid organization.
+	bURL, _ := url.Parse(b.URL)
+	p := testGitHubProvider(bURL.Host,
+		options.GitHubOptions{
+			Org: "test-org-1",
+		},
+	)
+
+	var err error
+	session := CreateAuthorizedSession()
+	err = p.getOrgAndTeam(context.Background(), session)
+	assert.NoError(t, err)
+	err = p.checkRestrictions(context.Background(), session)
+	assert.NoError(t, err)
+
+	// This part should fail, because user is not part of the organization
+	p = testGitHubProvider(bURL.Host,
+		options.GitHubOptions{
+			Org: "test-org-1-fail",
+		},
+	)
+
+	err = p.checkRestrictions(context.Background(), session)
+	assert.Error(t, err)
+}
+
+func TestGitHubProvider_checkRestrictionsOrgTeam(t *testing.T) {
+	b := testGitHubBackend(map[string][]string{
+		"/user/emails": {`[ {"email": "john.doe@example", "verified": true, "primary": true} ]`},
+		"/user/orgs": {
+			`[ { "login": "test-org-1" } ]`,
+			`[ { "login": "test-org-2" } ]`,
+			`[ ]`,
+		},
+		"/user/teams": {
+			`[ { "name":"test-team-1", "slug":"test-team-1", "id": 12345600, "organization": { "login": "test-org-1" } } ]`,
+			`[ { "name":"test-team-2", "slug":"test-team-2", "id": 12345601, "organization": { "login": "test-org-2" } } ]`,
+			`[ ]`,
+		},
+	})
+	defer b.Close()
+
+	// This test should succeed, because of the valid Org and Team combination.
+	bURL, _ := url.Parse(b.URL)
+	p := testGitHubProvider(bURL.Host,
+		options.GitHubOptions{
+			Org:  "test-org-1",
+			Team: "test-team-1",
+		},
+	)
+
+	var err error
+	session := CreateAuthorizedSession()
+	err = p.getOrgAndTeam(context.Background(), session)
+	assert.NoError(t, err)
+	err = p.checkRestrictions(context.Background(), session)
+	assert.NoError(t, err)
+
+	// This part should fail, because user is not part of the organization and the team
+	p = testGitHubProvider(bURL.Host,
+		options.GitHubOptions{
+			Org:  "test-org-1-fail",
+			Team: "test-team-1-fail",
+		},
+	)
+
+	err = p.checkRestrictions(context.Background(), session)
+	assert.Error(t, err)
+}
+
+func TestGitHubProvider_checkRestrictionsTeam(t *testing.T) {
+	b := testGitHubBackend(map[string][]string{
+		"/user/emails": {`[ {"email": "john.doe@example", "verified": true, "primary": true} ]`},
+		"/user/orgs": {
+			`[ { "login": "test-org-1" } ]`,
+			`[ { "login": "test-org-2" } ]`,
+			`[ ]`,
+		},
+		"/user/teams": {
+			`[ { "name":"test-team-1", "slug":"test-team-1", "id": 12345600, "organization": { "login": "test-org-1" } } ]`,
+			`[ { "name":"test-team-2", "slug":"test-team-2", "id": 12345601, "organization": { "login": "test-org-2" } } ]`,
+			`[ ]`,
+		},
+	})
+	defer b.Close()
+
+	// This test should succeed, because of the valid org:slug combination.
+	bURL, _ := url.Parse(b.URL)
+	p := testGitHubProvider(bURL.Host,
+		options.GitHubOptions{
+			Team: "test-org-1:test-team-1, group:12345600",
+		},
+	)
+
+	var err error
+	session := CreateAuthorizedSession()
+	err = p.getOrgAndTeam(context.Background(), session)
+	assert.NoError(t, err)
+	err = p.checkRestrictions(context.Background(), session)
+	assert.NoError(t, err)
+
+	// This test should succeed, because of the valid org:id combination
+	p = testGitHubProvider(bURL.Host,
+		options.GitHubOptions{
+			Team: "group:12345600",
+		},
+	)
+
+	err = p.checkRestrictions(context.Background(), session)
+	assert.NoError(t, err)
+
+	// This part should fail, because user is not part of the organization:team combination
+	p = testGitHubProvider(bURL.Host,
+		options.GitHubOptions{
+			Team: "test-org-1-fail:test-team-1-fail, test-org-1-fail:12345600",
+		},
+	)
+
+	err = p.checkRestrictions(context.Background(), session)
+	assert.Error(t, err)
 }
 
 func TestGitHubProvider_getEmailWithWriteAccessToPublicRepo(t *testing.T) {

--- a/providers/github_test.go
+++ b/providers/github_test.go
@@ -178,8 +178,8 @@ func TestGitHubProvider_checkRestrictionsOrg(t *testing.T) {
 			`[ ]`,
 		},
 		"/user/teams": {
-			`[ { "name":"test-team-1", "slug":"test-team-1", "id": 12345600, "organization": { "login": "test-org-1" } } ]`,
-			`[ { "name":"test-team-2", "slug":"test-team-2", "id": 12345601, "organization": { "login": "test-org-2" } } ]`,
+			`[ { "name":"test-team-1", "slug":"test-team-1", "organization": { "login": "test-org-1" } } ]`,
+			`[ { "name":"test-team-2", "slug":"test-team-2", "organization": { "login": "test-org-2" } } ]`,
 			`[ ]`,
 		},
 	})
@@ -220,8 +220,8 @@ func TestGitHubProvider_checkRestrictionsOrgTeam(t *testing.T) {
 			`[ ]`,
 		},
 		"/user/teams": {
-			`[ { "name":"test-team-1", "slug":"test-team-1", "id": 12345600, "organization": { "login": "test-org-1" } } ]`,
-			`[ { "name":"test-team-2", "slug":"test-team-2", "id": 12345601, "organization": { "login": "test-org-2" } } ]`,
+			`[ { "name":"test-team-1", "slug":"test-team-1", "organization": { "login": "test-org-1" } } ]`,
+			`[ { "name":"test-team-2", "slug":"test-team-2", "organization": { "login": "test-org-2" } } ]`,
 			`[ ]`,
 		},
 	})
@@ -264,8 +264,8 @@ func TestGitHubProvider_checkRestrictionsTeam(t *testing.T) {
 			`[ ]`,
 		},
 		"/user/teams": {
-			`[ { "name":"test-team-1", "slug":"test-team-1", "id": 12345600, "organization": { "login": "test-org-1" } } ]`,
-			`[ { "name":"test-team-2", "slug":"test-team-2", "id": 12345601, "organization": { "login": "test-org-2" } } ]`,
+			`[ { "name":"test-team-1", "slug":"test-team-1", "organization": { "login": "test-org-1" } } ]`,
+			`[ { "name":"test-team-2", "slug":"test-team-2", "organization": { "login": "test-org-2" } } ]`,
 			`[ ]`,
 		},
 	})
@@ -275,7 +275,7 @@ func TestGitHubProvider_checkRestrictionsTeam(t *testing.T) {
 	bURL, _ := url.Parse(b.URL)
 	p := testGitHubProvider(bURL.Host,
 		options.GitHubOptions{
-			Team: "test-org-1:test-team-1, group:12345600",
+			Team: "test-org-1:test-team-1, test-org-2:test-team-2-fail",
 		},
 	)
 
@@ -286,20 +286,10 @@ func TestGitHubProvider_checkRestrictionsTeam(t *testing.T) {
 	err = p.checkRestrictions(context.Background(), session)
 	assert.NoError(t, err)
 
-	// This test should succeed, because of the valid org:id combination
-	p = testGitHubProvider(bURL.Host,
-		options.GitHubOptions{
-			Team: "group:12345600",
-		},
-	)
-
-	err = p.checkRestrictions(context.Background(), session)
-	assert.NoError(t, err)
-
 	// This part should fail, because user is not part of the organization:team combination
 	p = testGitHubProvider(bURL.Host,
 		options.GitHubOptions{
-			Team: "test-org-1-fail:test-team-1-fail, test-org-1-fail:12345600",
+			Team: "test-org-1-fail:test-team-1-fail, test-org-2-fail:test-team-2-fail",
 		},
 	)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

I added the possibility to leave --github-org empty and just set --github-team (e.g. --github-team "<org>:<team slug>"). To distinguish between valid options I added this to the function **hasOrgAndTeamAccess**. Added the function **hasTeam** for the workflow. It checks if user is member of any of theses teams.

## Motivation and Context

We needed a solution to allow team memberships across different organizations for the Github provider.

[Fix for issue 3067]( https://github.com/oauth2-proxy/oauth2-proxy/issues/3067)

## How Has This Been Tested?

Tested it locally with a test Github org and a test Github OAuth App. Did a functional test on our dev K8s.

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
- [x] I have written tests for my code changes.
