### PR TITLE
fix: resolve version from build info when not set via ldflags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Changes since v7.15.3
 
+- [#3452](https://github.com/oauth2-proxy/oauth2-proxy/pull/3452) fix: resolve version from build info when not set via ldflags (so `go install`-ed binaries report a real version instead of `undefined`) (@Lrifton92)
+
 # V7.15.3
 
 ## Release Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Changes since v7.15.4
 
+- [#3452](https://github.com/oauth2-proxy/oauth2-proxy/pull/3452) fix: resolve version from build info when not set via ldflags (so `go install`-ed binaries report a real version instead of `undefined`) (@Lrifton92)
+
 # V7.15.4
 
 ## Release Highlights

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,30 @@
 package version
 
-// VERSION contains version information
+import "runtime/debug"
+
+// VERSION contains version information. It is set at build time via
+// -ldflags "-X github.com/oauth2-proxy/oauth2-proxy/v7/pkg/version.VERSION=<version>".
+// When the binary is built without those flags (for example via
+// `go install github.com/oauth2-proxy/oauth2-proxy/v7@latest`), it falls back
+// to the module version recorded in the build info so that `--version` still
+// reports a meaningful value instead of "undefined".
 var VERSION = "undefined"
+
+func init() {
+	VERSION = resolveVersion(VERSION, debug.ReadBuildInfo)
+}
+
+// resolveVersion returns ldflagsVersion when it has been explicitly set at
+// build time. Otherwise it derives the version from the module build info,
+// allowing `go install`-ed binaries to report a meaningful version.
+func resolveVersion(ldflagsVersion string, readBuildInfo func() (*debug.BuildInfo, bool)) string {
+	if ldflagsVersion != "" && ldflagsVersion != "undefined" {
+		return ldflagsVersion
+	}
+	if info, ok := readBuildInfo(); ok && info != nil {
+		if v := info.Main.Version; v != "" && v != "(devel)" {
+			return v
+		}
+	}
+	return ldflagsVersion
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -22,6 +22,14 @@ func resolveVersion(ldflagsVersion string, readBuildInfo func() (*debug.BuildInf
 		return ldflagsVersion
 	}
 	if info, ok := readBuildInfo(); ok && info != nil {
+		// info.Main.Version is populated by the Go toolchain only for
+		// module-aware builds: it is the clean tag for an exact
+		// `@vX.Y.Z` install, or a synthesized pseudo-version
+		// (e.g. v7.15.4-0.20240115123456-abcdef123456) carrying the
+		// base version, commit timestamp and hash when built from
+		// commits on top of a release. A plain `go build` from a source
+		// checkout reports "(devel)", which we skip so release builds
+		// keep deferring to the ldflags value below.
 		if v := info.Main.Version; v != "" && v != "(devel)" {
 			return v
 		}

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,0 +1,63 @@
+package version
+
+import (
+	"runtime/debug"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveVersion(t *testing.T) {
+	testCases := []struct {
+		name           string
+		ldflagsVersion string
+		buildInfo      *debug.BuildInfo
+		buildInfoOK    bool
+		expected       string
+	}{
+		{
+			name:           "ldflags version takes precedence over build info",
+			ldflagsVersion: "v7.15.3",
+			buildInfo:      &debug.BuildInfo{Main: debug.Module{Version: "v7.15.0"}},
+			buildInfoOK:    true,
+			expected:       "v7.15.3",
+		},
+		{
+			name:           "falls back to build info version when undefined",
+			ldflagsVersion: "undefined",
+			buildInfo:      &debug.BuildInfo{Main: debug.Module{Version: "v7.15.3"}},
+			buildInfoOK:    true,
+			expected:       "v7.15.3",
+		},
+		{
+			name:           "keeps undefined when build info is unavailable",
+			ldflagsVersion: "undefined",
+			buildInfo:      nil,
+			buildInfoOK:    false,
+			expected:       "undefined",
+		},
+		{
+			name:           "keeps undefined for a (devel) build info version",
+			ldflagsVersion: "undefined",
+			buildInfo:      &debug.BuildInfo{Main: debug.Module{Version: "(devel)"}},
+			buildInfoOK:    true,
+			expected:       "undefined",
+		},
+		{
+			name:           "keeps undefined for an empty build info version",
+			ldflagsVersion: "undefined",
+			buildInfo:      &debug.BuildInfo{Main: debug.Module{Version: ""}},
+			buildInfoOK:    true,
+			expected:       "undefined",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := resolveVersion(tc.ldflagsVersion, func() (*debug.BuildInfo, bool) {
+				return tc.buildInfo, tc.buildInfoOK
+			})
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## Description

When oauth2-proxy is built **without** the Makefile/`dist.sh` ldflags — for example when a user runs `go install github.com/oauth2-proxy/oauth2-proxy/v7@latest` — the `VERSION` variable keeps its default `"undefined"` value, so `--version` reports:

```
oauth2-proxy undefined (built with go1.26.4)
```

This change makes the `version` package fall back to the module version recorded in `runtime/debug` build info when `VERSION` has not been overridden at build time. With the fix, a `go install`-ed binary reports the real module version, e.g.:

```
oauth2-proxy v7.15.3 (built with go1.26.4)
```

The ldflags-injected value still takes precedence, so official release builds (Makefile / `dist.sh`) are **unchanged**. Build-info versions of `""` or `"(devel)"` are ignored so the value only improves, never regresses to noise.

## Motivation and Context

Fixes the confusing `undefined` version output reported in #3451. `go install` is a common install path and currently produces no usable version string, which makes bug reports and support harder.

Closes #3451

## How Has This Been Tested?

- Added table-driven unit tests for the resolution logic (`resolveVersion`) covering: ldflags precedence, fallback to build info, unavailable build info, and the `"(devel)"`/empty cases. `go test ./pkg/version/...` passes.
- `go vet ./pkg/version/...` and `gofmt -l` are clean.
- `go build ./...` succeeds.
- Built the binary locally from a checkout and confirmed `--version` now derives a meaningful version from build info instead of `undefined`, while ldflags builds keep their injected value.

Environment: go1.26.4, windows/amd64.

## Checklist:

- [x] I have added an entry for my changes to the CHANGELOG.md.
- [x] I have signed off all my commits.
- [x] I have created a feature (non-master) branch for my PR.
- [x] I have used conventional commits for the PR title.
- [x] I have written tests for my code changes.