### PR TITLE
fix: skip the invalid fd IPv6 bind test in DevContainer environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Changes since v7.15.2
 
+- [#3442](https://github.com/oauth2-proxy/oauth2-proxy/pull/3442) fix: skip the invalid fd IPv6 bind test in DevContainer environments (@mateenali66)
+
 # V7.15.2
 
 ## Release Highlights

--- a/pkg/proxyhttp/server_test.go
+++ b/pkg/proxyhttp/server_test.go
@@ -394,6 +394,7 @@ var _ = Describe("Server", func() {
 				expectHTTPListener: true,
 				expectTLSListener:  false,
 				fdAddr:             "[::1]:0",
+				ipv6:               true,
 			}),
 			Entry("with an ipv6 valid http bind address", &newServerTableInput{
 				opts: Opts{


### PR DESCRIPTION
## Description

The `with a invalid fd IPv6 bind address` entry in the `NewServer` table test set `fdAddr: "[::1]:0"` but was missing `ipv6: true`. The table only calls `skipDevContainer()` when `in.ipv6` is set, so this entry was never skipped and tried to bind `[::1]:0`, failing with `bind: cannot assign requested address` on hosts without IPv6 when running with `DEVCONTAINER=1`. Added `ipv6: true` to match the sibling `with valid fd IPv6 bind address` entry.

## Motivation and Context

Fixes #3441. `DEVCONTAINER=1 go test ./...` failed in environments without IPv6 (e.g. build sandboxes) on a single proxyhttp spec that should have been skipped like the other IPv6 specs.

## How Has This Been Tested?

- `DEVCONTAINER=1 go test ./pkg/proxyhttp/` now passes; the entry is skipped along with the other IPv6 specs.
- `go test ./pkg/proxyhttp/` on a host with IPv6 still runs and passes the IPv6 specs.

## Checklist:

- [x] I have added an entry for my changes to the CHANGELOG.md.
- [x] I have signed off all my commits.
- [x] I have created a feature (non-master) branch for my PR.
- [x] I have used conventional commits for the PR title.
- [x] I have written tests for my code changes.