### PR TITLE
feat: support MS Entra ID app role authorization

### DIFF
--- a/docs/docs/configuration/alpha_config.md
+++ b/docs/docs/configuration/alpha_config.md
@@ -395,6 +395,7 @@ character.
 | ----- | ---- | ----------- |
 | `allowedTenants` | _[]string_ | AllowedTenants is a list of allowed tenants. In case of multi-tenant apps, incoming tokens are<br/>issued by different issuers and OIDC issuer verification needs to be disabled.<br/>When not specified, all tenants are allowed. Redundant for single-tenant apps<br/>(regular ID token validation matches the issuer). |
 | `federatedTokenAuth` | _bool_ | FederatedTokenAuth enable oAuth2 client authentication with federated token projected<br/>by Entra Workload Identity plugin, instead of client secret. |
+| `roles` | _[]string_ | Role enables to restrict login to users with app role |
 
 ### OIDCOptions
 

--- a/docs/docs/configuration/providers/keycloak_oidc.md
+++ b/docs/docs/configuration/providers/keycloak_oidc.md
@@ -7,7 +7,7 @@ title: Keycloak OIDC
 
 | Flag             | Toml Field      | Type           | Description                                                                                                        | Default |
 | ---------------- | --------------- | -------------- | ------------------------------------------------------------------------------------------------------------------ | ------- |
-| `--allowed-role` | `allowed_roles` | string \| list | restrict logins to users with this role (may be given multiple times). Only works with the keycloak-oidc provider. |         |
+| `--allowed-role` | `allowed_roles` | string \| list | Restrict logins to users with this role (may be given multiple times). Works with the keycloak-oidc and ms-entra-id provider. |         |
 
 ## Usage
 

--- a/docs/docs/configuration/providers/ms_entra_id.md
+++ b/docs/docs/configuration/providers/ms_entra_id.md
@@ -13,6 +13,7 @@ The provider is OIDC-compliant, so all the OIDC parameters are honored. Addition
 | --------------------------- | -------------------------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
 | `--entra-id-allowed-tenant` | `entra_id_allowed_tenants` | string \| list | List of allowed tenants. In case of multi-tenant apps, incoming tokens are issued by different issuers and OIDC issuer verification needs to be disabled. When not specified, all tenants are allowed. Redundant for single-tenant apps (regular ID token validation matches the issuer). |         |
 | `--entra-id-federated-token-auth` | `entra_id_federated_token_auth` | boolean | Enable oAuth2 client authentication with federated token projected by Entra Workload Identity plugin, instead of client secret.   | false |
+| `--allowed-role` | `allowed_roles` | string \| list | Restrict logins to users with this app role (may be given multiple times). Works with the keycloak-oidc and ms-entra-id provider. |         |
 
 ## Configure App registration
 To begin, create an App registration, set a redirect URI, and generate a secret. All account types are supported, including single-tenant, multi-tenant, multi-tenant with Microsoft accounts, and Microsoft accounts only.

--- a/pkg/apis/options/legacy_options.go
+++ b/pkg/apis/options/legacy_options.go
@@ -604,7 +604,7 @@ func legacyProviderFlagSet() *pflag.FlagSet {
 
 	flagSet.String("user-id-claim", OIDCEmailClaim, "(DEPRECATED for `oidc-email-claim`) which claim contains the user ID")
 	flagSet.StringSlice("allowed-group", []string{}, "restrict logins to members of this group (may be given multiple times)")
-	flagSet.StringSlice("allowed-role", []string{}, "(keycloak-oidc) restrict logins to members of these roles (may be given multiple times)")
+	flagSet.StringSlice("allowed-role", []string{}, "(keycloak-oidc, ms-entra-id) restrict logins to members of these roles (may be given multiple times)")
 	flagSet.String("backend-logout-url", "", "url to perform a backend logout, {id_token} can be used as placeholder for the id_token")
 
 	return flagSet
@@ -770,6 +770,7 @@ func (l *LegacyProvider) convert() (Providers, error) {
 		provider.MicrosoftEntraIDConfig = MicrosoftEntraIDOptions{
 			AllowedTenants:     l.EntraIDAllowedTenants,
 			FederatedTokenAuth: l.EntraIDFederatedTokenAuth,
+			Roles:              l.AllowedRoles,
 		}
 	}
 

--- a/pkg/apis/options/providers.go
+++ b/pkg/apis/options/providers.go
@@ -176,6 +176,9 @@ type MicrosoftEntraIDOptions struct {
 	// FederatedTokenAuth enable oAuth2 client authentication with federated token projected
 	// by Entra Workload Identity plugin, instead of client secret.
 	FederatedTokenAuth bool `json:"federatedTokenAuth,omitempty"`
+
+	// Role enables to restrict login to users with app role
+	Roles []string `json:"roles,omitempty"`
 }
 
 type ADFSOptions struct {

--- a/providers/util.go
+++ b/providers/util.go
@@ -1,11 +1,14 @@
 package providers
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/sessions"
 	"golang.org/x/oauth2"
 )
 
@@ -73,4 +76,19 @@ func formatGroup(rawGroup interface{}) (string, error) {
 		return "", err
 	}
 	return string(jsonGroup), nil
+}
+
+// extractAccessTokenPayload extracts the access token payload (JSON string in bytes)
+func extractAccessTokenPayload(s *sessions.SessionState) ([]byte, error) {
+	parts := strings.Split(s.AccessToken, ".")
+	if len(parts) < 2 {
+		return nil, fmt.Errorf("malformed access token, expected 3 parts got %d", len(parts))
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("malformed access token, couldn't extract jwt payload: %v", err)
+	}
+
+	return payload, nil
 }


### PR DESCRIPTION
## Description

Using configuration '--allowed-role' to support Microsoft Entra ID app role authorization.

## Motivation and Context

Hi, I'm from Microsoft.

My daily workload typically involves doing authorization via Azure RBAC.
Due to our Azure tenant policy settings, neither Microsoft.GraphAPI nor 'groups' is available for user authentication by oauth2-proxy. Setting app role registration to users and then implementing authorization by looking at the 'roles' claim of each access token is the only one possible solution. After looking through oauth2-proxy implementation, I added authorization by app roles to provider ms-entra-id, which was built on top of current '--allowed-role' setting.
To test this feature, I created my own Application in my Azure Cloud. And it was able to see and check user's roles available in every JWT token, then made sure the user had one of authorized roles.

Authorization through app role is part of Azure RBAC ecosystem. You can learn more about app role here: [Add app roles to your application and receive them in the token](https://learn.microsoft.com/en-us/entra/identity-platform/howto-add-app-roles-in-apps#usage-scenario-of-app-roles)

## How Has This Been Tested?

1. I wrote a unit-test in ms_entra_id_test.go file.
2. I created my own Enterprise Application in my Azure Cloud. After assigning one of app roles to my account, oauth2-proxy could successfully extract roles I had, and checked the roles in the authorization process as a whole.
3. I also updated the documentation.

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
- [x] I have written tests for my code changes.