### PR TITLE
fix(redirect): preserve requested URL in forward_auth flows without whitelist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Changes since v7.15.3
 
+- [#2940](https://github.com/oauth2-proxy/oauth2-proxy/issues/2940) fix: preserve originally requested URL in `forward_auth`/`auth_request` redirects when the host is not whitelisted (@zhaoxinyi02)
+
 # V7.15.3
 
 ## Release Highlights

--- a/pkg/app/redirect/director_test.go
+++ b/pkg/app/redirect/director_test.go
@@ -206,3 +206,96 @@ var _ = Describe("Director Suite", func() {
 		Expect(redirect).To(Equal("/foo?bar"))
 	})
 })
+
+var _ = Describe("forward_auth redirect preservation (issue #2940)", func() {
+	// These tests model the Caddy `forward_auth` (and nginx `auth_request`)
+	// flow: when /oauth2/auth returns 401, the reverse proxy redirects the
+	// client to /oauth2/sign_in?rd={scheme}://{host}{uri}. The {uri} includes
+	// the originally requested path and query, so `rd` is an absolute URL for
+	// the same host the client used to reach the proxy.
+	//
+	// The Caddy integration docs require --reverse-proxy=true but do not mention
+	// --whitelist-domain. Without it the absolute `rd` used to be rejected and,
+	// because sign_in/start are served under the proxy prefix, the redirect
+	// collapsed to "/", silently losing the originally requested URL (and its
+	// query) after login.
+	var (
+		appDirector    AppDirector
+		trustedProxies *ip.NetSet
+	)
+
+	BeforeEach(func() {
+		var err error
+		trustedProxies, err = ip.ParseNetSet([]string{"127.0.0.1"})
+		Expect(err).ToNot(HaveOccurred())
+		appDirector = NewAppDirector(AppDirectorOpts{
+			ProxyPrefix: testProxyPrefix,
+			// No --whitelist-domain configured, matching the Caddy docs.
+			Validator: NewValidator([]string{}),
+		})
+	})
+
+	// makeSignInRequest builds the /oauth2/sign_in request that Caddy's
+	// `redir * /oauth2/sign_in?rd={scheme}://{host}{uri}` produces for an
+	// original request on the given host, with `rd` set to rd.
+	makeSignInRequest := func(host, rd string) *http.Request {
+		req, _ := http.NewRequest("GET", "https://oauth2-proxy.internal/oauth2/sign_in?rd="+rd, nil)
+		req.Header.Set("X-Forwarded-Proto", "http")
+		req.Header.Set("X-Forwarded-Host", host)
+		// Caddy's `reverse_proxy /oauth2/* { header_up X-Forwarded-Uri {uri} }`
+		// sets X-Forwarded-Uri to the sign_in request's own URI, which is under
+		// the proxy prefix.
+		req.Header.Set("X-Forwarded-Uri", "/oauth2/sign_in?rd="+rd)
+		req.RemoteAddr = "127.0.0.1:4180"
+		req = middleware.AddRequestScope(req, &middleware.RequestScope{
+			ReverseProxy:   true,
+			TrustedProxies: trustedProxies,
+		})
+		return req
+	}
+
+	It("preserves the originally requested path and query from a same-host absolute rd", func() {
+		// Original request was /echo/foo?bar=baz on localhost.
+		req := makeSignInRequest("localhost", "http://localhost/echo/foo?bar=baz")
+		redirect, err := appDirector.GetRedirect(req)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(redirect).To(Equal("/echo/foo?bar=baz"))
+	})
+
+	It("preserves the path when the same-host rd includes a port", func() {
+		req := makeSignInRequest("localhost:8080", "http://localhost:8080/echo/foo?bar=baz")
+		redirect, err := appDirector.GetRedirect(req)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(redirect).To(Equal("/echo/foo?bar=baz"))
+	})
+
+	It("preserves the absolute rd as-is when the host is whitelisted", func() {
+		whitelisted := NewAppDirector(AppDirectorOpts{
+			ProxyPrefix: testProxyPrefix,
+			Validator:   NewValidator([]string{"localhost"}),
+		})
+		req := makeSignInRequest("localhost", "http://localhost/echo/foo?bar=baz")
+		redirect, err := whitelisted.GetRedirect(req)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(redirect).To(Equal("http://localhost/echo/foo?bar=baz"))
+	})
+
+	It("does not redirect to a different, non-whitelisted host's path", func() {
+		// rd points at evil.example.com while the request was served on
+		// localhost: the path must not be extracted and the redirect must not
+		// leak the attacker-controlled host.
+		req := makeSignInRequest("localhost", "http://evil.example.com/echo/foo")
+		redirect, err := appDirector.GetRedirect(req)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(redirect).To(Equal("/"))
+	})
+
+	It("still rejects open-redirect rd values", func() {
+		// Extracted paths are re-validated, so protocol-relative and other
+		// open-redirect payloads are rejected even when the host matches.
+		req := makeSignInRequest("localhost", "//evil.example.com/path")
+		redirect, err := appDirector.GetRedirect(req)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(redirect).To(Equal("/"))
+	})
+})

