### PR TITLE
MCP client compatibility: RFC 9728 Protected Resource Metadata + RFC 7591 Dynamic Client Registration proxying

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -46,14 +46,15 @@ const (
 	schemeHTTPS     = "https"
 	applicationJSON = "application/json"
 
-	robotsPath        = "/robots.txt"
-	signInPath        = "/sign_in"
-	signOutPath       = "/sign_out"
-	oauthStartPath    = "/start"
-	oauthCallbackPath = "/callback"
-	authOnlyPath      = "/auth"
-	userInfoPath      = "/userinfo"
-	staticPathPrefix  = "/static/"
+	robotsPath                    = "/robots.txt"
+	protectedResourceMetadataPath = "/.well-known/oauth-protected-resource"
+	signInPath                    = "/sign_in"
+	signOutPath                   = "/sign_out"
+	oauthStartPath                = "/start"
+	oauthCallbackPath             = "/callback"
+	authOnlyPath                  = "/auth"
+	userInfoPath                  = "/userinfo"
+	staticPathPrefix              = "/static/"
 
 	idTokenPlaceholder = "{id_token}"
 )
@@ -118,6 +119,12 @@ type OAuthProxy struct {
 	appDirector       redirect.AppDirector
 
 	encodeState bool
+
+	// oidcIssuerURL is the configured OIDC issuer, exposed via
+	// /.well-known/oauth-protected-resource (RFC 9728) so MCP-spec OAuth
+	// clients can discover the authorization server. See
+	// ProtectedResourceMetadata.
+	oidcIssuerURL string
 }
 
 // NewOAuthProxy creates a new instance of OAuthProxy from the options provided
@@ -253,6 +260,7 @@ func NewOAuthProxy(opts *options.Options, validator func(string) bool) (*OAuthPr
 		redirectValidator:  redirectValidator,
 		appDirector:        appDirector,
 		encodeState:        opts.EncodeState,
+		oidcIssuerURL:      opts.Providers[0].OIDCConfig.IssuerURL,
 	}
 	p.buildServeMux(opts.ProxyPrefix)
 
