### PR TITLE
fix: apply signing algorithms to extra JWT issuers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Changes since v7.15.3
 
+- [#3472](https://github.com/oauth2-proxy/oauth2-proxy/pull/3472) fix: apply configured signing algorithms to extra JWT issuers (#3471) (@Bortlesboat)
+
 # V7.15.3
 
 ## Release Highlights

--- a/pkg/validation/options.go
+++ b/pkg/validation/options.go
@@ -61,6 +61,7 @@ func Validate(o *options.Options) error {
 				verifier, err := newVerifierFromJwtIssuer(
 					o.Providers[0].OIDCConfig.AudienceClaims,
 					o.Providers[0].OIDCConfig.ExtraAudiences,
+					o.Providers[0].OIDCConfig.EnabledSigningAlgs,
 					jwtIssuer,
 				)
 				if err != nil {
@@ -143,13 +144,8 @@ func parseJwtIssuers(issuers []string, msgs []string) ([]jwtIssuer, []string) {
 
 // newVerifierFromJwtIssuer takes in issuer information in jwtIssuer info and returns
 // a verifier for that issuer.
-func newVerifierFromJwtIssuer(audienceClaims []string, extraAudiences []string, jwtIssuer jwtIssuer) (internaloidc.IDTokenVerifier, error) {
-	pvOpts := internaloidc.ProviderVerifierOptions{
-		AudienceClaims: audienceClaims,
-		ClientID:       jwtIssuer.audience,
-		ExtraAudiences: extraAudiences,
-		IssuerURL:      jwtIssuer.issuerURI,
-	}
+func newVerifierFromJwtIssuer(audienceClaims []string, extraAudiences []string, supportedSigningAlgs []string, jwtIssuer jwtIssuer) (internaloidc.IDTokenVerifier, error) {
+	pvOpts := providerVerifierOptionsFromJwtIssuer(audienceClaims, extraAudiences, supportedSigningAlgs, jwtIssuer)
 
 	pv, err := internaloidc.NewProviderVerifier(context.TODO(), pvOpts)
 	if err != nil {
@@ -164,6 +160,16 @@ func newVerifierFromJwtIssuer(audienceClaims []string, extraAudiences []string, 
 	}
 
 	return pv.Verifier(), nil
+}
+
+func providerVerifierOptionsFromJwtIssuer(audienceClaims []string, extraAudiences []string, supportedSigningAlgs []string, jwtIssuer jwtIssuer) internaloidc.ProviderVerifierOptions {
+	return internaloidc.ProviderVerifierOptions{
+		AudienceClaims:       audienceClaims,
+		ClientID:             jwtIssuer.audience,
+		ExtraAudiences:       extraAudiences,
+		IssuerURL:            jwtIssuer.issuerURI,
+		SupportedSigningAlgs: supportedSigningAlgs,
+	}
 }
 
 // jwtIssuer hold parsed JWT issuer info that's used to construct a verifier.

--- a/pkg/validation/options_test.go
+++ b/pkg/validation/options_test.go
@@ -107,6 +107,24 @@ func TestInitializedOptions(t *testing.T) {
 	assert.Equal(t, nil, Validate(o))
 }
 
+func TestProviderVerifierOptionsFromJwtIssuer(t *testing.T) {
+	audienceClaims := []string{"aud", "client_id"}
+	extraAudiences := []string{"extra-audience"}
+	supportedSigningAlgs := []string{"RS256", "ES256"}
+	issuer := jwtIssuer{
+		issuerURI: "https://issuer.example.com",
+		audience:  "client-id",
+	}
+
+	got := providerVerifierOptionsFromJwtIssuer(audienceClaims, extraAudiences, supportedSigningAlgs, issuer)
+
+	assert.Equal(t, audienceClaims, got.AudienceClaims)
+	assert.Equal(t, issuer.audience, got.ClientID)
+	assert.Equal(t, extraAudiences, got.ExtraAudiences)
+	assert.Equal(t, issuer.issuerURI, got.IssuerURL)
+	assert.Equal(t, supportedSigningAlgs, got.SupportedSigningAlgs)
+}
+
 // Note that it's not worth testing nonparseable URLs, since url.Parse()
 // seems to parse damn near anything.
 func TestRedirectURL(t *testing.T) {


### PR DESCRIPTION
## Description

Pass the primary OIDC provider's configured `EnabledSigningAlgs` into verifier construction for every `--extra-jwt-issuers` entry. The fallback no-discovery verifier reuses the same options, so configured algorithms apply consistently on both discovery paths.

A focused regression covers the complete verifier-option mapping, including ES256 alongside RS256.

## Motivation and Context

Extra JWT issuers currently omit `SupportedSigningAlgs`, leaving the underlying verifier at its RS256 default even when `--oidc-enabled-signing-alg=ES256` is configured. Valid ES256 bearer tokens are therefore rejected for extra issuers while working for the primary issuer.

Fixes #3471.

## How Has This Been Tested?

- `go test ./pkg/validation -run '^TestProviderVerifierOptionsFromJwtIssuer$' -count=1`
- `go build ./pkg/validation`
- `go vet ./pkg/validation`
- `gofmt` on changed Go files
- `git diff --check`

The full validation package reaches 66/69 specs on Windows. The three failures are existing platform-specific message assertions in `sessions_test.go` and `common_test.go` (`connect` vs Windows `connectex`, and Unix vs Windows file-error wording); they do not exercise this change.

## Checklist

- [x] I have added an entry for my changes to the CHANGELOG.md.
- [x] I have signed off all my commits.
- [x] I have created a feature (non-master) branch for my PR.
- [x] I have used conventional commits for the PR title.
- [x] I have written tests for my code changes.
