### PR TITLE
fix(devcontainer): bump Go version to 1.25 in devcontainer base image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/go:1-1.23
+FROM mcr.microsoft.com/vscode/devcontainers/go:1-1.25
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 


### PR DESCRIPTION
Fixes #3207

## Summary

Updates the devcontainer base image from Go 1.23 to Go 1.25 to match the version required in `go.mod`. This resolves the `go mod tidy` failure that occurred when bootstrapping the devcontainer environment.

## Changes

- Updated `.devcontainer/Dockerfile` base image from `mcr.microsoft.com/vscode/devcontainers/go:1-1.23` to `mcr.microsoft.com/vscode/devcontainers/go:1-1.25`

## Testing

Verified that the go.mod requires Go 1.25.0 and the new base image version matches this requirement.

```
.devcontainer/Dockerfile | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```