### PR TITLE
feat: differentiate between "no available key" and error for redis sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 - [#3104](https://github.com/oauth2-proxy/oauth2-proxy/pull/3104) feat(cookie): add feature support for cookie-secret-file (@sandy2008)
 - [#3055](https://github.com/oauth2-proxy/oauth2-proxy/pull/3055) feat: support non-default authorization request response mode also for OIDC providers (@stieler-it)
 - [#3138](https://github.com/oauth2-proxy/oauth2-proxy/pull/3138) feat: make google_groups argument optional when using google provider (@sourava01)
+- [#3093](https://github.com/oauth2-proxy/oauth2-proxy/pull/3093) feat: differentiate between "no available key" and error for redis sessions (@nobletrout)
+
 
 # V7.10.0
 

--- a/pkg/sessions/redis/redis_store.go
+++ b/pkg/sessions/redis/redis_store.go
@@ -49,9 +49,12 @@ func (store *SessionStore) Save(ctx context.Context, key string, value []byte, e
 // cookie within the HTTP request object
 func (store *SessionStore) Load(ctx context.Context, key string) ([]byte, error) {
 	value, err := store.Client.Get(ctx, key)
-	if err != nil {
+	if err == redis.Nil {
+		return nil, fmt.Errorf("session does not exist")
+	} else if err != nil {
 		return nil, fmt.Errorf("error loading redis session: %v", err)
 	}
+
 	return value, nil
 }
 


### PR DESCRIPTION
## Description
Redis.nil error is a different error than a standard error, it indicates that the key is not present and not an actual error in retrieval or connection. This change differentiates that error to reduce confusion when reading logs.

string is defined here: https://github.com/redis/go-redis/blob/4e22885ca14e81e221039ce8955a5364172b638c/internal/proto/reader.go#L41

description of what `Nil` means here:
https://github.com/redis/go-redis/blob/master/redis.go#L22

## Motivation and Context

Spent a lot of time hunting down this code to figure out what was meant by "redis: nil" . Surely a `nil` error indicates success and should not fall into a golang error handling hole. This makes that missing key error a lot easier to understand.

## How Has This Been Tested?

I ran `go test` and unit tests continued to succeed.

## Checklist:

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [X] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.
