### PR TITLE
chore(dep): upgrade to latest golang 1.24.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Release Highlights
 
+- 🕵️‍♀️ Vulnerabilities have been addressed
+  - [CVE-2025-47907](https://pkg.go.dev/vuln/GO-2025-3849)
+
 ## Important Notes
 
 ## Breaking Changes
@@ -9,6 +12,7 @@
 ## Changes since v7.11.0
 
 - [#2273](https://github.com/oauth2-proxy/oauth2-proxy/pull/2273) feat: add Cidaas provider (@Bibob7, @Teko012)
+- [#3166](https://github.com/oauth2-proxy/oauth2-proxy/pull/3166) chore(dep): upgrade to latest golang 1.24.6 (@tuunit)
 
 # V7.11.0
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/oauth2-proxy/oauth2-proxy/v7
 
-go 1.24.5
+go 1.24.6
 
 require (
 	cloud.google.com/go/compute/metadata v0.7.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Upgrade to golang 1.24.6 to fix CVE: https://pkg.go.dev/vuln/GO-2025-3849

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have updated the documentation/CHANGELOG accordingly.
- [X] I have created a feature (non-master) branch for my PR.
