### PR TITLE
fix: upgrade Go to 1.25.7 to address CVE-2025-68121

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/oauth2-proxy/oauth2-proxy/v7
 
-go 1.25.6
+go 1.25.7
 
 require (
 	cloud.google.com/go/compute/metadata v0.9.0


### PR DESCRIPTION
## Summary

- Bumps Go toolchain from 1.25.6 to 1.25.7 to fix [CVE-2025-68121](https://github.com/advisories/GHSA-h355-32pf-p2xm), a Critical-severity `crypto/tls` session resumption vulnerability

Closes #3342

## Test plan

- [x] `go mod tidy` completes without errors
- [x] `make build` succeeds
- [x] `go test -race ./...` — all packages pass
- [x] Built binary reports `go1.25.7` via `go version ./oauth2-proxy`