### PR TITLE
feat: more aggressively truncate logged access_token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#3197](https://github.com/oauth2-proxy/oauth2-proxy/pull/3197) fix: NewRemoteKeySet is not using DefaultHTTPClient (@rsrdesarrollo / @tuunit)
 - [#3292](https://github.com/oauth2-proxy/oauth2-proxy/pull/3292) chore(deps): upgrade gomod and bump to golang v1.25.5 (@tuunit)
 - [#3304](https://github.com/oauth2-proxy/oauth2-proxy/pull/3304) fix: added conditional so default is not always set and env vars are honored fixes 3303 (@pixeldrew)
+- [#3264](https://github.com/oauth2-proxy/oauth2-proxy/pull/3264) fix: more aggressively truncate logged access_token (@MartinNowak / @tuunit)
 
 # V7.13.0
 

--- a/providers/internal_util.go
+++ b/providers/internal_util.go
@@ -36,6 +36,7 @@ func stripParam(param, endpoint string) string {
 		}
 
 		if val := values.Get(param); val != "" {
+			// Truncate by at least half and allow for a maximum of 5 characters
 			values.Set(param, val[:min(len(val)/2, 5)]+"...")
 			u.RawQuery = values.Encode()
 			return u.String()

--- a/providers/internal_util_test.go
+++ b/providers/internal_util_test.go
@@ -149,3 +149,9 @@ func TestStripToken(t *testing.T) {
 	expected := "http://local.test/api/test?access_token=dead...&b=1&c=2"
 	assert.Equal(t, expected, stripToken(test))
 }
+
+func TestStripLongToken(t *testing.T) {
+	test := "http://local.test/api/test?access_token=deadbeefwithsupersecret&b=1&c=2"
+	expected := "http://local.test/api/test?access_token=deadb...&b=1&c=2"
+	assert.Equal(t, expected, stripToken(test))
+}


### PR DESCRIPTION
## Description

- leaking half of the access token to the logs seems problematic from a security point of view
- also noisier than necessary logging (partly addresses #2120)
- fixed by truncating to at most first 5 chars (e.g. `ya29.`)

## Motivation and Context

Leaking too much of the access token could expose 

## How Has This Been Tested?

This is covered by an [existing unittest](https://github.com/oauth2-proxy/oauth2-proxy/blob/7cf69b27fa93923db4c3bc6104d21235f8d77712/providers/internal_util_test.go#L147-L151).

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
- [x] I have written tests for my code changes.
