### PR TITLE
fix: include the provider's error_description on the callback error page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Changes since v7.15.3
 
+- [#3459](https://github.com/oauth2-proxy/oauth2-proxy/pull/3459) fix: include the provider's error_description on the OAuth2 callback error page (#3458) (@Molaire)
+
 # V7.15.3
 
 ## Release Highlights

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -896,10 +896,21 @@ func (p *OAuthProxy) OAuthCallback(rw http.ResponseWriter, req *http.Request) {
 	}
 	errorString := req.Form.Get("error")
 	if errorString != "" {
-		logger.Errorf("Error while parsing OAuth2 callback: %s", errorString)
+		// Many providers (e.g. Okta, Entra ID, Keycloak) return a human-readable
+		// error_description alongside the error code. Surfacing it lets end users
+		// distinguish causes of an otherwise opaque code such as access_denied
+		// (for example "User is not assigned to the application" versus a policy
+		// denial) without needing access to the proxy logs.
+		errorDescription := req.Form.Get("error_description")
+		logger.Errorf("Error while parsing OAuth2 callback: %s %s", errorString, errorDescription)
 		message := fmt.Sprintf("Login Failed: The upstream identity provider returned an error: %s", errorString)
-		// Set the debug message and override the non debug message to be the same for this case
-		p.ErrorPage(rw, req, http.StatusForbidden, message, message)
+		if errorDescription != "" {
+			message = fmt.Sprintf("%s: %s", message, errorDescription)
+		}
+		// Set the debug message and override the non debug message to be the same
+		// for this case. The message is passed as an argument rather than a format
+		// string so a provider-supplied description containing '%' is rendered verbatim.
+		p.ErrorPage(rw, req, http.StatusForbidden, message, "%s", message)
 		return
 	}
 

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -843,6 +843,33 @@ func TestSignInPageSkipProviderDirect(t *testing.T) {
 	}
 }
 
+func TestOAuthCallbackProviderErrorIncludesDescription(t *testing.T) {
+	sipTest, err := NewSignInPageTest(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Okta (and other OIDC providers) return error_description alongside the
+	// error code when, for example, the user is not assigned the application.
+	code, body := sipTest.GetEndpoint(
+		"/oauth2/callback?error=access_denied&error_description=User+is+not+assigned+to+the+client+application.",
+	)
+	assert.Equal(t, http.StatusForbidden, code)
+	assert.Contains(t, body, "access_denied")
+	assert.Contains(t, body, "User is not assigned to the client application.")
+}
+
+func TestOAuthCallbackProviderErrorWithoutDescription(t *testing.T) {
+	sipTest, err := NewSignInPageTest(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	code, body := sipTest.GetEndpoint("/oauth2/callback?error=access_denied")
+	assert.Equal(t, http.StatusForbidden, code)
+	assert.Contains(t, body, "The upstream identity provider returned an error: access_denied")
+}
+
 type ProcessCookieTest struct {
 	opts         *options.Options
 	proxy        *OAuthProxy


### PR DESCRIPTION
## Description

When an identity provider redirects to `/oauth2/callback` with an error, `OAuthCallback` only read the `error` query parameter and discarded the optional `error_description`. This change appends `error_description` to the error page message when the provider supplies it.

```go
errorString := req.Form.Get("error")
if errorString != "" {
    errorDescription := req.Form.Get("error_description")
    logger.Errorf("Error while parsing OAuth2 callback: %s %s", errorString, errorDescription)
    message := fmt.Sprintf("Login Failed: The upstream identity provider returned an error: %s", errorString)
    if errorDescription != "" {
        message = fmt.Sprintf("%s: %s", message, errorDescription)
    }
    p.ErrorPage(rw, req, http.StatusForbidden, message, "%s", message)
    return
}
```

`error_description` is optional per [RFC 6749 §4.1.2.1](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1), so it is only appended when present — the message is **unchanged** for providers that omit it.

The user-facing message is now passed as a printf **argument** (`"%s", message`) rather than as the format string itself. This hardens against a provider-supplied description that contains `%`, which `getMessage` would otherwise interpret as a format verb.

## Motivation and Context

`access_denied` is heavily overloaded. With Okta, an unassigned user gets:

```
error=access_denied
error_description=User is not assigned to the client application.
```

Without the description, the end user only sees `Login Failed: The upstream identity provider returned an error: access_denied` and cannot tell "I need to be granted access (ask IT)" apart from a different failure such as an expired session or misconfiguration. That detail previously lived only in the proxy logs, which end users cannot see. Surfacing `error_description` makes the error page self-service.

Fixes #3458

## How Has This Been Tested?

- Added `TestOAuthCallbackProviderErrorIncludesDescription`: a callback with `error=access_denied&error_description=User+is+not+assigned+to+the+client+application.` returns `403` and the page body contains the description.
- Added `TestOAuthCallbackProviderErrorWithoutDescription`: a callback with only `error=access_denied` returns `403` with the original message (back-compat).
- `go build ./...` and `go test ./` pass.

## Checklist:

- [x] I have added an entry for my changes to the [CHANGELOG.md](https://github.com/oauth2-proxy/oauth2-proxy/blob/master/CHANGELOG.md).
- [x] I have [signed off](https://github.com/apps/dco) all my commits.
- [x] I have created a feature (non-master) branch for my PR.
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#examples) for the PR title.
- [x] I have written tests for my code changes.
