### PR TITLE
  feat: respect browser dark mode on error page

### DIFF
--- a/pkg/app/pagewriter/error.html
+++ b/pkg/app/pagewriter/error.html
@@ -4,6 +4,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+<meta name="color-scheme" content="light dark">
   <title>{{.StatusCode}} {{.Title}}</title>
 <link rel="stylesheet" href="{{.ProxyPrefix}}/static/css/bulma.min.css">
 <link rel="stylesheet" href="{{.ProxyPrefix}}/static/css/all.min.css">
@@ -36,6 +37,33 @@
   }
   footer a {
     text-decoration: underline;
+  }
+  @media (prefers-color-scheme: dark) {
+    html,
+    body.has-background-light,
+    footer.footer.has-background-light {
+      background-color: #121212 !important;
+      color: #f5f5f5;
+    }
+    .error-box,
+    #more-info.card {
+      background-color: #1f1f1f;
+      color: #f5f5f5;
+    }
+    .subtitle,
+    .card-header-title {
+      color: #f5f5f5;
+    }
+    #more-info.card {
+      border-color: #3a3a3a;
+    }
+    hr {
+      background-color: #3a3a3a;
+    }
+    footer.footer.has-text-grey,
+    footer.footer a.has-text-grey {
+      color: #b5b5b5 !important;
+    }
   }
 </style>
 </head>

--- a/pkg/app/pagewriter/pagewriter_test.go
+++ b/pkg/app/pagewriter/pagewriter_test.go
@@ -52,6 +52,7 @@ var _ = Describe("Writer", func() {
 				body, err := io.ReadAll(recorder.Result().Body)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(string(body)).To(HavePrefix("\n<!DOCTYPE html>"))
+				Expect(string(body)).To(ContainSubstring("@media (prefers-color-scheme: dark)"))
 			})
 
 			It("Writes the default sign in template", func() {


### PR DESCRIPTION
## Description

  Add automatic dark mode support to the default error page.

  The page now:

  - declares support for light and dark color schemes;
  - uses `prefers-color-scheme: dark` to follow the browser or operating system preference;
  - overrides Bulma's explicit light colors for the background, error box, details card, text, borders, and footer;
  - keeps the existing light theme unchanged.

  A regression test verifies that the default rendered error page includes the dark-mode media query.

  ## Motivation and Context

  The default error page always uses a light color scheme, even when the browser is configured to prefer dark mode.

  Declaring `color-scheme` alone only affects browser-rendered controls and system colors. Since the page and Bulma stylesheet use explicit light colors, CSS overrides
  are also required to render the complete page in dark mode.

  This change improves visual consistency and reduces glare while respecting the user's existing browser preference without requiring JavaScript or a manual theme
  setting.

  ## How Has This Been Tested?

  Tested on Linux amd64 with Go 1.26.0.

  The application package tests pass:

  ```console
  go test ./pkg/app/...

  Result:

  ok github.com/oauth2-proxy/oauth2-proxy/v7/pkg/app/pagewriter
  ok github.com/oauth2-proxy/oauth2-proxy/v7/pkg/app/redirect
```

  The patch also passes:

  git diff --check

  ## Checklist:

  - [ ] I have added an entry for my changes to the CHANGELOG.md (https://github.com/oauth2-proxy/oauth2-proxy/blob/master/CHANGELOG.md).
  - [x] I have signed off (https://github.com/apps/dco) all my commits.
  - [ ] I have created a feature (non-master) branch for my PR.
  - [x] I have used conventional commits (https://www.conventionalcommits.org/en/v1.0.0/#examples) for the PR title.
  - [x] I have written tests for my code changes.

