### PR TITLE
docs: clarify alpha config secret values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Changes since v7.15.3
 
+- [#3484](https://github.com/oauth2-proxy/oauth2-proxy/pull/3484) docs: clarify alpha config secret values (@Guflly)
+
 # V7.15.3
 
 ## Release Highlights

--- a/docs/docs/configuration/alpha_config.md
+++ b/docs/docs/configuration/alpha_config.md
@@ -143,29 +143,33 @@ injectRequestHeaders:
           claim: "email" # extract the email claim contents from the id token
   - name: "X-Static-Secret"
     values:
-      # secrets need to be encoded with base64 when directly in the yaml config but will be send decoded
       - secretSource:
-          value: "c3VwZXItc2VjcmV0"
+          value: "super-secret"
+  - name: "X-Static-Binary-Secret"
+    values:
+      - secretSource:
+          value: !!binary c3VwZXItc2VjcmV0
   - name: "X-Static-File-Secret"
+    values:
       - secretSource:
           fromFile: "/path/to/my/secret"
   - name: "X-Static-Env-Secret"
+    values:
       - secretSource:
-          value: "${MY_SECRET_ENV}" # content still needs to be base64 encoded
+          fromEnv: "MY_SECRET_ENV"
 injectResponseHeaders:
   # Following will result in a header "Authorization: Basic <user:password> (encoded)"
   - name: "Authorization"
     values:
     - claimSource:
         claim: user
-        prefix: "Basic "
         basicAuthPassword:
-          value: c3VwZXItc2VjcmV0LXBhc3N3b3Jk # base64 encoded password
+          value: super-secret-password
 ```
 
-**Value sources:** 
+**Value sources:**
 * `claimSource` - `claim` (session claims either from id token or from profile URL)
-* `secretSource` - `value` (base64), `fromFile` (file path)
+* `secretSource` - `value` (literal string or `!!binary` value), `fromEnv` (environment variable), `fromFile` (file path)
 
 **Request option:** `preserveRequestValue: true` retains existing header values
 
@@ -410,12 +414,8 @@ make up the header value
 
 | Field | Type | Description |
 | ----- | ---- | ----------- |
-| `value` | _[]byte_ | Value expects a base64 encoded string value. |
-| `fromEnv` | _string_ | FromEnv expects the name of an environment variable. |
-| `fromFile` | _string_ | FromFile expects a path to a file containing the secret value. |
-| `claim` | _string_ | Claim is the name of the claim in the session that the value should be<br/>loaded from. Available claims: `access_token` `id_token` `created_at`<br/>`expires_on` `refresh_token` `email` `user` `groups` `preferred_username`. |
-| `prefix` | _string_ | Prefix is an optional prefix that will be prepended to the value of the<br/>claim if it is non-empty. |
-| `basicAuthPassword` | _[SecretSource](#secretsource)_ | BasicAuthPassword converts this claim into a basic auth header.<br/>Note the value of claim will become the basic auth username and the<br/>basicAuthPassword will be used as the password value. |
+| `secretSource` | _[SecretSource](#secretsource)_ | Allow users to load the value from a secret source |
+| `claimSource` | _[ClaimSource](#claimsource)_ | Allow users to load the value from a session claim |
 
 ### KeycloakOptions
 
@@ -624,7 +624,7 @@ Only one source within the struct should be defined at any time.
 
 | Field | Type | Description |
 | ----- | ---- | ----------- |
-| `value` | _[]byte_ | Value expects a base64 encoded string value. |
+| `value` | _[]byte_ | Value is used as provided. YAML's !!binary tag can be used for base64-encoded input. |
 | `fromEnv` | _string_ | FromEnv expects the name of an environment variable. |
 | `fromFile` | _string_ | FromFile expects a path to a file containing the secret value. |
 

--- a/docs/docs/configuration/alpha_config.md.tmpl
+++ b/docs/docs/configuration/alpha_config.md.tmpl
@@ -143,29 +143,33 @@ injectRequestHeaders:
           claim: "email" # extract the email claim contents from the id token
   - name: "X-Static-Secret"
     values:
-      # secrets need to be encoded with base64 when directly in the yaml config but will be send decoded
       - secretSource:
-          value: "c3VwZXItc2VjcmV0"
+          value: "super-secret"
+  - name: "X-Static-Binary-Secret"
+    values:
+      - secretSource:
+          value: !!binary c3VwZXItc2VjcmV0
   - name: "X-Static-File-Secret"
+    values:
       - secretSource:
           fromFile: "/path/to/my/secret"
   - name: "X-Static-Env-Secret"
+    values:
       - secretSource:
-          value: "${MY_SECRET_ENV}" # content still needs to be base64 encoded
+          fromEnv: "MY_SECRET_ENV"
 injectResponseHeaders:
   # Following will result in a header "Authorization: Basic <user:password> (encoded)"
   - name: "Authorization"
     values:
     - claimSource:
         claim: user
-        prefix: "Basic "
         basicAuthPassword:
-          value: c3VwZXItc2VjcmV0LXBhc3N3b3Jk # base64 encoded password
+          value: super-secret-password
 ```
 
-**Value sources:** 
+**Value sources:**
 * `claimSource` - `claim` (session claims either from id token or from profile URL)
-* `secretSource` - `value` (base64), `fromFile` (file path)
+* `secretSource` - `value` (literal string or `!!binary` value), `fromEnv` (environment variable), `fromFile` (file path)
 
 **Request option:** `preserveRequestValue: true` retains existing header values
 

--- a/pkg/apis/options/header.go
+++ b/pkg/apis/options/header.go
@@ -40,10 +40,10 @@ type Header struct {
 // make up the header value
 type HeaderValue struct {
 	// Allow users to load the value from a secret source
-	*SecretSource `yaml:"secretSource,omitempty"`
+	SecretSource *SecretSource `yaml:"secretSource,omitempty"`
 
 	// Allow users to load the value from a session claim
-	*ClaimSource `yaml:"claimSource,omitempty"`
+	ClaimSource *ClaimSource `yaml:"claimSource,omitempty"`
 }
 
 // ClaimSource allows loading a header value from a claim within the session

--- a/pkg/apis/options/load_test.go
+++ b/pkg/apis/options/load_test.go
@@ -533,6 +533,8 @@ injectResponseHeaders:
   values:
   - secretSource:
       value: secret
+  - secretSource:
+      value: !!binary YmluYXJ5LXNlY3JldA==
 `)
 
 		By("Creating a config file")
@@ -582,6 +584,11 @@ injectResponseHeaders:
 						{
 							SecretSource: &SecretSource{
 								Value: []byte("secret"),
+							},
+						},
+						{
+							SecretSource: &SecretSource{
+								Value: []byte("binary-secret"),
 							},
 						},
 					},

--- a/pkg/apis/options/secret_source.go
+++ b/pkg/apis/options/secret_source.go
@@ -3,7 +3,7 @@ package options
 // SecretSource references an individual secret value.
 // Only one source within the struct should be defined at any time.
 type SecretSource struct {
-	// Value expects a base64 encoded string value.
+	// Value is used as provided. YAML's !!binary tag can be used for base64-encoded input.
 	Value []byte `yaml:"value,omitempty"`
 
 	// FromEnv expects the name of an environment variable.


### PR DESCRIPTION
## Description

Clarifies how alpha config secret values are loaded, fixes the custom header examples, and shows the nested `HeaderValue` fields in the generated reference.

The config load test now covers plain and `!!binary` values.

## Motivation and Context

Fixes #3334.

## How Has This Been Tested?

- `go test ./pkg/apis/options`
- `go test ./pkg/header`
- `golangci-lint run --new-from-rev=HEAD`
- `npm run build`

## Checklist:

- [x] I have added an entry for my changes to the [CHANGELOG.md](https://github.com/oauth2-proxy/oauth2-proxy/blob/master/CHANGELOG.md).
- [x] I have [signed off](https://github.com/apps/dco) all my commits.
- [x] I have created a feature (non-master) branch for my PR.
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#examples) for the PR title.
- [x] I have written tests for my code changes.
