### PR TITLE
Makefile: simplify validate-go-version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,13 +36,9 @@ REPOSITORY ?= oauth2-proxy
 DATE := $(shell date +"%Y%m%d")
 .NOTPARALLEL:
 
-GO_MAJOR_VERSION = $(shell $(GO) version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f1)
-GO_MINOR_VERSION = $(shell $(GO) version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f2)
-
-GO_MOD_VERSION = $(shell sed -En 's/^go ([[:digit:]]\.[[:digit:]]+)\.[[:digit:]]+/\1/p' go.mod)
-MINIMUM_SUPPORTED_GO_MAJOR_VERSION = $(shell echo ${GO_MOD_VERSION} | cut -d' ' -f1 | cut -d'.' -f1)
-MINIMUM_SUPPORTED_GO_MINOR_VERSION = $(shell echo ${GO_MOD_VERSION} | cut -d' ' -f1 | cut -d'.' -f2)
-GO_VERSION_VALIDATION_ERR_MSG = Golang version is not supported, please update to at least $(MINIMUM_SUPPORTED_GO_MAJOR_VERSION).$(MINIMUM_SUPPORTED_GO_MINOR_VERSION)
+# From go1.21 go will transparently download the toolchain declared in go.mod. https://go.dev/doc/toolchain
+# We don't need to keep this message updated: the important info is in go.mod.
+GO_VERSION_VALIDATION_ERR_MSG = Golang version is not supported, please update to at least go1.21
 
 ifeq ($(COVER),true)
 TESTCOVER ?= -coverprofile c.out
@@ -158,15 +154,7 @@ lint: validate-go-version ## Lint all files using golangci-lint
 
 .PHONY: validate-go-version
 validate-go-version: ## Validate Go environment requirements
-	@if [ $(GO_MAJOR_VERSION) -gt $(MINIMUM_SUPPORTED_GO_MAJOR_VERSION) ]; then \
-		exit 0 ;\
-	elif [ $(GO_MAJOR_VERSION) -lt $(MINIMUM_SUPPORTED_GO_MAJOR_VERSION) ]; then \
-		echo '$(GO_VERSION_VALIDATION_ERR_MSG)';\
-		exit 1; \
-	elif [ $(GO_MINOR_VERSION) -lt $(MINIMUM_SUPPORTED_GO_MINOR_VERSION) ] ; then \
-		echo '$(GO_VERSION_VALIDATION_ERR_MSG)';\
-		exit 1; \
-	fi
+	@$(GO) list . >/dev/null || { echo '$(GO_VERSION_VALIDATION_ERR_MSG)'; exit 1; }
 
 # local-env can be used to interact with the local development environment
 # eg:


### PR DESCRIPTION
## Description

Since Go 1.21 the go toolchain validates strictly the "go" version directive in go.mod, and downloads and uses the requested toolchain if necessary. See https://go.dev/doc/toolchain

So we can just run "go list" to tell the Go toolchain to validate our build environment according to go.mod.

## Motivation and Context

Faster 'make'. Simpler Makefile.

## How Has This Been Tested?

```console
$ make validate-go-version GO=go1.23.11 
go: downloading go1.24.5 (darwin/arm64)
```

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.
