### PR TITLE
fix: return 403 instead of 500 for malformed OAuth2 state on callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Changes since v7.15.3
 
+- [#3453](https://github.com/oauth2-proxy/oauth2-proxy/pull/3453) fix: return 403 instead of 500 for malformed OAuth2 state on the callback (@Elaine-cls)
+
 # V7.15.3
 
 ## Release Highlights

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -905,8 +905,15 @@ func (p *OAuthProxy) OAuthCallback(rw http.ResponseWriter, req *http.Request) {
 
 	nonce, appRedirect, err := decodeState(req.Form.Get("state"), p.encodeState)
 	if err != nil {
+		// A malformed or missing state parameter is a client/auth failure, not a
+		// server error: the request did not originate from a valid /oauth2/start
+		// flow (e.g. crawlers and scanners hitting the callback directly). Return
+		// 403 instead of 500 so these do not surface as server errors / trigger
+		// 5xx alerting, leaking minimal information to the caller. This restores
+		// the pre-v7.7.1 behaviour and is consistent with the other auth-failure
+		// paths below (CSRF cookie missing, CSRF mismatch), which also return 403.
 		logger.Errorf("Error while parsing OAuth2 state: %v", err)
-		p.ErrorPage(rw, req, http.StatusInternalServerError, err.Error())
+		p.ErrorPage(rw, req, http.StatusForbidden, err.Error())
 		return
 	}
 

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -913,7 +913,7 @@ func (p *OAuthProxy) OAuthCallback(rw http.ResponseWriter, req *http.Request) {
 		// the pre-v7.7.1 behaviour and is consistent with the other auth-failure
 		// paths below (CSRF cookie missing, CSRF mismatch), which also return 403.
 		logger.Errorf("Error while parsing OAuth2 state: %v", err)
-		p.ErrorPage(rw, req, http.StatusForbidden, err.Error())
+		p.ErrorPage(rw, req, http.StatusForbidden, err.Error(), "Login Failed: invalid or missing state parameter.")
 		return
 	}
 

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -2087,6 +2087,43 @@ func Test_noCacheHeaders(t *testing.T) {
 	})
 }
 
+func TestOAuthCallbackMalformedStateIsClientError(t *testing.T) {
+	// A crawler/scanner that hits /oauth2/callback directly sends a missing or
+	// malformed state parameter (no "nonce:redirect" form). This must be
+	// reported as a 4xx auth failure (403), not a 5xx server error, otherwise it
+	// pollutes 5xx-based alerting even though the proxy is healthy.
+	opts := baseTestOptions()
+	err := validation.Validate(opts)
+	require.NoError(t, err)
+
+	proxy, err := NewOAuthProxy(opts, func(string) bool { return true })
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name  string
+		state string
+	}{
+		{name: "EmptyState", state: ""},
+		{name: "NoColonSeparator", state: "garbage"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(
+				http.MethodGet,
+				fmt.Sprintf("/oauth2/callback?code=abc&state=%s", url.QueryEscape(tc.state)),
+				nil,
+			)
+			proxy.ServeHTTP(rec, req)
+
+			assert.Equal(t, http.StatusForbidden, rec.Code)
+			assert.Less(t, rec.Code, http.StatusInternalServerError,
+				"malformed state must not be reported as a 5xx server error")
+		})
+	}
+}
+
 func TestSignOutCallsBackendLogoutURL(t *testing.T) {
 	const testIDToken = "test-id-token-12345"
 	var receivedURL string


### PR DESCRIPTION
## Description

`/oauth2/callback` returns **HTTP 500** when the `state` parameter is missing or
malformed (cannot be split into the expected `nonce:redirect` form). In that case
`decodeState` returns `invalid length` and `OAuthCallback` renders a
`500 Internal Server Error`:

```go
nonce, appRedirect, err := decodeState(req.Form.Get("state"), p.encodeState)
if err != nil {
    logger.Errorf("Error while parsing OAuth2 state: %v", err)
    p.ErrorPage(rw, req, http.StatusInternalServerError, err.Error()) // <- 500
    return
}
```

A missing/malformed `state` means the request never went through `/oauth2/start`
— it is a client/auth failure, not a server error. In practice this is triggered
constantly by crawlers and security scanners hitting the callback URL directly
(e.g. `meta-externalagent`). Reporting it as `5xx` makes a perfectly healthy proxy
look like it is failing and trips 5xx-based alerting/SLOs.

This PR changes that single error path to return **403 Forbidden**, which:
- correctly classifies it as a client/auth failure (4xx), not a server error;
- leaks minimal information to the caller, as requested in #2822;
- is **consistent with the other auth-failure paths** in the same `OAuthCallback`
  function, which already return 403 (CSRF cookie missing, CSRF token mismatch);
- restores the behaviour that existed before v7.7.1 (which returned 403 here).

## Motivation and Context

Fixes #2822
Refs #2833

`#2822` ("Invalid callback request should be denied") asks for exactly this: an
invalid callback should be denied with a 4xx, not return 500. `#2833` reports the
same `invalid length` 500 symptom (its underlying cause — double-encoded state on
Azure/Entra — is a separate functional bug; this PR only fixes the incorrect status
classification, hence "Refs" and not "Fixes").

## How Has This Been Tested?

- New regression test `TestOAuthCallbackMalformedStateIsClientError` covering an
  empty state and a non-colon-delimited state — both must return 403 and must not
  be a 5xx.
- Full root-package test suite (`go test ./`) and `go vet ./` pass.
- End-to-end against a binary built from this branch, reproducing the scanner case:

  | Request to `/oauth2/callback` | before (v7.14.2) | after (this PR) |
  |---|---|---|
  | `?code=abc&state=garbage` (no `:`) | 500 | **403** |
  | no `state` at all | 500 | **403** |
  | `?code=abc&state=foo:bar` (valid form, missing CSRF cookie) | 403 | 403 (unchanged) |

  Only the state-parse path changes; the CSRF-cookie validation path is untouched.

## Checklist

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the CHANGELOG.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits are signed off (DCO).
