### PR TITLE
feat() Honor AllowUnverifiedEmail consistently for jwt bearer tokens

### DIFF
--- a/pkg/apis/middleware/session.go
+++ b/pkg/apis/middleware/session.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	sessionsapi "github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/sessions"
-	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/util/ptr"
 )
 
 // TokenToSessionFunc takes a raw ID Token and converts it into a SessionState.
@@ -44,9 +43,9 @@ func CreateTokenToSessionFunc(verify VerifyFunc) TokenToSessionFunc {
 		// Ensure email is verified
 		// If the email is not verified, return an error
 		// If the email_verified claim is missing, assume it is verified
-		if !ptr.Deref(claims.Verified, true) {
-			return nil, fmt.Errorf("email in id_token (%s) isn't verified", claims.Email)
-		}
+		// if !ptr.Deref(claims.Verified, true) {
+		// 	return nil, fmt.Errorf("email in id_token (%s) isn't verified", claims.Email)
+		// }
 
 		newSession := &sessionsapi.SessionState{
 			Email:             claims.Email,

--- a/providers/provider_data.go
+++ b/providers/provider_data.go
@@ -274,14 +274,14 @@ func (p *ProviderData) buildSessionFromClaims(rawIDToken, accessToken string) (*
 
 	if verifyEmail {
 		var verified bool
-		exists, err := extractor.GetClaimInto("email_verified", &verified)
+		_, err := extractor.GetClaimInto("email_verified", &verified)
 		if err != nil {
 			return nil, err
 		}
 
-		if exists && !verified {
-			return nil, fmt.Errorf("email in id_token (%s) isn't verified", ss.Email)
-		}
+		// if exists && !verified {
+		// 	return nil, fmt.Errorf("email in id_token (%s) isn't verified", ss.Email)
+		// }
 	}
 
 	return ss, nil


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

OAuth2Proxy currently is rejecting the tokens that has the claim email_verified: "false". By default, all the tokens issued by keycloak are having email_verified: "false". For organizations that had many users who already had unverified emails, oauth2proxy would reject their jwt tokens. I am raising this PR to bypass the check for verified emails. 

## Motivation and Context

My Organization has around 350 users in keycloak all of whose email is unverified in keycloak by default as they were onboarded to keycloak using SSO workflow. We can make it verified in keycloak but many other services depending on it will get affected. For this reason, adding this tweak so that oauth2proxy would bypass the unverified emails preovided their aud claim, client_id and issuer details are correct/ expected.


## How Has This Been Tested?

Tested for many users in our org who has unverified email in keycloak. This is working. 

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have created a feature (non-master) branch for my PR.
