### PR TITLE
docs: clarify structured claim header serialization

### DIFF
--- a/docs/docs/configuration/alpha_config.md
+++ b/docs/docs/configuration/alpha_config.md
@@ -167,6 +167,17 @@ injectResponseHeaders:
 * `claimSource` - `claim` (session claims either from id token or from profile URL)
 * `secretSource` - `value` (base64), `fromFile` (file path)
 
+#### Claim value serialization
+
+`claimSource` converts the selected claim into one or more string header values. Scalars
+produce one value, while arrays produce one value per element. Values that cannot be
+converted directly to strings, such as objects, are JSON-encoded individually.
+
+Each non-empty value is added separately under the configured header name. An array of
+objects therefore produces multiple header values containing one JSON object each, not a
+single JSON array. HTTP libraries and intermediaries may expose repeated values as a
+comma-joined string, so consumers should retrieve and parse each header value separately.
+
 **Request option:** `preserveRequestValue: true` retains existing header values
 
 **Incompatibility:** Remove legacy flags `pass-user-headers`, `set-xauthrequest`

--- a/docs/docs/configuration/alpha_config.md.tmpl
+++ b/docs/docs/configuration/alpha_config.md.tmpl
@@ -167,6 +167,17 @@ injectResponseHeaders:
 * `claimSource` - `claim` (session claims either from id token or from profile URL)
 * `secretSource` - `value` (base64), `fromFile` (file path)
 
+#### Claim value serialization
+
+`claimSource` converts the selected claim into one or more string header values. Scalars
+produce one value, while arrays produce one value per element. Values that cannot be
+converted directly to strings, such as objects, are JSON-encoded individually.
+
+Each non-empty value is added separately under the configured header name. An array of
+objects therefore produces multiple header values containing one JSON object each, not a
+single JSON array. HTTP libraries and intermediaries may expose repeated values as a
+comma-joined string, so consumers should retrieve and parse each header value separately.
+
 **Request option:** `preserveRequestValue: true` retains existing header values
 
 **Incompatibility:** Remove legacy flags `pass-user-headers`, `set-xauthrequest`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Document how `claimSource` turns scalar, array, and object claims into header values. Clarify that arrays of objects become repeated, individually JSON-encoded header values rather than one JSON array.

## Motivation and Context

Consumers currently have to infer structured-claim serialization from the implementation, and comma-joined representations of repeated headers can be mistaken for JSON arrays.

Fixes #3466.

## How Has This Been Tested?

- `make verify-generate`
- `npm run build` (passes; reports pre-existing warnings for `simplified-architecture.svg` and broken anchors)
- `go test ./pkg/util ./pkg/apis/sessions ./pkg/header`
- `git diff --check upstream/master..HEAD`

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added an entry for my changes to the [CHANGELOG.md](https://github.com/oauth2-proxy/oauth2-proxy/blob/master/CHANGELOG.md). N/A: this is a documentation-only clarification.
- [x] I have [signed off](https://github.com/apps/dco) all my commits.
- [x] I have created a feature (non-master) branch for my PR.
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#examples) for the PR title.
- [ ] I have written tests for my code changes. N/A: no code changed; the documentation build and existing behavior tests pass.
