### PR TITLE
docs: fix incorrect flattened groups example

### DIFF
--- a/docs/versioned_docs/version-7.14.x/configuration/providers/cidaas.md
+++ b/docs/versioned_docs/version-7.14.x/configuration/providers/cidaas.md
@@ -30,7 +30,7 @@ This will be transformed into a flat list of groups:
 
 ```json
 {
-  "groups": ["group1:role1", "group2:role2", "group2:role3"]
+  "groups": ["group1:role1", "group1:role2", "group2:role3"]
 }
 ```
 


### PR DESCRIPTION
Fix for incorrect example in Cidaas provider

## Description

Fixes an incorrect example. The flattened groups should contain two roles for group 1 and only one role for group 2

## Motivation and Context

Misleading

## How Has This Been Tested?

N/A

## Checklist:

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.
