### PR TITLE
feat: add option to use organization id for preferred username in Google Provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#3228](https://github.com/oauth2-proxy/oauth2-proxy/pull/3228) fix: use GetSecret() in ticket.go makeCookie to respect cookie-secret-file (@stagswtf)
 - [#3244](https://github.com/oauth2-proxy/oauth2-proxy/pull/3244) chore(deps): upgrade to latest go1.25.3 (@tuunit)
 - [#3238](https://github.com/oauth2-proxy/oauth2-proxy/pull/3238) chore: Replace pkg/clock with narrowly targeted stub clocks (@dsymonds)
+- [#3237](https://github.com/oauth2-proxy/oauth2-proxy/pull/3237) - feat: add option to use organization id for preferred username in Google Provider (@pixeldrew)
 
 # V7.12.0
 

--- a/docs/docs/configuration/alpha_config.md
+++ b/docs/docs/configuration/alpha_config.md
@@ -252,6 +252,8 @@ Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 | `serviceAccountJson` | _string_ | ServiceAccountJSON is the path to the service account json credentials |
 | `useApplicationDefaultCredentials` | _bool_ | UseApplicationDefaultCredentials is a boolean whether to use Application Default Credentials instead of a ServiceAccountJSON |
 | `targetPrincipal` | _string_ | TargetPrincipal is the Google Service Account used for Application Default Credentials |
+| `useOrganizationID` | _bool_ | UseOrganizationId indicates whether to use the organization ID as the UserName claim |
+| `adminAPIUserScope` | _string_ | admin scope needed for fetching user organization information from admin api, can be one of cloud, user or defaults to readonly |
 
 ### Header
 

--- a/docs/docs/configuration/providers/google.md
+++ b/docs/docs/configuration/providers/google.md
@@ -5,13 +5,15 @@ title: Google (default)
 
 ## Config Options
 
-| Flag                                           | Toml Field                                   | Type   | Description                                                                                      | Default                                            |
-| ---------------------------------------------- | -------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------ | -------------------------------------------------- |
-| `--google-admin-email`                         | `google_admin_email`                         | string | the google admin to impersonate for api calls                                                    |                                                    |
-| `--google-group`                               | `google_groups`                              | string | restrict logins to members of this google group (may be given multiple times). If not specified and service account or default credentials are configured, all user groups will be allowed.                   |                                                    |
-| `--google-service-account-json`                | `google_service_account_json`                | string | the path to the service account json credentials                                                 |                                                    |
-| `--google-use-application-default-credentials` | `google_use_application_default_credentials` | bool   | use application default credentials instead of service account json (i.e. GKE Workload Identity) |                                                    |
-| `--google-target-principal`                    | `google_target_principal`                    | bool   | the target principal to impersonate when using ADC                                               | defaults to the service account configured for ADC |
+| Flag                                            | Toml Field                                   | Type   | Description                                                                                                                                                                                 | Default                                             |
+|-------------------------------------------------|----------------------------------------------| ------ |---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------|
+| `--google-admin-email`                          | `google_admin_email`                         | string | the google admin to impersonate for api calls                                                                                                                                               |                                                     |
+| `--google-group`                                | `google_groups`                              | string | restrict logins to members of this google group (may be given multiple times). If not specified and service account or default credentials are configured, all user groups will be allowed. |                                                     |
+| `--google-service-account-json`                 | `google_service_account_json`                | string | the path to the service account json credentials                                                                                                                                            |                                                     |
+| `--google-use-application-default-credentials`  | `google_use_application_default_credentials` | bool   | use application default credentials instead of service account json (i.e. GKE Workload Identity)                                                                                            |                                                     |
+| `--google-target-principal`                     | `google_target_principal`                    | bool   | the target principal to impersonate when using ADC                                                                                                                                          | defaults to the service account configured for ADC  |
+| `--google-use-organization-id`                  | `google_use_organization_id`                 | bool   | use organization id as preferred username                                                                                                                                                   | false                                               |
+| `--google-admin-api-user-scope`                 | `google_admin_api_user_scope`                | string | the OAuth scope to use when querying the Google Admin SDK for organization id, can be 'readonly', 'user' or 'cloud'<br/>                                                                    | `readonly`                                          |
 
 ## Usage
 
@@ -73,3 +75,10 @@ can be leveraged through a feature called Workload Identity. Follow Google's [gu
 to set up Workload Identity.
 
 When deployed outside of GCP, [Workload Identity Federation](https://cloud.google.com/docs/authentication/provide-credentials-adc#wlif) might be an option.
+
+##### Using Organization ID as Preferred Username (optional)
+By default, the google provider uses the google id as username. If you would like to use an organization id instead, you can set the `google-use-organization-id` flag to true.
+This requires that the service account used to query the Google Admin SDK has one of the following scopes granted in step 5 above: 
+- `https://www.googleapis.com/auth/admin.directory.user.readonly`, 
+- `https://www.googleapis.com/auth/admin.directory.user` 
+- `https://www.googleapis.com/auth/cloud-platform` 

--- a/pkg/apis/options/legacy_options.go
+++ b/pkg/apis/options/legacy_options.go
@@ -510,6 +510,8 @@ type LegacyProvider struct {
 	GoogleServiceAccountJSON               string   `flag:"google-service-account-json" cfg:"google_service_account_json"`
 	GoogleUseApplicationDefaultCredentials bool     `flag:"google-use-application-default-credentials" cfg:"google_use_application_default_credentials"`
 	GoogleTargetPrincipal                  string   `flag:"google-target-principal" cfg:"google_target_principal"`
+	GoogleUseOrganizationID                bool     `flag:"google-use-organization-id" cfg:"google_use_organization_id"`
+	GoogleAdminAPIUserScope                string   `flag:"google-admin-api-user-scope" cfg:"google_admin_api_user_scope"`
 
 	// These options allow for other providers besides Google, with
 	// potential overrides.
@@ -623,6 +625,8 @@ func legacyGoogleFlagSet() *pflag.FlagSet {
 	flagSet.String("google-service-account-json", "", "the path to the service account json credentials")
 	flagSet.String("google-use-application-default-credentials", "", "use application default credentials instead of service account json (i.e. GKE Workload Identity)")
 	flagSet.String("google-target-principal", "", "the target principal to impersonate when using ADC")
+	flagSet.String("google-use-organization-id", "", "use organization id as preferred username")
+	flagSet.String("google-admin-api-user-scope", "", "authorization scope required to call users.get, can be one of ")
 
 	return flagSet
 }
@@ -770,6 +774,8 @@ func (l *LegacyProvider) convert() (Providers, error) {
 			ServiceAccountJSON:               l.GoogleServiceAccountJSON,
 			UseApplicationDefaultCredentials: l.GoogleUseApplicationDefaultCredentials,
 			TargetPrincipal:                  l.GoogleTargetPrincipal,
+			UseOrganizationID:                l.GoogleUseOrganizationID,
+			AdminAPIUserScope:                l.GoogleAdminAPIUserScope,
 		}
 	case "entra-id":
 		provider.MicrosoftEntraIDConfig = MicrosoftEntraIDOptions{

--- a/pkg/apis/options/providers.go
+++ b/pkg/apis/options/providers.go
@@ -230,6 +230,10 @@ type GoogleOptions struct {
 	UseApplicationDefaultCredentials bool `json:"useApplicationDefaultCredentials,omitempty"`
 	// TargetPrincipal is the Google Service Account used for Application Default Credentials
 	TargetPrincipal string `json:"targetPrincipal,omitempty"`
+	// UseOrganizationId indicates whether to use the organization ID as the UserName claim
+	UseOrganizationID bool `json:"useOrganizationID,omitempty"`
+	// admin scope needed for fetching user organization information from admin api, can be one of cloud, user or defaults to readonly
+	AdminAPIUserScope string `json:"adminAPIUserScope,omitempty"`
 }
 
 type OIDCOptions struct {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Google id token uses the google id as username. I have internal systems that the username should match employee id which is my mapped into my google workspace directory as "Organization Id". I needed to have a way to retrieve that and add it to a header as it's not in the id token either.

<!--- Describe your changes in detail -->

## Motivation and Context

This allows a preferred username to be retrieved from the directory as "organization" id instead of google's user id. This is similar to how you might use MS Entra's onpremid to map to local AD usernames. I added a config change to enable this. If the user does not have an organization id mapped, the auth service will 500, i'm open to changing this behavior.

Due to the way the scope permissions are iterated over, it currently only works if you have both https://www.googleapis.com/auth/admin.directory.group.member.readonly and https://www.googleapis.com/auth/admin.directory.user.readonly.

Made the scope required for AdminApiUser as a config option.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Tested locally and in production. 

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My change requires a change to the documentation or CHANGELOG.
- [X] I have updated the documentation/CHANGELOG accordingly.
- [X] I have created a feature (non-master) branch for my PR.
- [X] I have written tests for my code changes.
