### PR TITLE
fix: stop logging provider userinfo response body in token validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Changes since v7.15.2
 
+- [#3431](https://github.com/oauth2-proxy/oauth2-proxy/issues/3431) fix: stop logging provider userinfo response body in token validation (@sschmidt)
+
 # V7.15.2
 
 ## Release Highlights

--- a/providers/internal_util.go
+++ b/providers/internal_util.go
@@ -71,12 +71,12 @@ func validateToken(ctx context.Context, p Provider, accessToken string, header h
 		return false
 	}
 
-	logger.Printf("%d GET %s %s", result.StatusCode(), stripToken(endpoint), result.Body())
+	logger.Printf("%d GET %s", result.StatusCode(), stripToken(endpoint))
 
 	if result.StatusCode() == 200 {
 		return true
 	}
-	logger.Errorf("token validation request failed: status %d - %s", result.StatusCode(), result.Body())
+	logger.Errorf("token validation request failed: status %d", result.StatusCode())
 	return false
 }
 

--- a/providers/internal_util_test.go
+++ b/providers/internal_util_test.go
@@ -1,14 +1,17 @@
 package providers
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
 
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/sessions"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/logger"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -137,6 +140,29 @@ func TestValidateSessionValidateURLWithQueryParams(t *testing.T) {
 	defer vtTest.Close()
 	vtTest.provider.Data().ValidateURL, _ = url.Parse(vtTest.provider.Data().ValidateURL.String() + "?query_param1=true&query_param2=test")
 	assert.Equal(t, true, validateToken(context.Background(), vtTest.provider, "foobar", nil))
+}
+
+func TestValidateSessionDoesNotLogResponseBody(t *testing.T) {
+	vtTest := NewValidateSessionTest()
+	defer vtTest.Close()
+
+	var buf bytes.Buffer
+	logger.SetOutput(&buf)
+	logger.SetErrOutput(&buf)
+	t.Cleanup(func() {
+		logger.SetOutput(io.Discard)
+		logger.SetErrOutput(io.Discard)
+	})
+
+	// Successful validation must not log the response body.
+	assert.Equal(t, true, validateToken(context.Background(), vtTest.provider, "foobar", nil))
+	assert.NotContains(t, buf.String(), "only code matters; contents disregarded")
+
+	// Error path (non-200) must not log the response body either.
+	buf.Reset()
+	vtTest.responseCode = 401
+	assert.Equal(t, false, validateToken(context.Background(), vtTest.provider, "foobar", nil))
+	assert.NotContains(t, buf.String(), "only code matters; contents disregarded")
 }
 
 func TestStripTokenNotPresent(t *testing.T) {


### PR DESCRIPTION
## Description                                                                                                                                                                              
                                                                  
Drop `result.Body()` from the two log statements in `providers/internal_util.go` (`validateToken`) so the provider's `ValidateURL` response body is no longer written to the standard log:
                                                                                                                                                                                              
- L73 `Printf("%d GET %s %s", ..., result.Body())`
- L78 `Errorf("token validation request failed: status %d - %s", ..., result.Body())`                                                                                                       
                                                                                       
Adds a regression test that asserts the response body does not appear in standard log output on the success path and the non-200 error path.                                                
                                                                                                                                                                                              
  ## Motivation and Context
                                                                                                                                                                                              
For OIDC-style providers `ValidateURL` points at the userinfo endpoint, so userinfo claims (email, sub, name, …) ended up in the standard log on every session-validate tick. The lines could not be suppressed via `--request-logging=false` / `--auth-logging=false`; only `--standard-logging` silences them, which also disables operationally important error logging on the same channel.                                                                                                                                                                            
                                                                                                                                                                                              
Closes #3431                                                    
              
## How Has This Been Tested?
                              
`go test ./providers/... -count=1` — all existing tests pass plus the new `TestValidateSessionDoesNotLogResponseBody`.
                                                                                                                                                                                              
## Checklist:
                                                                                                                                                                                              
- [x] I have added an entry for my changes to the CHANGELOG.md. 
- [x] I have signed off all my commits.                                                                                                                                                     
- [x] I have created a feature (non-master) branch for my PR.
- [x] I have used conventional commits for the PR title.                                                                                                                                    
- [x] I have written tests for my code changes.