### PR TITLE
fix: Gitea team membership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [#2273](https://github.com/oauth2-proxy/oauth2-proxy/pull/2273) feat: add Cidaas provider (@Bibob7, @Teko012)
 - [#3166](https://github.com/oauth2-proxy/oauth2-proxy/pull/3166) chore(dep): upgrade to latest golang 1.24.6 (@tuunit)
 - [#3156](https://github.com/oauth2-proxy/oauth2-proxy/pull/3156) feat: allow disable-keep-alives configuration for upstream (@jet-go)
+- [#3150](https://github.com/oauth2-proxy/oauth2-proxy/pull/3150) fix: Gitea team membership (@MagicRB, @tuunit)
 
 # V7.11.0
 

--- a/docs/docs/configuration/providers/gitea.md
+++ b/docs/docs/configuration/providers/gitea.md
@@ -1,10 +1,10 @@
 ---
 id: gitea
-title: Gitea
+title: Gitea / Forgejo
 ---
 
 :::note
-This is not actually its own provider. For more details and options please refer to the [GitHub Provider Options](github.md)
+This is not actually a fully serparate provider. For more details and options please refer to the [GitHub Provider Options](github.md)
 :::
 
 1. Create a new application: `https://< your gitea host >/user/settings/applications`

--- a/providers/github.go
+++ b/providers/github.go
@@ -464,6 +464,7 @@ func (p *GitHubProvider) getOrgs(ctx context.Context, s *sessions.SessionState) 
 
 	type Organization struct {
 		Login string `json:"login"`
+		Name string `json:"name"`
 	}
 
 	pn := 1
@@ -490,8 +491,12 @@ func (p *GitHubProvider) getOrgs(ctx context.Context, s *sessions.SessionState) 
 		}
 
 		for _, org := range orgs {
-			logger.Printf("Member of Github Organization:%q", org.Login)
-			s.Groups = append(s.Groups, org.Login)
+			orgName := org.Login
+			if orgName == "" {
+				orgName = org.Name
+			}
+			logger.Printf("Member of Github Organization:%q", orgName)
+			s.Groups = append(s.Groups, orgName)
 		}
 		pn++
 	}
@@ -506,6 +511,7 @@ func (p *GitHubProvider) getTeams(ctx context.Context, s *sessions.SessionState)
 		Slug string `json:"slug"`
 		Org  struct {
 			Login string `json:"login"`
+			Name string `json:"name"`
 		} `json:"organization"`
 	}
 
@@ -533,7 +539,15 @@ func (p *GitHubProvider) getTeams(ctx context.Context, s *sessions.SessionState)
 		}
 
 		for _, team := range teams {
-			logger.Printf("Member of Github Organization/Team: %q/%q", team.Org.Login, team.Slug)
+			orgName := team.Org.Login
+			if orgName == "" {
+				orgName = team.Org.Name
+			}
+			teamName := team.Slug
+			if teamName == "" {
+				teamName = team.Name
+			}
+			logger.Printf("Member of Github Organization/Team:%q/%q", orgName, teamName)
 			s.Groups = append(s.Groups, fmt.Sprintf("%s%s%s", team.Org.Login, orgTeamSeparator, team.Slug))
 		}
 


### PR DESCRIPTION
Fixes https://github.com/oauth2-proxy/oauth2-proxy/issues/3048

<!--- Provide a general summary of your changes in the Title above -->

## Description

Gitea doesn't properly fill in all the fields like GitHub, so implement a series of fallbacks.

<!--- Describe your changes in detail -->

## Motivation and Context

When using `oauth2-proxy` with the GitHub provider backed by Gitea, team/org membership is broken.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

We've been running a slightly older version of this in production for 4 months. (one line change)

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.

Not sure if this warrants tests or a changelog entry, if it does ill add those :) .
