### PR TITLE
ci: harden workflows; add trivy scanning; add manual workflow_dispatch trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,18 +7,21 @@ on:
   pull_request:
     branches:
       - '**'
+  workflow_dispatch:
+
 permissions:
   contents: read
   id-token: write
+  security-events: write
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      COVER: true
     steps:
     - name: Check out code
       uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
 
     - name: Get Go version
       run: |
@@ -33,11 +36,10 @@ jobs:
         check-latest: true
 
     - name: Install golangci-lint
-      env:
-        # renovate: datasource=github-tags depName=golangci/golangci-lint
-        GOLANGCI_LINT_VERSION: v2.8.0
-      run: |
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin ${GOLANGCI_LINT_VERSION}
+      uses: golangci/golangci-lint-action@v9
+      with:
+        install-only: true
+        version: v2.8.0 # renovate: datasource=github-tags depName=golangci/golangci-lint
 
     - name: Verify Code Generation
       run: |
@@ -59,13 +61,15 @@ jobs:
         make release
 
     - name: Test
+      env:
+        COVER: true
       run: |
         make test
 
     - name: Generate Coverage Report
       if: github.event_name == 'push'
       run: |
-        go install github.com/jandelgado/gcov2lcov@latest
+        go install github.com/jandelgado/gcov2lcov@25681830fb515e3d4c117e136b4f049e21efb4d0
         gcov2lcov -infile=c.out -outfile=lcov.info
 
     - name: Upload Coverage Report
@@ -75,11 +79,30 @@ jobs:
         oidc: true
         files: lcov.info
 
+    - name: Run Trivy vulnerability scanner
+      if: (!startsWith(github.head_ref, 'release'))
+      uses: aquasecurity/trivy-action@0.35.0
+      with:
+        scan-type: 'rootfs'
+        scan-ref: './oauth2-proxy'
+        severity: 'CRITICAL,HIGH'
+        hide-progress: true
+        format: 'sarif'
+        output: 'trivy-results.sarif'
+        exit-code: '0'
+
+    - name: Upload Trivy scan results
+      uses: github/codeql-action/upload-sarif@v4
+      with:
+        sarif_file: 'trivy-results.sarif'
+
   docker:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
       uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -55,14 +55,14 @@ jobs:
         go-version: ${{ steps.go-version.outputs.version }}
         check-latest: true
 
-    - name: Get dependencies
-      env:
-        # renovate: datasource=github-tags depName=golangci/golangci-lint
-        GOLANGCI_LINT_VERSION: v2.8.0
-      run: |
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin ${GOLANGCI_LINT_VERSION}
+    - name: Install golangci-lint
+      uses: golangci/golangci-lint-action@v9
+      with:
+        install-only: true
+        version: v2.8.0 # renovate: datasource=github-tags depName=golangci/golangci-lint
 
-        # Install go dependencies
+    - name: Get go dependencies
+      run: |
         go mod download
 
     - name: Build Artifacts


### PR DESCRIPTION
# Motivation and Context

1. Harden workflows
    i. Using official golangci-lint action for the installation
    ii. Using sha for gocov dependency
    iii. Using fetch-depth 0 for proper version through tag resolution
1. Add trivy scanning of binary built to have quicker insights into Golang CVEs
1. Add manual workflow_dispatch trigger for CI workflow to be able to tes it on demand

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.
