### PR TITLE
chore(CI): run tests on Go versions N and N-1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go:
+        - stable
+        - oldstable
     env:
       COVER: true
     steps:
@@ -19,7 +24,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version-file: go.mod
+        go-version: ${{ matrix.go }}
       id: go
 
     - name: Get dependencies


### PR DESCRIPTION
Run tests on CI with Go version 'stable' (latest stable release) and 'oldstable' (previous) which are currently 1.24.x and 1.23.x.
Previously the tests were only executed against the version declared in go.mod which is so far go 1.23.

<!--- Provide a general summary of your changes in the Title above -->

## Description

Change the CI workflow to run tests on rolling 'stable' and 'oldstable' releases of Go.

## Motivation and Context

So far tests only run against the Go version declared in go.mod which is 1.23.x. This means tests are not executed against the current stable release of Go (1.24.x).

## How Has This Been Tested?

The push of this PR will trigger CI!

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.
