### PR TITLE
fix(sessions): clear stale cookie parts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Changes since v7.15.3
 
+- fix: clear stale cookie session parts after session size changes
+
 # V7.15.3
 
 ## Release Highlights

--- a/pkg/sessions/cookie/session_store.go
+++ b/pkg/sessions/cookie/session_store.go
@@ -121,6 +121,35 @@ func (s *SessionStore) setSessionCookie(rw http.ResponseWriter, req *http.Reques
 	if err != nil {
 		return err
 	}
+
+	newCookieNames := make(map[string]struct{}, len(cookies))
+	for _, c := range cookies {
+		newCookieNames[c.Name] = struct{}{}
+	}
+
+	sessionCookieName := regexp.QuoteMeta(s.Cookie.Name)
+	sessionCookiePattern := regexp.MustCompile(fmt.Sprintf("^%s(_\\d+)?$", sessionCookieName))
+	for _, c := range req.Cookies() {
+		if !sessionCookiePattern.MatchString(c.Name) {
+			continue
+		}
+		if _, ok := newCookieNames[c.Name]; ok {
+			continue
+		}
+
+		clearCookieOptions := &pkgcookies.CookieOptions{
+			Name:       c.Name,
+			Value:      "",
+			Domains:    s.Cookie.Domains,
+			Expiration: time.Hour * -1,
+			SameSite:   s.Cookie.SameSite,
+			Path:       s.Cookie.Path,
+			HTTPOnly:   s.Cookie.HTTPOnly,
+			Secure:     s.Cookie.Secure,
+		}
+		http.SetCookie(rw, pkgcookies.MakeCookieFromOptions(req, clearCookieOptions))
+	}
+
 	for _, c := range cookies {
 		http.SetCookie(rw, c)
 	}

--- a/pkg/sessions/cookie/session_store_test.go
+++ b/pkg/sessions/cookie/session_store_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	mathrand "math/rand"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -136,6 +137,74 @@ func Test_splitCookieName(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			splitName := splitCookieName(tc.Name, tc.Count)
 			assert.Equal(t, tc.Output, splitName)
+		})
+	}
+}
+
+func Test_setSessionCookieClearsStaleCookies(t *testing.T) {
+	store := &SessionStore{
+		Cookie: &options.Cookie{
+			Name:   "_oauth2_proxy",
+			Secret: "0123456789abcdef",
+			Path:   "/",
+			Expire: time.Hour,
+		},
+	}
+	now := time.Now()
+
+	testCases := map[string]struct {
+		value             []byte
+		existingCookies   []string
+		wantSessionParts  int
+		wantClearedCookie []string
+	}{
+		"split session becomes a single cookie": {
+			value:             []byte("small session"),
+			existingCookies:   []string{"_oauth2_proxy_0", "_oauth2_proxy_1", "_oauth2_proxy_csrf"},
+			wantSessionParts:  1,
+			wantClearedCookie: []string{"_oauth2_proxy_0", "_oauth2_proxy_1"},
+		},
+		"split session uses fewer parts": {
+			value:             []byte(strings.Repeat("v", 4500)),
+			existingCookies:   []string{"_oauth2_proxy_0", "_oauth2_proxy_1", "_oauth2_proxy_2", "_oauth2_proxy_3"},
+			wantSessionParts:  2,
+			wantClearedCookie: []string{"_oauth2_proxy_2", "_oauth2_proxy_3"},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "https://example.com/", nil)
+			for _, cookieName := range tc.existingCookies {
+				req.AddCookie(&http.Cookie{Name: cookieName, Value: "old"})
+			}
+
+			newCookies, err := store.makeSessionCookie(req, tc.value, now)
+			assert.NoError(t, err)
+			assert.Len(t, newCookies, tc.wantSessionParts)
+
+			rw := httptest.NewRecorder()
+			err = store.setSessionCookie(rw, req, tc.value, now)
+			assert.NoError(t, err)
+
+			responseCookies := make(map[string]*http.Cookie)
+			for _, cookie := range rw.Result().Cookies() {
+				responseCookies[cookie.Name] = cookie
+			}
+			for _, cookieName := range tc.wantClearedCookie {
+				cookie := responseCookies[cookieName]
+				if assert.NotNil(t, cookie, "stale cookie %q was not cleared", cookieName) {
+					assert.Equal(t, -1, cookie.MaxAge)
+				}
+			}
+			for _, wantCookie := range newCookies {
+				cookie := responseCookies[wantCookie.Name]
+				if assert.NotNil(t, cookie, "current cookie %q was not set", wantCookie.Name) {
+					assert.Greater(t, cookie.MaxAge, 0)
+				}
+			}
+			assert.Len(t, responseCookies, len(newCookies)+len(tc.wantClearedCookie))
+			assert.NotContains(t, responseCookies, "_oauth2_proxy_csrf")
 		})
 	}
 }


### PR DESCRIPTION
## Description

Expires session-cookie names from the incoming request that are no longer part of the refreshed session. This covers both a split session shrinking to fewer parts and a split session becoming a single cookie.

Fixes #3486.

## Motivation and Context

Old cookie parts currently remain in the browser until their original expiry. Besides leaving obsolete session data behind, switching between split and single-cookie representations can inflate the cookie header sent upstream.

## How Has This Been Tested?

Tested on macOS arm64 with Go 1.26.0:

- regression test for split-to-single and four-part-to-two-part refreshes
- `go test -race ./pkg/sessions/cookie -count=1`
- `go test ./pkg/sessions/... -count=1`
- `go test -race ./...`
- `golangci-lint v2.11.4 run`
- `go vet ./...`
- `git diff --check`

## Checklist:

- [x] I have added an entry for my changes to the [CHANGELOG.md](https://github.com/oauth2-proxy/oauth2-proxy/blob/master/CHANGELOG.md).
- [x] I have [signed off](https://github.com/apps/dco) all my commits.
- [x] I have created a feature (non-master) branch for my PR.
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#examples) for the PR title.
- [x] I have written tests for my code changes.

## AI assistance

Developed with OpenAI Codex assistance; I reviewed the implementation and validated the final diff with the commands above.
