### PR TITLE
feat: added updated google endpoints so id token has full profile info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [#3197](https://github.com/oauth2-proxy/oauth2-proxy/pull/3197) fix: NewRemoteKeySet is not using DefaultHTTPClient (@rsrdesarrollo / @tuunit)
 - [#3292](https://github.com/oauth2-proxy/oauth2-proxy/pull/3292) chore(deps): upgrade gomod and bump to golang v1.25.5 (@tuunit)
+- [#3236](https://github.com/oauth2-proxy/oauth2-proxy/pull/3236) Updated the Google Provider's token endpoint to match Google OIDC's token endpoint. As listed in https://accounts.google.com/.well-known/openid-configuration this token endpoint provides additional claims in the id token such as profile photo and full name (@pixeldrew)
 
 # V7.13.0
 

--- a/providers/google.go
+++ b/providers/google.go
@@ -70,19 +70,26 @@ var (
 	}
 
 	// Default Redeem URL for Google.
-	// Pre-parsed URL of https://www.googleapis.com/oauth2/v3/token.
+	// pulled from https://accounts.google.com/.well-known/openid-configuration
 	googleDefaultRedeemURL = &url.URL{
 		Scheme: "https",
-		Host:   "www.googleapis.com",
-		Path:   "/oauth2/v3/token",
+		Host:   "oauth2.googleapis.com",
+		Path:   "/token",
 	}
 
 	// Default Validation URL for Google.
-	// Pre-parsed URL of https://www.googleapis.com/oauth2/v1/tokeninfo.
+	// https://developers.google.com/identity/sign-in/android/backend-auth#calling-the-tokeninfo-endpoint
 	googleDefaultValidateURL = &url.URL{
 		Scheme: "https",
-		Host:   "www.googleapis.com",
-		Path:   "/oauth2/v1/tokeninfo",
+		Host:   "oauth2.googleapis.com",
+		Path:   "/tokeninfo",
+	}
+
+	// pulled from https://openidconnect.googleapis.com/v1/userinfo
+	googleDefaultProfileURL = &url.URL{
+		Scheme: "https",
+		Host:   "openidconnect.googleapis.com",
+		Path:   "/v1/userinfo",
 	}
 )
 
@@ -92,7 +99,7 @@ func NewGoogleProvider(p *ProviderData, opts options.GoogleOptions) (*GoogleProv
 		name:        googleProviderName,
 		loginURL:    googleDefaultLoginURL,
 		redeemURL:   googleDefaultRedeemURL,
-		profileURL:  nil,
+		profileURL:  googleDefaultProfileURL,
 		validateURL: googleDefaultValidateURL,
 		scope:       googleDefaultScope,
 	})

--- a/providers/google_test.go
+++ b/providers/google_test.go
@@ -51,9 +51,9 @@ func TestNewGoogleProvider(t *testing.T) {
 
 	g.Expect(providerData.ProviderName).To(Equal("Google"))
 	g.Expect(providerData.LoginURL.String()).To(Equal("https://accounts.google.com/o/oauth2/auth?access_type=offline"))
-	g.Expect(providerData.RedeemURL.String()).To(Equal("https://www.googleapis.com/oauth2/v3/token"))
-	g.Expect(providerData.ProfileURL.String()).To(Equal(""))
-	g.Expect(providerData.ValidateURL.String()).To(Equal("https://www.googleapis.com/oauth2/v1/tokeninfo"))
+	g.Expect(providerData.RedeemURL.String()).To(Equal("https://oauth2.googleapis.com/token"))
+	g.Expect(providerData.ProfileURL.String()).To(Equal("https://openidconnect.googleapis.com/v1/userinfo"))
+	g.Expect(providerData.ValidateURL.String()).To(Equal("https://oauth2.googleapis.com/tokeninfo"))
 	g.Expect(providerData.Scope).To(Equal("profile email"))
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Changed the OIDC token endpoint so that I can get the firstname/lastname in the OIDC ID token.

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

This pulls a different google ID token that has the profile information of the user (firstName/lastName).

<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/oauth2-proxy/oauth2-proxy/issues/3181

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Locally and used in my environment.

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My change requires a change to the documentation or CHANGELOG.
- [X] I have updated the documentation/CHANGELOG accordingly.
- [X] I have created a feature (non-master) branch for my PR.
- [X] I have written tests for my code changes.
