### PR TITLE
doc: add statusRewrites to traefik errors middleware example

### DIFF
--- a/docs/docs/configuration/integrations/traefik.md
+++ b/docs/docs/configuration/integrations/traefik.md
@@ -79,7 +79,15 @@ http:
           - "401-403"
         service: oauth-backend
         query: "/oauth2/sign_in?rd={url}"
+        statusRewrites:
+          "401": 302
 ```
+
+:::caution Troubleshooting: Browser shows "Found." instead of redirecting
+When using the Errors middleware without `statusRewrites`, the redirect response from oauth2-proxy can be served within the original 401/403 status context. This causes some browsers to display a "Found." link instead of automatically following the redirect to the identity provider.
+
+Adding `statusRewrites` to rewrite `401 -> 302` ensures the browser treats the response as a proper redirect and follows it automatically.
+:::
 
 ### ForwardAuth with static upstreams configuration
 

--- a/docs/versioned_docs/version-7.10.x/configuration/integration.md
+++ b/docs/versioned_docs/version-7.10.x/configuration/integration.md
@@ -225,7 +225,15 @@ http:
           - "401-403"
         service: oauth-backend
         query: "/oauth2/sign_in?rd={url}"
+        statusRewrites:
+          "401": 302
 ```
+
+:::info Troubleshooting: Browser shows "Found." instead of redirecting
+When using the Errors middleware without `statusRewrites`, the redirect response from oauth2-proxy can be served within the original 401/403 status context. This causes some browsers to display a "Found." link instead of automatically following the redirect to the identity provider.
+
+Adding `statusRewrites` to rewrite `401 -> 302` ensures the browser treats the response as a proper redirect and follows it automatically.
+:::
 
 ### ForwardAuth with static upstreams configuration
 

--- a/docs/versioned_docs/version-7.11.x/configuration/integration.md
+++ b/docs/versioned_docs/version-7.11.x/configuration/integration.md
@@ -225,7 +225,15 @@ http:
           - "401-403"
         service: oauth-backend
         query: "/oauth2/sign_in?rd={url}"
+        statusRewrites:
+          "401": 302
 ```
+
+:::info Troubleshooting: Browser shows "Found." instead of redirecting
+When using the Errors middleware without `statusRewrites`, the redirect response from oauth2-proxy can be served within the original 401/403 status context. This causes some browsers to display a "Found." link instead of automatically following the redirect to the identity provider.
+
+Adding `statusRewrites` to rewrite `401 -> 302` ensures the browser treats the response as a proper redirect and follows it automatically.
+:::
 
 ### ForwardAuth with static upstreams configuration
 

--- a/docs/versioned_docs/version-7.12.x/configuration/integration.md
+++ b/docs/versioned_docs/version-7.12.x/configuration/integration.md
@@ -225,7 +225,15 @@ http:
           - "401-403"
         service: oauth-backend
         query: "/oauth2/sign_in?rd={url}"
+        statusRewrites:
+          "401": 302
 ```
+
+:::info Troubleshooting: Browser shows "Found." instead of redirecting
+When using the Errors middleware without `statusRewrites`, the redirect response from oauth2-proxy can be served within the original 401/403 status context. This causes some browsers to display a "Found." link instead of automatically following the redirect to the identity provider.
+
+Adding `statusRewrites` to rewrite `401 -> 302` ensures the browser treats the response as a proper redirect and follows it automatically.
+:::
 
 ### ForwardAuth with static upstreams configuration
 

--- a/docs/versioned_docs/version-7.13.x/configuration/integrations/traefik.md
+++ b/docs/versioned_docs/version-7.13.x/configuration/integrations/traefik.md
@@ -79,7 +79,15 @@ http:
           - "401-403"
         service: oauth-backend
         query: "/oauth2/sign_in?rd={url}"
+        statusRewrites:
+          "401": 302
 ```
+
+:::info Troubleshooting: Browser shows "Found." instead of redirecting
+When using the Errors middleware without `statusRewrites`, the redirect response from oauth2-proxy can be served within the original 401/403 status context. This causes some browsers to display a "Found." link instead of automatically following the redirect to the identity provider.
+
+Adding `statusRewrites` to rewrite `401 -> 302` ensures the browser treats the response as a proper redirect and follows it automatically.
+:::
 
 ### ForwardAuth with static upstreams configuration
 

--- a/docs/versioned_docs/version-7.14.x/configuration/integrations/traefik.md
+++ b/docs/versioned_docs/version-7.14.x/configuration/integrations/traefik.md
@@ -79,7 +79,15 @@ http:
           - "401-403"
         service: oauth-backend
         query: "/oauth2/sign_in?rd={url}"
+        statusRewrites:
+          "401": 302
 ```
+
+:::info Troubleshooting: Browser shows "Found." instead of redirecting
+When using the Errors middleware without `statusRewrites`, the redirect response from oauth2-proxy can be served within the original 401/403 status context. This causes some browsers to display a "Found." link instead of automatically following the redirect to the identity provider.
+
+Adding `statusRewrites` to rewrite `401 -> 302` ensures the browser treats the response as a proper redirect and follows it automatically.
+:::
 
 ### ForwardAuth with static upstreams configuration
 


### PR DESCRIPTION
## Summary

- Adds `statusRewrites: "401": 302` to the Traefik Errors middleware YAML example in the ForwardAuth section
- Adds a troubleshooting note explaining the "Found." page pitfall when `statusRewrites` is missing
- Applied to `docs/docs/`, `versioned_docs/version-7.13.x/`, and `versioned_docs/version-7.14.x/`

Fixes #3359

## Context

Without `statusRewrites`, the redirect response from oauth2-proxy is served within the original 401 status context, causing browsers to display a "Found." link instead of auto-redirecting to the identity provider. Adding `statusRewrites` to rewrite `401 -> 302` resolves this.