### PR TITLE
docs: fix invalid nginx error_page 401 example for API routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## Breaking Changes
 
 ## Changes since v7.15.3
+- [#3469](https://github.com/oauth2-proxy/oauth2-proxy/pull/3469) docs: fix invalid `error_page 401 =401` in the nginx API route example and note that the shared `auth_request` config must be replicated
 
 # V7.15.3
 

--- a/docs/docs/configuration/integrations/nginx.md
+++ b/docs/docs/configuration/integrations/nginx.md
@@ -119,6 +119,10 @@ The named location pattern above ensures the browser receives a standard **302 r
 Redirecting authentication failures (302 to `/oauth2/sign_in`) should **only be used for browser-facing routes**. API or machine clients should receive a plain 401/403 response without redirect.
 :::
 
+:::note
+The two snippets below show only the routing difference (redirect vs. no redirect). Replicate the rest of the `auth_request` configuration from the [main `location /` example](#configuring-for-use-with-the-nginx-auth_request-directive) above (the `auth_request_set`/`proxy_set_header` lines that pass `X-User`, `X-Email`, the access token and cookies to the backend); copying only the lines shown here omits those headers.
+:::
+
 #### Browser-facing routes (HTML, UI)
 
 For interactive browser routes where users should be redirected to sign in:
@@ -142,7 +146,8 @@ For API endpoints where clients expect a 401/403 status code (not a redirect):
 ```nginx
 location /api/ {
   auth_request /oauth2/auth;
-  error_page 401 =401;  # Pass through the 401 status
+  # No `error_page 401` directive: nginx returns the 401 from auth_request
+  # to the client unchanged, which is what API/machine clients expect.
   proxy_pass http://backend/;
 }
 ```


### PR DESCRIPTION
## Description

Fixes the API/machine route example in the nginx integration docs. It used `error_page 401 =401;`, but nginx parses `=401` as the error_page URI, so an unauthenticated API call is internally redirected to a location named `/=401` instead of returning 401 to the client. The directive is dropped: without an `error_page 401`, nginx returns the 401 from `auth_request` to the client unchanged, which is what API/machine clients expect.

Also adds a note (per @robinp on the issue) that the browser and API snippets show only the routing difference, and the rest of the `auth_request` config from the main example (the `auth_request_set`/`proxy_set_header` lines passing `X-User`, `X-Email`, the access token and cookies) must be replicated, otherwise those headers are silently omitted.

## Motivation and Context

Fixes #3467. The current example produces a broken config: unauthed API calls redirect to `/=401` rather than passing the 401 through.

## How Has This Been Tested?

Docs-only change. Verified the `:::note` admonition matches the existing Docusaurus admonitions in the file and the anchor link resolves to the `Configuring for use with the Nginx auth_request directive` heading. The 401 pass-through behaviour (no `error_page 401` means nginx returns the auth_request 401 to the client) is standard `auth_request` behaviour and was confirmed by the reporter, who tested dropping the directive.

## Checklist:

- [x] I have added an entry for my changes to the CHANGELOG.md.
- [x] I have signed off all my commits.
- [x] I have created a feature (non-master) branch for my PR.
- [x] I have used conventional commits for the PR title.
- [ ] I have written tests for my code changes. (N/A - documentation only)