### PR TITLE
doc: remove insecure trustForwardHeader option from Traefik configur...

### DIFF
--- a/docs/docs/configuration/integrations/traefik.md
+++ b/docs/docs/configuration/integrations/traefik.md
@@ -72,7 +72,6 @@ http:
     oauth-auth:
       forwardAuth:
         address: https://oauth.example.com/oauth2/auth
-        trustForwardHeader: true
     oauth-errors:
       errors:
         status:
@@ -166,14 +165,12 @@ http:
     oauth-auth-redirect:
       forwardAuth:
         address: https://oauth.example.com/
-        trustForwardHeader: true
         authResponseHeaders:
           - X-Auth-Request-Access-Token
           - Authorization
     oauth-auth-wo-redirect:
       forwardAuth:
         address: https://oauth.example.com/oauth2/auth
-        trustForwardHeader: true
         authResponseHeaders:
           - X-Auth-Request-Access-Token
           - Authorization


### PR DESCRIPTION
Fixes #3186

## Description

Removes the `trustForwardHeader: true` option from Traefik ForwardAuth configuration examples in the documentation.

## Motivation and Context

The documentation currently suggests setting `trustForwardHeader: true` in Traefik's ForwardAuth middleware configuration. This option causes Traefik to pass all `X-Forwarded-*` headers from incoming requests to oauth2-proxy without validation.

This is insecure for most deployment scenarios where users run oauth2-proxy behind Traefik without another trusted proxy in front of it. When enabled, any client can set these headers to arbitrary values, potentially bypassing security controls.

The `trustForwardHeader` option should only be enabled when there is a trusted proxy in front of Traefik that properly sets these headers. Since most users don't have this setup, the documentation should not recommend this insecure default.

## How Has This Been Tested?

This is a documentation-only change. The YAML syntax remains valid after removing the `trustForwardHeader` lines.

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.

**Files changed:**
```
docs/docs/configuration/integrations/traefik.md | 3 ---
1 file changed, 3 deletions(-)
```