### PR TITLE
fix: remove response body from validateToken logging to prevent PII leak

### DIFF
--- a/providers/internal_util.go
+++ b/providers/internal_util.go
@@ -71,12 +71,12 @@ func validateToken(ctx context.Context, p Provider, accessToken string, header h
 		return false
 	}
 
-	logger.Printf("%d GET %s %s", result.StatusCode(), stripToken(endpoint), result.Body())
+	logger.Printf("%d GET %s", result.StatusCode(), stripToken(endpoint))
 
 	if result.StatusCode() == 200 {
 		return true
 	}
-	logger.Errorf("token validation request failed: status %d - %s", result.StatusCode(), result.Body())
+	logger.Errorf("token validation request failed: status %d", result.StatusCode())
 	return false
 }
 

--- a/providers/internal_util_test.go
+++ b/providers/internal_util_test.go
@@ -1,14 +1,17 @@
 package providers
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"testing"
 
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/sessions"
+	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/logger"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -137,6 +140,25 @@ func TestValidateSessionValidateURLWithQueryParams(t *testing.T) {
 	defer vtTest.Close()
 	vtTest.provider.Data().ValidateURL, _ = url.Parse(vtTest.provider.Data().ValidateURL.String() + "?query_param1=true&query_param2=test")
 	assert.Equal(t, true, validateToken(context.Background(), vtTest.provider, "foobar", nil))
+}
+
+func TestValidateTokenDoesNotLogResponseBody(t *testing.T) {
+	vtTest := NewValidateSessionTest()
+	defer vtTest.Close()
+	vtTest.responseCode = 401
+
+	var buf bytes.Buffer
+	logger.SetOutput(&buf)
+	defer logger.SetOutput(os.Stdout)
+
+	validateToken(context.Background(), vtTest.provider, "foobar", nil)
+
+	output := buf.String()
+	// Response body from the test server is "only code matters; contents disregarded"
+	assert.NotContains(t, output, "only code matters")
+	assert.NotContains(t, output, "contents disregarded")
+	// But we should still see the status code logged
+	assert.Contains(t, output, "401")
 }
 
 func TestStripTokenNotPresent(t *testing.T) {


### PR DESCRIPTION
## Summary

The `validateToken` function in `providers/internal_util.go` was logging the full response body on every token validation call. For OIDC providers (Keycloak, Azure, etc.), the ValidateURL points to the userinfo endpoint, so claims like email, sub, and name were being written to standard logs on every refresh tick.

## Changes

- Remove `result.Body()` from success path log (`Printf`) on L74
- Remove `result.Body()` from error path log (`Errorf`) on L79
- Add test `TestValidateTokenDoesNotLogResponseBody` to verify response body is not present in log output

## Testing

- Added unit test that captures logger output during a validateToken call and asserts the response body is not logged
- CI will validate full test suite

Fixes #3431