### PR TITLE
Allow http:// URLs in custom-sign-in-logo flag

### DIFF
--- a/pkg/app/pagewriter/sign_in_page.go
+++ b/pkg/app/pagewriter/sign_in_page.go
@@ -105,7 +105,7 @@ func loadCustomLogo(logoPath string) (string, error) {
 		return "", nil
 	}
 
-	if strings.HasPrefix(logoPath, "https://") {
+	if strings.HasPrefix(logoPath, "https://") || strings.HasPrefix(logoPath, "http://") {
 		// Return img tag pointing to the URL.
 		return fmt.Sprintf("<img src=\"%s\" alt=\"Logo\" />", logoPath), nil
 	}

--- a/pkg/app/pagewriter/sign_in_page_test.go
+++ b/pkg/app/pagewriter/sign_in_page_test.go
@@ -131,6 +131,11 @@ var _ = Describe("SignIn Page", func() {
 				expectedErr:  nil,
 				expectedData: "<img src=\"https://raw.githubusercontent.com/oauth2-proxy/oauth2-proxy/master/docs/static/img/logos/OAuth2_Proxy_icon.png\" alt=\"Logo\" />",
 			}),
+			Entry("with HTTP URL", loadCustomLogoTableInput{
+				logoPath:     "http://example.com/logo.png",
+				expectedErr:  nil,
+				expectedData: "<img src=\"http://example.com/logo.png\" alt=\"Logo\" />",
+			}),
 			Entry("with an svg custom logo", loadCustomLogoTableInput{
 				logoPath:     "customDir/logo.svg",
 				expectedErr:  nil,


### PR DESCRIPTION
Fixes #3206

## Description

This PR fixes a bug where the `--custom-sign-in-logo` flag (and its environment variable equivalent `OAUTH2_PROXY_CUSTOM_SIGN_IN_LOGO`) would incorrectly reject `http://` URLs, treating them as file paths instead. The application would then fail to start with a "file not found" error.

The fix extends the URL prefix check to accept both `https://` and `http://` URLs, allowing users to reference logo images served over HTTP.

## Motivation and Context

Users attempting to use HTTP image URLs for the custom sign-in logo would encounter startup failures. The code only checked for `https://` prefix before treating the value as a file path, which meant `http://` URLs were incorrectly interpreted as local file paths.

This change enables users to use HTTP URLs for their custom logos, which is particularly useful in development environments or when using internal image servers that don't have HTTPS configured.

## How Has This Been Tested?

- Added a new test case in `sign_in_page_test.go` to verify HTTP URLs are handled correctly
- The test follows the same pattern as the existing HTTPS URL test
- Test validates that `http://example.com/logo.png` produces the expected `<img>` tag output

**Diff stats:**
```
pkg/app/pagewriter/sign_in_page.go      | 2 +-
pkg/app/pagewriter/sign_in_page_test.go | 5 +++++
2 files changed, 6 insertions(+), 1 deletion(-)
```

## Checklist:

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
- [x] I have written tests for my code changes.