@@ -324,6 +332,12 @@ func (p *OAuthProxy) buildServeMux(proxyPrefix string) {
 
 	// Register the robots path writer
 	r.Path(robotsPath).HandlerFunc(p.pageWriter.WriteRobotsTxt)
+
+	// RFC 9728 Protected Resource Metadata MUST live at the host root, not
+	// under proxyPrefix (unlike sign_in/start/callback below) - MCP clients
+	// build this well-known URL themselves and don't know about our
+	// ProxyPrefix. See ProtectedResourceMetadata.
+	r.Path(protectedResourceMetadataPath).HandlerFunc(p.ProtectedResourceMetadata)
 
 	// The authonly path should be registered separately to prevent it from getting no-cache headers.
 	// We do this to allow users to have a short cache (via nginx) of the response to reduce the
@@ -1057,7 +1071,7 @@ func (p *OAuthProxy) Proxy(rw http.ResponseWriter, req *http.Request) {
 		if p.forceJSONErrors || isAjax(req) || p.isAPIPath(req) {
 			logger.Printf("No valid authentication in request. Access Denied.")
 			// no point redirecting an AJAX request
-			p.errorJSON(rw, http.StatusUnauthorized)
+			p.unauthorizedJSON(rw, req)
 			return
 		}
 
@@ -1342,6 +1356,49 @@ func (p *OAuthProxy) errorJSON(rw http.ResponseWriter, code int) {
 	// we need to send some JSON response because we set the Content-Type to
 	// application/json
 	rw.Write([]byte("{}"))
+}
+
+// unauthorizedJSON returns a 401 with a WWW-Authenticate header pointing at
+// this server's OAuth 2.0 Protected Resource Metadata document (RFC 9728),
+// and a non-empty OAuth-shaped JSON error body (RFC 6750 section 3) -
+// required for MCP clients (modelcontextprotocol.io/specification/
+// 2025-06-18/basic/authorization) to discover how to authenticate. Plain
+// errorJSON's empty "{}" body and missing header left MCP clients unable
+// to parse the response as a valid OAuth error at all.
+func (p *OAuthProxy) unauthorizedJSON(rw http.ResponseWriter, req *http.Request) {
+	metadataURL := url.URL{
+		Scheme: requestutil.GetRequestProto(req),
+		Host:   requestutil.GetRequestHost(req),
+		Path:   protectedResourceMetadataPath,
+	}
+	rw.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer resource_metadata=%q`, metadataURL.String()))
+	rw.Header().Set("Content-Type", applicationJSON)
+	rw.WriteHeader(http.StatusUnauthorized)
+	rw.Write([]byte(`{"error":"unauthorized","error_description":"authentication required"}`))
+}
+
+// ProtectedResourceMetadata serves OAuth 2.0 Protected Resource Metadata
+// (RFC 9728) at the well-known path MCP clients fetch after receiving a 401
+// with a WWW-Authenticate header (see unauthorizedJSON). Points clients at
+// the OIDC issuer this proxy is already configured with - the issuer's own
+// RFC 8414 Authorization Server Metadata (a document oauth2-proxy does not
+// need to serve itself) tells the client where to actually authenticate.
+func (p *OAuthProxy) ProtectedResourceMetadata(rw http.ResponseWriter, req *http.Request) {
+	resource := url.URL{
+		Scheme: requestutil.GetRequestProto(req),
+		Host:   requestutil.GetRequestHost(req),
+	}
+	body, err := json.Marshal(map[string]interface{}{
+		"resource":              resource.String(),
+		"authorization_servers": []string{p.oidcIssuerURL},
+	})
+	if err != nil {
+		p.errorJSON(rw, http.StatusInternalServerError)
+		return
+	}
+	rw.Header().Set("Content-Type", applicationJSON)
+	rw.WriteHeader(http.StatusOK)
+	rw.Write(body)
 }
 
 // LoggingCSRFCookiesInOAuthCallback Log all CSRF cookies found in HTTP request OAuth callback,

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"embed"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -48,6 +50,7 @@ const (
 
 	robotsPath                    = "/robots.txt"
 	protectedResourceMetadataPath = "/.well-known/oauth-protected-resource"
+	dynamicClientRegistrationPath = "/register"
 	signInPath                    = "/sign_in"
 	signOutPath                   = "/sign_out"
 	oauthStartPath                = "/start"
@@ -338,6 +341,14 @@ func (p *OAuthProxy) buildServeMux(proxyPrefix string) {
 	// build this well-known URL themselves and don't know about our
 	// ProxyPrefix. See ProtectedResourceMetadata.
 	r.Path(protectedResourceMetadataPath).HandlerFunc(p.ProtectedResourceMetadata)
+
+	// Also host root, not under proxyPrefix, for the same reason - MCP
+	// clients (confirmed against Claude Code) request RFC 7591 Dynamic
+	// Client Registration at <this proxy's own origin>/register rather
+	// than the authorization server's real advertised
+	// registration_endpoint, even after correctly resolving that server
+	// via RFC 9728/8414 discovery. See DynamicClientRegistration.
+	r.Path(dynamicClientRegistrationPath).HandlerFunc(p.DynamicClientRegistration)
 
 	// The authonly path should be registered separately to prevent it from getting no-cache headers.
 	// We do this to allow users to have a short cache (via nginx) of the response to reduce the
@@ -1399,6 +1410,78 @@ func (p *OAuthProxy) ProtectedResourceMetadata(rw http.ResponseWriter, req *http
 	rw.Header().Set("Content-Type", applicationJSON)
 	rw.WriteHeader(http.StatusOK)
 	rw.Write(body)
+}
+
+// DynamicClientRegistration proxies RFC 7591 Dynamic Client Registration
+// requests to the configured OIDC issuer's own registration_endpoint
+// (discovered from its .well-known/openid-configuration document) and
+// relays the response verbatim, including its status code.
+//
+// MCP clients need this because of the same origin-assumption behavior
+// ProtectedResourceMetadata's WWW-Authenticate header is meant to correct
+// for authorization/token requests: confirmed against Claude Code, once it
+// receives Protected Resource Metadata pointing at an external
+// authorization server, it correctly directs the user's browser to that
+// server's own /authorize and posts to its own /token - but it still POSTs
+// its DCR request to THIS proxy's own /register instead of the issuer's
+// real advertised registration_endpoint. Forwarding the Authorization
+// header lets Initial-Access-Token-gated ("authenticated" RFC 7591)
+// registration work too, not just anonymous.
+func (p *OAuthProxy) DynamicClientRegistration(rw http.ResponseWriter, req *http.Request) {
+	client := &http.Client{Timeout: 10 * time.Second}
+
+	discoveryResp, err := client.Get(strings.TrimSuffix(p.oidcIssuerURL, "/") + "/.well-known/openid-configuration")
+	if err != nil {
+		logger.Errorf("error fetching issuer discovery document for dynamic client registration: %v", err)
+		http.Error(rw, "failed to reach issuer", http.StatusBadGateway)
+		return
+	}
+	defer discoveryResp.Body.Close()
+
+	var discovery struct {
+		RegistrationEndpoint string `json:"registration_endpoint"`
+	}
+	if err := json.NewDecoder(discoveryResp.Body).Decode(&discovery); err != nil || discovery.RegistrationEndpoint == "" {
+		logger.Errorf("issuer discovery document has no registration_endpoint: %v", err)
+		http.Error(rw, "issuer does not support dynamic client registration", http.StatusNotImplemented)
+		return
+	}
+
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		http.Error(rw, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	upstreamReq, err := http.NewRequest(http.MethodPost, discovery.RegistrationEndpoint, bytes.NewReader(body))
+	if err != nil {
+		logger.Errorf("error building dynamic client registration request: %v", err)
+		http.Error(rw, "internal error", http.StatusInternalServerError)
+		return
+	}
+	upstreamReq.Header.Set("Content-Type", applicationJSON)
+	if auth := req.Header.Get("Authorization"); auth != "" {
+		upstreamReq.Header.Set("Authorization", auth)
+	}
+
+	upstreamResp, err := client.Do(upstreamReq)
+	if err != nil {
+		logger.Errorf("error forwarding dynamic client registration request: %v", err)
+		http.Error(rw, "failed to reach issuer", http.StatusBadGateway)
+		return
+	}
+	defer upstreamResp.Body.Close()
+
+	respBody, err := io.ReadAll(upstreamResp.Body)
+	if err != nil {
+		logger.Errorf("error reading dynamic client registration response: %v", err)
+		http.Error(rw, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	rw.Header().Set("Content-Type", applicationJSON)
+	rw.WriteHeader(upstreamResp.StatusCode)
+	rw.Write(respBody)
 }
 
 // LoggingCSRFCookiesInOAuthCallback Log all CSRF cookies found in HTTP request OAuth callback,


### PR DESCRIPTION
## Problem

Fronting an MCP server with oauth2-proxy (a common pattern, especially for OIDC providers - like Authentik, Keycloak, etc. - that don't have first-class MCP support) doesn't work with real MCP clients today, because oauth2-proxy doesn't implement the discovery/registration mechanisms the [MCP Authorization spec](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization) requires:

> MCP servers **MUST** implement OAuth 2.0 Protected Resource Metadata ([RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728)). MCP clients **MUST** use OAuth 2.0 Protected Resource Metadata for authorization server discovery.
>
> MCP servers **MUST** use the HTTP header `WWW-Authenticate` when returning a *401 Unauthorized* to indicate the location of the resource server metadata URL as described in RFC 9728 Section 5.1.

Neither exists in oauth2-proxy today:
- No route for `/.well-known/oauth-protected-resource` (RFC 9728's well-known path).
- The existing JSON-error 401 path (`errorJSON`, hit via `forceJSONErrors`/`isAjax`/`isAPIPath` in `Proxy()`) writes a bare `{}` body and sets no `WWW-Authenticate` header at all.

On top of that, even once a client correctly discovers the real authorization server via RFC 9728, MCP clients (confirmed against Claude Code) still POST their RFC 7591 Dynamic Client Registration request to *this proxy's own* `/register`, not the issuer's real advertised `registration_endpoint` - the same origin-assumption behavior, just for registration instead of the authorize/token steps.

Related to #3167, which asked about MCP server integration but had no implementation or discussion yet.

## Testing evidence

Deployed oauth2-proxy in front of a real MCP server (HashiCorp's official `vault-mcp-server`), OIDC-backed first by Authentik and later by Keycloak, and tried connecting with Claude Code's MCP client. Real failures against stock oauth2-proxy (v7.15.3):

1. Passive health check (`claude mcp list`):
   ```
   vault-mcp: https://vault-mcp-server.example.com/mcp (HTTP) - ✘ Failed to connect —
   HTTP 401: Invalid OAuth error response: ZodError: [ { "expected": "string", "code":
   "invalid_type", "path": [ "error" ], "message": "Invalid input: expected string,
   received undefined" } ]. Raw body: {}
   ```
   The client correctly gets a 401, but can't parse `{}` as a valid OAuth error response.

2. Interactive login (`claude mcp login vault-mcp`), before the RFC 9728 fix:
   ```
   Starting authentication for "vault-mcp"…
   Couldn't complete authentication for "vault-mcp": SDK auth failed: Failed to parse JSON
   ```
   The client attempts to fetch `/.well-known/oauth-protected-resource` per RFC 9728 to discover the authorization server; oauth2-proxy has no such route, so the client gets a non-JSON response and can't proceed at all.

3. Interactive login again, after the RFC 9728 fix but before the DCR proxy fix (against Keycloak, which has real Dynamic Client Registration support unlike Authentik):
   ```
   Starting authentication for "vault-mcp"…
   Couldn't complete authentication for "vault-mcp": SDK auth failed: Failed to parse JSON
   ```
   Same symptom, different cause: the client now correctly resolves Keycloak as the authorization server, but still POSTs its DCR request to oauth2-proxy's own `/register` instead of Keycloak's real `registration_endpoint`. No route exists for it, so the request falls through to oauth2-proxy's normal unauthenticated-redirect behavior, and the client's SDK fails trying to parse that redirect as a JSON registration response.

## Fix

Minimal, additive patch, in two parts:

**1. RFC 9728 Protected Resource Metadata + WWW-Authenticate**

- New `/.well-known/oauth-protected-resource` route, registered at the host root (not under `ProxyPrefix` - MCP clients build this well-known URL themselves against the resource's own origin, with no knowledge of oauth2-proxy's configured prefix). Returns:
  ```json
  {"resource": "https://<host>", "authorization_servers": ["<configured OIDC issuer>"]}
  ```
  No new configuration needed - `resource` is derived per-request from the (trusted, via `--reverse-proxy`) request host/scheme, and `authorization_servers` reuses the already-configured `--oidc-issuer-url`.
- The existing JSON-error 401 path now sets `WWW-Authenticate: Bearer resource_metadata="https://<host>/.well-known/oauth-protected-resource"` and returns a minimal non-empty OAuth-shaped error body (`{"error":"unauthorized","error_description":"authentication required"}`) instead of `{}`.

**2. RFC 7591 Dynamic Client Registration proxying**

- New `/register` route, also at the host root, for the same reason as above.
- `DynamicClientRegistration` discovers the issuer's real `registration_endpoint` from its own `.well-known/openid-configuration` document, and proxies the request there, relaying the response verbatim (status code + body).
- Forwards the `Authorization` header too, so Initial-Access-Token-gated ("authenticated" RFC 7591) registration works, not just anonymous.
- No new dependencies, no new CLI flags - reuses the already-configured `oidcIssuerURL`.

After this patch, deployed against the same real setup: `claude mcp list` no longer errors, and `claude mcp login` completes the full flow end-to-end against a real, unmodified authorization server (Keycloak) - real dynamic client registration, real authorization code exchange, no manual client-id/secret configuration anywhere.

Scope note: this covers the resource-server side of MCP compatibility (RFC 9728 discovery + RFC 7591 registration proxying) for authorization servers that support Dynamic Client Registration. It does not add any workaround for authorization servers that lack DCR entirely (e.g. Authentik as of this writing) - that would require oauth2-proxy to fake being an authorization server itself, a much larger and more IdP-specific change, out of scope here.

## Testing

- `go build ./...`, `go vet ./...`, and `gofmt -l` all pass.
- Manual verification against two live deployments (curl + a real MCP client) as described above - both the RFC 9728 metadata/401 fix and the DCR registration proxy independently confirmed working end-to-end.
- Unit tests not yet added; happy to add coverage for the new routes if that's the right next step for this to be mergeable - wanted to open this to get feedback on the approach first, especially given #3167 had no prior discussion of direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)