### PR TITLE
Add arcgis provider

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -15,6 +15,7 @@ body:
       description: Which identity provider are you using?
       options:
         - adfs
+        - arcgis
         - azure
         - bitbucket
         - digitalocean

--- a/.github/ISSUE_TEMPLATE/configuration-support.yml
+++ b/.github/ISSUE_TEMPLATE/configuration-support.yml
@@ -15,6 +15,7 @@ body:
       description: Which identity provider are you using?
       options:
         - adfs
+        - arcgis
         - azure
         - bitbucket
         - digitalocean

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -31,6 +31,7 @@ body:
       options:
         - new provider
         - adfs
+        - arcgis
         - azure
         - bitbucket
         - digitalocean

--- a/docs/docs/configuration/alpha_config.md
+++ b/docs/docs/configuration/alpha_config.md
@@ -462,7 +462,7 @@ Provider holds all configuration for a single provider
 (**Appears on:** [Provider](#provider))
 
 ProviderType is used to enumerate the different provider type options
-Valid options are: adfs, azure, bitbucket, digitalocean facebook, github,
+Valid options are: adfs, arcgis, azure, bitbucket, digitalocean facebook, github,
 gitlab, google, keycloak, keycloak-oidc, linkedin, login.gov, nextcloud
 and oidc.
 

--- a/docs/docs/configuration/providers/arcgis.md
+++ b/docs/docs/configuration/providers/arcgis.md
@@ -1,0 +1,32 @@
+---
+id: arcgis
+title: Arcgis
+---
+
+The Arcgis provider allows you to authenticate users on [ArcGIS Online](https://www.arcgis.com/) or on your premises [Portal for ArcGIS](https://enterprise.arcgis.com/en/portal/).
+When you are using the ArcGIS provider to authenticate user on your on premises Portal for ArcGIS, you must specify the urls via configuration, environment variable, or command line argument. Depending on your Portal for ArcGIS instance your urls may be of the form `/webcontext/sharing/rest/*`.
+
+Refer to the [OAuth2 documentation](https://developers.arcgis.com/documentation/security-and-authentication/app-authentication/tutorials/create-oauth-credentials-app-auth/) to set up the client id and client secret. Your "Redirection URI" will be `https://internalapp.yourcompany.com/oauth2/callback`.
+
+Additionally, all the groups id a user belongs to are set as part of the X-Forwarded-Groups header. e.g. 15b7fa70521e409083d445dfbe62844a,30300c6e207f4fdd8c5b06bb7ef006ab,8d0d64cc4d054aefb55648c0783a740f. Note that groups ids are stored as names are not unique (cf. [ESRI Support](https://support.esri.com/en-us/bug/it-is-possible-to-have-two-groups-with-the-same-name-in-bug-000128049)).
+
+
+Example of configuration for ArcGIS Online:
+```
+    -provider arcgis
+    -provider-display-name="ArcGIS Online"
+    -client-id <from arcgis admin>
+    -client-secret <from arcgis admin>
+```
+
+Example of configuration for Portal for ArcGIS with URL https://gis.company.com/geoportail:
+```
+    -provider arcgis
+    -provider-display-name="Geoportail"
+    -client-id <from arcgis admin>
+    -client-secret <from arcgis admin>
+    -login-url="https://gis.company.com/geoportail/sharing/rest/oauth2/authorize"
+    -redeem-url="https://gis.company.com/geoportail/sharing/rest/oauth2/token"
+    -validate-url="https://gis.company.com/geoportail/sharing/rest/community/self"
+```
+

--- a/docs/docs/configuration/providers/index.md
+++ b/docs/docs/configuration/providers/index.md
@@ -9,6 +9,7 @@ with Redirect URI(s) for the domain you intend to run `oauth2-proxy` on.
 Valid providers are :
 
 - [ADFS](adfs.md)
+- [Arcgis](arcgis.md)
 - [Bitbucket](bitbucket.md)
 - [DigitalOcean](digitalocean.md)
 - [Facebook](facebook.md)

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -32,6 +32,7 @@ const sidebars = {
           },
           items: [
             "configuration/providers/adfs",
+            "configuration/providers/arcgis",
             "configuration/providers/azure",
             "configuration/providers/bitbucket",
             "configuration/providers/digitalocean",

--- a/pkg/apis/options/providers.go
+++ b/pkg/apis/options/providers.go
@@ -97,7 +97,7 @@ type Provider struct {
 }
 
 // ProviderType is used to enumerate the different provider type options
-// Valid options are: adfs, azure, bitbucket, digitalocean facebook, github,
+// Valid options are: adfs, arcgis, azure, bitbucket, digitalocean facebook, github,
 // gitlab, google, keycloak, keycloak-oidc, linkedin, login.gov, nextcloud
 // and oidc.
 type ProviderType string
@@ -105,6 +105,9 @@ type ProviderType string
 const (
 	// ADFSProvider is the provider type for ADFS
 	ADFSProvider ProviderType = "adfs"
+
+	// ArcgisProvider is the provider type for Arcgis
+	ArcgisProvider ProviderType = "arcgis"
 
 	// AzureProvider is the provider type for Azure
 	AzureProvider ProviderType = "azure"

--- a/providers/arcgis.go
+++ b/providers/arcgis.go
@@ -1,0 +1,118 @@
+package providers
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/sessions"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/requests"
+)
+
+// ArcgisProvider represents an ArcGIS based Identity Provider
+type ArcgisProvider struct {
+	*ProviderData
+}
+
+type arcgisGroups []struct {
+	Id string `json:"id"`
+}
+
+type arcgisUserinfo struct {
+	Username string       `json:"username"`
+	Email    string       `json:"email"`
+	Fullname string       `json:"fullName"`
+	Groups   arcgisGroups `json:"groups"`
+}
+
+var _ Provider = (*ArcgisProvider)(nil)
+
+const (
+	arcgisProviderName = "Arcgis"
+)
+
+var (
+	// Default Login URL for ArcGIS.
+	// Pre-parsed URL of https://www.arcgis.com/sharing/rest/oauth2/authorize.
+	arcgisDefaultLoginURL = &url.URL{
+		Scheme: "https",
+		Host:   "www.arcgis.com",
+		Path:   "/sharing/rest/oauth2/authorize",
+	}
+
+	// Default Redeem URL for ArcGIS.
+	// Pre-parsed URL of https://wwww.arcgis.com/sharing/rest/oauth2/token.
+	arcgisDefaultRedeemURL = &url.URL{
+		Scheme: "https",
+		Host:   "www.arcgis.com",
+		Path:   "/sharing/rest/oauth2/token",
+	}
+
+	// Validate URL for ArcGIS.
+	// Pre-parsed URL of https://www.arcgis.com/sharing/rest/community/self?f=json.
+	arcgisValidateURL = &url.URL{
+		Scheme: "https",
+		Host:   "www.arcgis.com",
+		Path:   "/sharing/rest/community/self",
+	}
+)
+
+// NewArcgisProvider initiates a new ArcgisProvider
+func NewArcgisProvider(p *ProviderData) *ArcgisProvider {
+	p.setProviderDefaults(providerDefaults{
+		name:        arcgisProviderName,
+		loginURL:    arcgisDefaultLoginURL,
+		redeemURL:   arcgisDefaultRedeemURL,
+		validateURL: arcgisValidateURL,
+	})
+	// ArcGIS ValidateURL requires json output to be forced
+	p.ValidateURL.RawQuery = "f=json"
+	return &ArcgisProvider{ProviderData: p}
+}
+
+// GetUserInfo returns the arcgisUserinfo
+func (p *ArcgisProvider) GetUserInfo(ctx context.Context, s *sessions.SessionState) (*arcgisUserinfo, error) {
+	var userinfo arcgisUserinfo
+
+	err := requests.New(p.ValidateURL.String()).
+		WithContext(ctx).
+		SetHeader("Authorization", tokenTypeBearer+" "+s.AccessToken).
+		Do().
+		UnmarshalInto(&userinfo)
+	if err != nil {
+		return nil, fmt.Errorf("error getting user info: %v", err)
+	}
+
+	return &userinfo, nil
+}
+
+// EnrichSession updates the Username, Email, Fullname and Groups after the initial Redeem
+func (p *ArcgisProvider) EnrichSession(ctx context.Context, s *sessions.SessionState) error {
+	// Retrieve user info
+	userinfo, err := p.GetUserInfo(ctx, s)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve user info: %v", err)
+	}
+	if userinfo.Username != "" {
+		s.User = userinfo.Username
+	}
+	if userinfo.Email != "" {
+		s.Email = userinfo.Email
+	}
+	if userinfo.Fullname != "" {
+		s.PreferredUsername = userinfo.Fullname
+	}
+	if len(userinfo.Groups) > 0 {
+		for _, group := range userinfo.Groups {
+			if group.Id != "" {
+				s.Groups = append(s.Groups, group.Id)
+			}
+		}
+	}
+	return nil
+}
+
+// ValidateSession validates the AccessToken
+func (p *ArcgisProvider) ValidateSession(ctx context.Context, s *sessions.SessionState) bool {
+	return validateToken(ctx, p, s.AccessToken, makeAuthorizationHeader(tokenTypeBearer, s.AccessToken, nil))
+}

--- a/providers/arcgis_test.go
+++ b/providers/arcgis_test.go
@@ -1,0 +1,141 @@
+package providers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/sessions"
+	"github.com/stretchr/testify/assert"
+)
+
+const jsonParam = "f=json"
+
+func testArcgisProvider(hostname string) *ArcgisProvider {
+	p := NewArcgisProvider(
+		&ProviderData{
+			ProviderName: "",
+			LoginURL:     &url.URL{},
+			RedeemURL:    &url.URL{},
+			ProfileURL:   &url.URL{},
+			ValidateURL:  &url.URL{},
+		})
+	if hostname != "" {
+		updateURL(p.Data().LoginURL, hostname)
+		updateURL(p.Data().RedeemURL, hostname)
+		updateURL(p.Data().ProfileURL, hostname)
+		updateURL(p.Data().ValidateURL, hostname)
+	}
+	return p
+}
+
+func testArcgisBackend() *httptest.Server {
+	authResponse := `
+		{
+			"access_token": "my_access_token"
+		 }
+	`
+	userInfo := `
+		{
+			"fullName": "Guinea Pig",
+			"username": "guineapig",
+			"email": "guineapig@email.com",
+			"groups": [{
+				"id": "abc"
+			},{
+				"id": "def"
+			}]
+		}
+	`
+
+	authHeader := "Bearer arcgis_access_token"
+
+	return httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/sharing/rest/oauth2/authorize":
+				w.WriteHeader(200)
+				w.Write([]byte(authResponse))
+			case "/sharing/rest/community/self":
+				if r.Header["Authorization"][0] == authHeader {
+					w.WriteHeader(200)
+					if r.URL.RawQuery == "f=json" {
+						w.Write([]byte(userInfo))
+					}
+				} else {
+					w.WriteHeader(401)
+				}
+			default:
+				w.WriteHeader(200)
+			}
+		}))
+}
+
+func TestArcgisProviderDefaults(t *testing.T) {
+	p := testArcgisProvider("")
+	assert.NotEqual(t, nil, p)
+	assert.Equal(t, "Arcgis", p.Data().ProviderName)
+	assert.Equal(t, "https://www.arcgis.com/sharing/rest/oauth2/authorize",
+		p.Data().LoginURL.String())
+	assert.Equal(t, "https://www.arcgis.com/sharing/rest/oauth2/token",
+		p.Data().RedeemURL.String())
+	assert.Equal(t, "https://www.arcgis.com/sharing/rest/community/self?"+jsonParam,
+		p.Data().ValidateURL.String())
+}
+
+func TestArcgisProviderOverrides(t *testing.T) {
+	p := NewArcgisProvider(
+		&ProviderData{
+			LoginURL: &url.URL{
+				Scheme: "https",
+				Host:   "example.com",
+				Path:   "/portal/sharing/rest/oauth2/authorize"},
+			RedeemURL: &url.URL{
+				Scheme: "https",
+				Host:   "example.com",
+				Path:   "/portal/sharing/rest/oauth2/api/v1/token"},
+			ValidateURL: &url.URL{
+				Scheme:   "https",
+				Host:     "example.com",
+				Path:     "/portal/sharing/rest/community/self",
+				RawQuery: jsonParam},
+		})
+	assert.NotEqual(t, nil, p)
+	assert.Equal(t, "Arcgis", p.Data().ProviderName)
+	assert.Equal(t, "https://example.com/portal/sharing/rest/oauth2/authorize",
+		p.Data().LoginURL.String())
+	assert.Equal(t, "https://example.com/portal/sharing/rest/oauth2/api/v1/token",
+		p.Data().RedeemURL.String())
+	assert.Equal(t, "https://example.com/portal/sharing/rest/community/self?"+jsonParam,
+		p.Data().ValidateURL.String())
+}
+
+func TestArcgisProviderEnrichSession(t *testing.T) {
+	b := testArcgisBackend()
+	bURL, err := url.Parse(b.URL)
+	assert.Nil(t, err)
+	p := testArcgisProvider(bURL.Host)
+	session := &sessions.SessionState{AccessToken: "arcgis_access_token"}
+	err = p.EnrichSession(context.Background(), session)
+	assert.Equal(t, session.PreferredUsername, "Guinea Pig")
+	assert.Equal(t, session.Email, "guineapig@email.com")
+	assert.Equal(t, session.User, "guineapig")
+	assert.Equal(t, len(session.Groups), 2)
+	assert.Equal(t, session.Groups[0], "abc")
+	assert.Equal(t, session.Groups[1], "def")
+	assert.Nil(t, err)
+	b.Close()
+}
+
+func TestArcgisProviderEnrichSessionFailsWithBadToken(t *testing.T) {
+	b := testArcgisBackend()
+	bURL, err := url.Parse(b.URL)
+	assert.Nil(t, err)
+	p := testArcgisProvider(bURL.Host)
+	session := &sessions.SessionState{AccessToken: "unexpected_arcgis_access_token"}
+	err = p.EnrichSession(context.Background(), session)
+	assert.NotNil(t, err)
+	b.Close()
+}

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -39,6 +39,8 @@ func NewProvider(providerConfig options.Provider) (Provider, error) {
 	switch providerConfig.Type {
 	case options.ADFSProvider:
 		return NewADFSProvider(providerData, providerConfig), nil
+	case options.ArcgisProvider:
+		return NewArcgisProvider(providerData), nil
 	case options.AzureProvider:
 		return NewAzureProvider(providerData, providerConfig.AzureConfig), nil
 	case options.MicrosoftEntraIDProvider:
@@ -182,7 +184,7 @@ func parseCodeChallengeMethod(providerConfig options.Provider) string {
 
 func providerRequiresOIDCProviderVerifier(providerType options.ProviderType) (bool, error) {
 	switch providerType {
-	case options.BitbucketProvider, options.DigitalOceanProvider, options.FacebookProvider, options.GitHubProvider,
+	case options.ArcgisProvider, options.BitbucketProvider, options.DigitalOceanProvider, options.FacebookProvider, options.GitHubProvider,
 		options.GoogleProvider, options.KeycloakProvider, options.LinkedInProvider, options.LoginGovProvider, options.NextCloudProvider:
 		return false, nil
 	case options.ADFSProvider, options.AzureProvider, options.GitLabProvider, options.KeycloakOIDCProvider, options.OIDCProvider, options.MicrosoftEntraIDProvider:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Add `arcgis` provider (https://www.arcgis.com) a GIS (Geographic Information System) provider

## Description

The Arcgis provider allows you to authenticate users on [ArcGIS Online](https://www.arcgis.com/) or on your premises [Portal for ArcGIS](https://enterprise.arcgis.com/en/portal/).
When you are using the ArcGIS provider to authenticate user on your on premises Portal for ArcGIS, you must specify the urls via configuration, environment variable, or command line argument. Depending on your Portal for ArcGIS instance your urls may be of the form `/webcontext/sharing/rest/*`. 

Refer to the [OAuth2 documentation](https://developers.arcgis.com/documentation/security-and-authentication/app-authentication/tutorials/create-oauth-credentials-app-auth/) to set up the client id and client secret. Your "Redirection URI" will be `https://internalapp.yourcompany.com/oauth2/callback`.

Additionally, all the groups id a user belongs to are set as part of the X-Forwarded-Groups header. e.g. 15b7fa70522e408083d445dfbe62944a,30300c6e207f4fed8c5b06bb7ef006ab,8ded64cc4d054aefb55648c0783a740f. Note that groups ids are stored as names are not unique (cf. [ESRI Support](https://support.esri.com/en-us/bug/it-is-possible-to-have-two-groups-with-the-same-name-in-bug-000128049)).


Example of configuration for ArcGIS Online:
```
    -provider arcgis
    -provider-display-name="ArcGIS Online"
    -client-id <from arcgis admin>
    -client-secret <from arcgis admin>
```

Example of configuration for Portal for ArcGIS with URL https://gis.company.com/geoportail:
```
    -provider arcgis
    -provider-display-name="Geoportail"
    -client-id <from arcgis admin>
    -client-secret <from arcgis admin>
    -login-url="https://gis.company.com/geoportail/sharing/rest/oauth2/authorize"
    -redeem-url="https://gis.company.com/geoportail/sharing/rest/oauth2/token"
    -validate-url="https://gis.company.com/geoportail/sharing/rest/community/self"
```

## Motivation and Context

I need this provider for an architecture. It allows authenticating on ArcGIS Systems.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Tested locally with ArcGIS accounts for both ArcGIS Online and ArcGIS Enterprise
- Tested deployed in an Openshift environment with environment variables configured
- Added a dedicated test file for `arcgis` provider

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My change requires a change to the documentation or CHANGELOG.
- [X] I have updated the documentation/CHANGELOG accordingly.
- [X] I have created a feature (non-master) branch for my PR.
- [X] I have written tests for my code changes.
