### PR TITLE
fix: added conditional so default is not always set and env vars honored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [#3197](https://github.com/oauth2-proxy/oauth2-proxy/pull/3197) fix: NewRemoteKeySet is not using DefaultHTTPClient (@rsrdesarrollo / @tuunit)
 - [#3292](https://github.com/oauth2-proxy/oauth2-proxy/pull/3292) chore(deps): upgrade gomod and bump to golang v1.25.5 (@tuunit)
+- [#3304](https://github.com/oauth2-proxy/oauth2-proxy/pull/3304) fix: added conditional so default is not always set and env vars are honored fixes 3303 (@pixeldrew)
 
 # V7.13.0
 

--- a/pkg/apis/options/providers.go
+++ b/pkg/apis/options/providers.go
@@ -416,7 +416,9 @@ func (a *ADFSOptions) EnsureDefaults() {
 
 // EnsureDefaults sets any default values for GoogleOptions fields.
 func (g *GoogleOptions) EnsureDefaults() {
-	g.UseOrganizationID = ptr.To(DefaultGoogleUseOrganizationID)
+	if g.UseOrganizationID == nil {
+		g.UseOrganizationID = ptr.To(DefaultGoogleUseOrganizationID)
+	}
 
 	if g.UseApplicationDefaultCredentials == nil {
 		g.UseApplicationDefaultCredentials = ptr.To(DefaultUseApplicationDefaultCredentials)


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

adds a conditional when ensuredefaults runs so that env var options are set

## Motivation and Context

fixes an issue where the config is set by env var and the default does not overwrite it
fixes #3303

## How Has This Been Tested?

Locally

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My change requires a change to the documentation or CHANGELOG.
- [X] I have updated the documentation/CHANGELOG accordingly.
- [X] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes. Not needed
