### PR TITLE
chore(deps): upgrade to latest golang v1.23.x release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/oauth2-proxy/oauth2-proxy/v7
 
-go 1.23.8
+go 1.23.10
 
 require (
 	cloud.google.com/go/compute/metadata v0.6.0


### PR DESCRIPTION
Update golang version to v1.23.10

## Description

Bump go version to close some CVEs:
* CVE-2025-22874
* CVE-2025-4673
* CVE-2025-0193

## Motivation and Context

Fixes #3103 

## How Has This Been Tested?

Ran govulncheck with go 1.23.10, no vulnerabilities discovered.
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My change requires a change to the documentation or CHANGELOG.
- [/] I have updated the documentation/CHANGELOG accordingly.
- [/] I have created a feature (non-master) branch for my PR.
- [/] I have written tests for my code changes.
