### PR TITLE
fix(deps): Revert actions/upload-pages-artifact action to v3

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,7 +49,7 @@ jobs:
           npm run build
       
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./docs/build
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Downgrade actions/upload-pages-artifact action to v3 (reverts #3194)

## Motivation and Context

`actions/upload-pages-artifact@v4` excludes dotfiles which causes the `.nojekyll` file to be excluded and the Github page to break (see https://github.com/actions/upload-pages-artifact/issues/129)

Fixes #3208

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.