--- a/pkg/app/redirect/getters.go
+++ b/pkg/app/redirect/getters.go
@@ -3,6 +3,8 @@ package redirect
 import (
 	"fmt"
 	"net/http"
+	"net/url"
+	"strings"
 
 	requestutil "github.com/oauth2-proxy/oauth2-proxy/v7/pkg/requests/util"
 )
@@ -14,9 +16,50 @@ type redirectGetter func(req *http.Request) string
 // getRdQuerystringRedirect handles this getAppRedirect strategy:
 // - `rd` querysting parameter
 func (a *appDirector) getRdQuerystringRedirect(req *http.Request) string {
-	return a.validateRedirect(
-		req.Form.Get("rd"),
+	rd := req.Form.Get("rd")
+	redirect := a.validateRedirect(rd,
 		"Invalid redirect provided in rd querystring parameter: %s",
+	)
+	if redirect != "" {
+		return redirect
+	}
+
+	// If `rd` is an absolute http(s) URL that was rejected because its host is
+	// not on the whitelist, fall back to its path component when it targets the
+	// same host the request was served on. See getRdPathRedirect for details.
+	return a.getRdPathRedirect(req, rd)
+}
+
+// getRdPathRedirect extracts the path (and query) of an absolute http(s) `rd`
+// redirect and validates it as a relative redirect, but only when the `rd`
+// URL's host matches the host the request was served on.
+//
+// Reverse-proxy / forward_auth setups (e.g. Caddy `forward_auth` and nginx
+// `auth_request`) build the post-login redirect as `{scheme}://{host}{uri}`,
+// an absolute URL for the same host the client used to reach the proxy. The
+// Caddy integration docs do not mention that such hosts must also be added to
+// `--whitelist-domain`, so without that option the absolute `rd` is rejected
+// and, because the `sign_in`/`start` requests are served under the proxy
+// prefix, the remaining redirect strategies collapse to "/" — silently losing
+// the originally requested URL (and its query) after login.
+//
+// Falling back to the path component is safe: it is a same-origin relative
+// redirect, it is still run through the validator (so open-redirect protections
+// such as "//" and "/../" still apply), and a `rd` pointing at a different,
+// non-whitelisted host is left untouched so the other strategies can run.
+func (a *appDirector) getRdPathRedirect(req *http.Request, rd string) string {
+	if rd == "" || (!strings.HasPrefix(rd, "http://") && !strings.HasPrefix(rd, "https://")) {
+		return ""
+	}
+	rdURL, err := url.Parse(rd)
+	if err != nil || rdURL.Host == "" {
+		return ""
+	}
+	if rdURL.Host != requestutil.GetRequestHost(req) {
+		return ""
+	}
+	return a.validateRedirect(rdURL.RequestURI(),
+		"Invalid redirect extracted from rd querystring parameter: %s",
 	)
 }
 


### PR DESCRIPTION
## Description

When `rd` is an absolute `http(s)` URL that fails `--whitelist-domain` validation but targets the **same host** the request was served on, fall back to its path component (path + query) and re-validate that as a relative redirect. A `rd` pointing at a different, non-whitelisted host is left untouched, so the existing fallback strategies are unchanged.

This is a minimal change to `pkg/app/redirect/getters.go` (`getRdQuerystringRedirect` + new `getRdPathRedirect` helper).

## Motivation and Context

Fixes #2940.

In reverse-proxy / `forward_auth` setups (Caddy `forward_auth`, nginx `auth_request`), the post-login redirect is built as an absolute URL `{scheme}://{host}{uri}` and handed to oauth2-proxy via the `rd` query parameter — e.g. Caddy's documented config does exactly this:

```
redir * /oauth2/sign_in?rd={scheme}://{host}{uri}
```

The Caddy integration docs require `--reverse-proxy=true` but **do not mention `--whitelist-domain`**. Without it:

1. The absolute `rd` (e.g. `http://localhost/echo/foo?bar=baz`) is rejected by the redirect validator (`domain / port not in whitelist`).
2. The `sign_in` / `start` requests are served **under the proxy prefix** (`/oauth2/*`), and Caddy's `reverse_proxy /oauth2/* { header_up X-Forwarded-Uri {uri} }` sets `X-Forwarded-Uri` to the *sign_in request's own* URI — not the originally requested URL.
3. The remaining redirect strategies therefore collapse to `"/"`, and after a successful login the user is sent to `/` instead of the URL they originally requested. The original path **and query string** are silently lost.

The issue reporter observed this exactly: with `uri /oauth2/auth?allowed_groups=...`, group authorization works (it is checked on every `/oauth2/auth` subrequest via `authOnlyAuthorize`) but the originally requested URL is not preserved after login.

### Why this is a code defect, not a config mistake

The documented Caddy config (which omits `--whitelist-domain`) cannot preserve the requested URL. The originally requested URL is *only* carried via `rd` as an absolute URL, and the only code path that can recover it (the `X-Forwarded-Uri` fallback) is overwritten with the proxy-prefix path by the time `sign_in`/`start` run. So users following the docs hit a silent redirect drop with no actionable error.

### Safety

- The fallback only triggers when the `rd` host **matches the host the request was served on** (`requestutil.GetRequestHost`), i.e. a same-origin redirect. A `rd` pointing at any other host is rejected as before and the other strategies run unchanged.
- The extracted path is re-run through the validator, so existing open-redirect protections (`//`, `/\\`, `/../`, etc., covered by `testdata/openredirects.txt`) still apply.
- This adds no new capability an attacker didn't already have: a relative `rd=/path` is already accepted unconditionally, so redirecting to an arbitrary same-origin path is already possible. The change only recovers the path from a same-host *absolute* `rd` that would otherwise be dropped.
- In reverse-proxy mode the request host comes from the trusted proxy's `X-Forwarded-Host`, which an external client cannot spoof.

The whitelist path is unchanged: when the host *is* whitelisted, the absolute `rd` is still accepted as-is (verified by a test).

## How Has This Been Tested?

New Ginkgo specs in `pkg/app/redirect/director_test.go` model the Caddy `forward_auth` `sign_in` request (reverse proxy enabled, trusted proxy, empty whitelist, `X-Forwarded-Uri` set to the proxy-prefix sign_in path):

- ✅ same-host absolute `rd` → originally requested path **and query** preserved (`/echo/foo?bar=baz`) — **fails on `master`, passes with this change**
- ✅ same-host `rd` with a port → path preserved
- ✅ whitelisted host → absolute `rd` preserved as-is (unchanged behavior)
- ✅ `rd` for a different, non-whitelisted host → still collapses to `/` (no leak of the attacker-controlled host)
- ✅ protocol-relative / open-redirect `rd` values → still rejected

Verification run:

```
go test ./pkg/app/redirect/...                 # pass
go test ./...                                  # pass (29 packages, 0 failures)
gofmt -l pkg/app/redirect/getters.go pkg/app/redirect/director_test.go   # clean
go vet ./pkg/app/redirect/...                  # clean
golangci-lint run                              # 0 issues
```

Confirmed the two preservation specs fail on `master` (via `git stash` of the `getters.go` change) and pass with the fix; the safety specs pass on both.

## Checklist:

- [x] I have added an entry for my changes to the [CHANGELOG.md](https://github.com/oauth2-proxy/oauth2-proxy/blob/master/CHANGELOG.md).
- [x] I have [signed off](https://github.com/apps/dco) all my commits.
- [x] I have created a feature (non-master) branch for my PR.
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#examples) for the PR title.
- [x] I have written tests for my code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)