### PR TITLE
fix: renew session refresh lock lease during provider redeem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Changes since v7.15.3
 
+- [#3456](https://github.com/oauth2-proxy/oauth2-proxy/pull/3456) fix: renew the session refresh lock lease during the provider redeem so a slow refresh cannot expire the lock mid-flight and cause a concurrent double-redeem of single-use rotating refresh tokens (@ohadkedem)
+
 # V7.15.3
 
 ## Release Highlights

--- a/pkg/middleware/stored_session.go
+++ b/pkg/middleware/stored_session.go
@@ -215,6 +215,27 @@ func (s *storedSessionLoader) refreshSessionIfNeeded(rw http.ResponseWriter, req
 
 	// We are holding the lock and the session needs a refresh
 	logger.Printf("Refreshing session - User: %s; SessionAge: %s", session.User, session.Age())
+
+	// Renew the lock lease while the (possibly slow) provider redeem runs, so a
+	// fixed-TTL lock cannot expire mid-refresh and let a concurrent request
+	// re-present and double-redeem the single-use rotating refresh token.
+	stopWatchdog := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(sessionRefreshLockDuration / 3)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stopWatchdog:
+				return
+			case <-ticker.C:
+				if lockErr := session.RefreshLock(context.Background(), sessionRefreshLockDuration); lockErr != nil {
+					logger.Errorf("unable to renew session lock during refresh: %v", lockErr)
+				}
+			}
+		}
+	}()
+	defer close(stopWatchdog)
+
 	if err := s.refreshSession(rw, req, session); err != nil {
 		logger.Errorf("Unable to refresh session: %v", err)
 

--- a/pkg/middleware/stored_session_watchdog_test.go
+++ b/pkg/middleware/stored_session_watchdog_test.go
@@ -1,0 +1,83 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	sessionsapi "github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/sessions"
+)
+
+type countingLock struct {
+	mu        sync.Mutex
+	locked    bool
+	refreshes int
+}
+
+func (l *countingLock) Obtain(context.Context, time.Duration) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.locked = true
+	return nil
+}
+
+func (l *countingLock) Peek(context.Context) (bool, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.locked, nil
+}
+
+func (l *countingLock) Refresh(context.Context, time.Duration) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.refreshes++
+	return nil
+}
+
+func (l *countingLock) Release(context.Context) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.locked = false
+	return nil
+}
+
+func (l *countingLock) count() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.refreshes
+}
+
+func TestRefreshLockLeaseIsRenewedDuringSlowRedeem(t *testing.T) {
+	lock := &countingLock{}
+	createdPast := time.Now().Add(-5 * time.Minute)
+	session := &sessionsapi.SessionState{RefreshToken: "Refresh", CreatedAt: &createdPast, Lock: lock}
+
+	store := &fakeSessionStore{
+		LoadFunc: func(*http.Request) (*sessionsapi.SessionState, error) {
+			fresh := *session
+			fresh.Lock = &testLock{}
+			return &fresh, nil
+		},
+		SaveFunc: func(http.ResponseWriter, *http.Request, *sessionsapi.SessionState) error { return nil },
+	}
+
+	s := &storedSessionLoader{
+		refreshPeriod: time.Minute,
+		store:         store,
+		sessionRefresher: func(context.Context, *sessionsapi.SessionState) (bool, error) {
+			time.Sleep(sessionRefreshLockDuration) // redeem slower than the un-renewed lock TTL
+			return true, nil
+		},
+		sessionValidator: func(context.Context, *sessionsapi.SessionState) bool { return true },
+	}
+
+	if err := s.refreshSessionIfNeeded(nil, httptest.NewRequest("", "/", nil), session); err != nil {
+		t.Fatalf("refreshSessionIfNeeded returned error: %v", err)
+	}
+	if got := lock.count(); got < 1 {
+		t.Fatalf("expected the lock lease to be renewed at least once during a slow redeem, got %d", got)
+	}
+}


### PR DESCRIPTION
## Description

The per-session refresh lock is acquired with a fixed 2s TTL (`sessionRefreshLockDuration`) and is **never renewed** while `refreshSession` (the provider token redeem) is in flight. If a redeem takes longer than the TTL, the lock expires mid-refresh, a second concurrent request acquires it, re-presents the now-rotated refresh token, and providers that issue **single-use rotating refresh tokens** (e.g. Dex) return `invalid_grant` / "refresh token claimed twice" — invalidating the user's session.

This is the textbook "lock TTL shorter than the protected work" failure, and it affects both single-replica (two goroutines) and multi-replica (shared Redis lock) deployments.

This PR wires the existing — but previously unused — `Lock.Refresh` lease-renewal into a small watchdog goroutine that renews the lease every `sessionRefreshLockDuration/3` until the redeem completes, so the lock cannot expire while it is held. The renewal primitive already exists at every layer (`SessionState.RefreshLock` → `redis.Lock.Refresh` via `bsm/redislock`), so no new dependency is added.

## Motivation and Context

Fixes the concurrent-refresh double-redeem that logs users out (#1992), and implements the single-flight/synchronization intent originally proposed in #667.

## How Has This Been Tested?

Added `TestRefreshLockLeaseIsRenewedDuringSlowRedeem`: a refresher that outlasts the lock TTL must observe the lease renewed at least once. It passes with `-race`, and the full `pkg/middleware` suite passes with `-race` (no regression, no data race in the watchdog goroutine).

## Checklist:

- [x] I have added an entry for my changes to the CHANGELOG.md.
- [x] I have signed off all my commits.
- [x] I have created a feature (non-master) branch for my PR.
- [x] I have used conventional commits for the PR title.
- [x] I have written tests for my code changes.