### PR TITLE
fix: do not trust X-Forwarded-* headers when no --trusted-proxy-ip is configured

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -401,8 +401,8 @@ func buildPreAuthChain(opts *options.Options, sessionStore sessionsapi.SessionSt
 func buildTrustedProxyNetSet(opts *options.Options) (*ip.NetSet, error) {
 	trustedProxyIPs := opts.TrustedProxyIPs
 	if opts.ReverseProxy && len(trustedProxyIPs) == 0 {
-		logger.Print("WARNING: --reverse-proxy is enabled but no --trusted-proxy-ip CIDRs were configured. All connecting IPs are trusted to supply X-Forwarded-* headers by default (0.0.0.0/0, ::/0). This preserves backwards compatibility but is a potential security risk; configure --trusted-proxy-ip to match your reverse proxy addresses.")
-		trustedProxyIPs = defaultTrustedProxyIPs
+		logger.Print("WARNING: --reverse-proxy is enabled but no --trusted-proxy-ip CIDRs were configured. X-Forwarded-* headers will NOT be trusted. Configure --trusted-proxy-ip to list your reverse proxy addresses, otherwise forwarded headers (including X-Forwarded-Uri) are ignored.")
+		return nil, nil
 	}
 
 	return ip.ParseNetSet(trustedProxyIPs)

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -2793,6 +2793,7 @@ func TestAllowedRequestWithForwardedUriHeader(t *testing.T) {
 
 	opts := baseTestOptions()
 	opts.ReverseProxy = true
+	opts.TrustedProxyIPs = []string{"127.0.0.1/32"}
 	opts.UpstreamServers = options.UpstreamConfig{
 		Upstreams: []options.Upstream{
 			{


### PR DESCRIPTION
## Summary

Fixes #3506 — authentication bypass via spoofed `X-Forwarded-Uri` when `--reverse-proxy` is enabled without `--trusted-proxy-ip`.

## Root Cause

When `--reverse-proxy` is enabled but `--trusted-proxy-ip` is not configured, `buildTrustedProxyNetSet` defaults the trusted proxy set to `0.0.0.0/0` and `::/0` (trust all IPs). This means `CanTrustForwardedHeaders` returns true for every client, allowing an attacker to spoof `X-Forwarded-Uri` to a value matching a `skip_auth_routes` / `skip_auth_regex` entry while the actual request targets a protected path. OAuth2 Proxy skips auth based on the spoofed header but forwards the real (protected) path upstream.

## Fix

`buildTrustedProxyNetSet` now returns `nil` (no trusted proxies) when `--reverse-proxy` is enabled but `--trusted-proxy-ip` is not configured. This causes `CanTrustForwardedHeaders` to return `false` for all remote IPs, so `X-Forwarded-*` headers (including `X-Forwarded-Uri`) are not trusted.

Users who need forwarded header support must explicitly configure `--trusted-proxy-ip` to match their reverse proxy addresses.

## Testing

Updated `TestAllowedRequestWithForwardedUriHeader` to explicitly set `opts.TrustedProxyIPs = []string{"127.0.0.1/32"}` since the test's `RemoteAddr = 127.0.0.1:4180` relies on the forward-header trust mechanism.