### PR TITLE
fix: remove the deprecated user-id-claim option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 
 ## Changes since v7.15.4
 
+- [#3522](https://github.com/oauth2-proxy/oauth2-proxy/pull/3522) fix: remove the deprecated user-id-claim option (@erhudy)
+
 # V7.15.4
 
 ## Release Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@
 
 ## Breaking Changes
 
+- The long-deprecated `--user-id-claim` option has been removed. OAuth2 Proxy will now refuse to
+  start if it is set, via the flag, the `user_id_claim` config key, the
+  `OAUTH2_PROXY_USER_ID_CLAIM` environment variable, or the alpha config `userIDClaim` field.
+
+  The option was deprecated in favour of `--oidc-email-claim` in v7.0.0. Until now it silently
+  overwrote the email claim whenever it was set to anything other than `email`, which meant an
+  explicit `--oidc-email-claim` could not be honoured and `session.Email` (and with it
+  `--email-domain` validation, the `email` access-log field and `X-Auth-Request-Email`) was
+  populated from the wrong claim.
+
+  To migrate, replace `--user-id-claim=<claim>` with `--oidc-email-claim=<claim>`, or simply
+  remove it if it was set to `email` — `--oidc-email-claim` already defaults to `email`. Use
+  `--config-test` to check a configuration before upgrading.
+
 ## Changes since v7.15.4
 
 # V7.15.4

--- a/docs/docs/configuration/alpha_config.md
+++ b/docs/docs/configuration/alpha_config.md
@@ -559,7 +559,7 @@ character.
 | `publicKeyFiles` | _[]string_ | PublicKeyFiles is a list of paths pointing to public key files in PEM format to use<br/>for verifying JWT tokens |
 | `emailClaim` | _string_ | EmailClaim indicates which claim contains the user email,<br/>default set to 'email' |
 | `groupsClaim` | _string_ | GroupsClaim indicates which claim contains the user groups<br/>default set to 'groups' |
-| `userIDClaim` | _string_ | UserIDClaim indicates which claim contains the user ID<br/>default set to 'email' |
+| `userIDClaim` | _string_ | UserIDClaim indicates which claim contains the user ID<br/><br/>Deprecated: this option has been removed and is no longer accepted.<br/>Use EmailClaim instead. OAuth2 Proxy will refuse to start if it is set. |
 | `audienceClaims` | _[]string_ | AudienceClaim allows to define any claim that is verified against the client id<br/>By default `aud` claim is used for verification. |
 | `extraAudiences` | _[]string_ | ExtraAudiences is a list of additional audiences that are allowed<br/>to pass verification in addition to the client id. |
 | `enabledSigningAlgs` | _[]string_ | EnabledSigningAlgs is a list of allowed JWT signing algorithms.<br/>When discovery is enabled, the effective set is the intersection<br/>between this list and the provider's discovered supported algorithms.<br/>By default `RS256` is used if nothing has been discovered or specified. |

--- a/docs/docs/configuration/integrations/kubernetes-dashboard.md
+++ b/docs/docs/configuration/integrations/kubernetes-dashboard.md
@@ -60,7 +60,6 @@ alphaConfig:
             - aud
           emailClaim: email
           groupsClaim: groups
-          userIDClaim: oid
         scope: openid email profile
 
     upstreamConfig:

--- a/main_test.go
+++ b/main_test.go
@@ -95,7 +95,6 @@ providers:
   oidcConfig:
     groupsClaim: groups
     emailClaim: email
-    userIDClaim: email
     insecureSkipIssuerVerification: false
     insecureSkipNonce: true
     audienceClaims: [aud]
@@ -180,7 +179,6 @@ redirect_url="http://localhost:4180/oauth2/callback"
 				OIDCConfig: options.OIDCOptions{
 					GroupsClaim:                    "groups",
 					EmailClaim:                     "email",
-					UserIDClaim:                    "email",
 					AudienceClaims:                 []string{"aud"},
 					ExtraAudiences:                 []string{},
 					InsecureSkipNonce:              ptr.To(true),

--- a/pkg/apis/options/legacy_options.go
+++ b/pkg/apis/options/legacy_options.go
@@ -54,7 +54,6 @@ func NewLegacyOptions() *LegacyOptions {
 			ProviderType:           "google",
 			AzureTenant:            "common",
 			ApprovalPrompt:         "force",
-			UserIDClaim:            "email",
 			OIDCEmailClaim:         "email",
 			OIDCGroupsClaim:        "groups",
 			OIDCAudienceClaims:     []string{"aud"},
@@ -627,7 +626,7 @@ func legacyProviderFlagSet() *pflag.FlagSet {
 	flagSet.String("jwt-key-file", "", "path to the private key file in PEM format used to sign the JWT so that you can say something like -jwt-key-file=/etc/ssl/private/jwt_signing_key.pem: required by login.gov")
 	flagSet.String("pubjwk-url", "", "JWK pubkey access endpoint: required by login.gov")
 
-	flagSet.String("user-id-claim", OIDCEmailClaim, "(DEPRECATED for `oidc-email-claim`) which claim contains the user ID")
+	flagSet.String("user-id-claim", "", "(REMOVED - use --oidc-email-claim instead) which claim contains the user ID")
 	flagSet.StringSlice("allowed-group", []string{}, "restrict logins to members of this group (may be given multiple times)")
 	flagSet.StringSlice("allowed-role", []string{}, "(keycloak-oidc) restrict logins to members of these roles (may be given multiple times)")
 	flagSet.String("backend-logout-url", "", "url to perform a backend logout, {id_token} can be used as placeholder for the id_token")

--- a/pkg/apis/options/load_test.go
+++ b/pkg/apis/options/load_test.go
@@ -39,7 +39,6 @@ var _ = Describe("Load", func() {
 			ProviderType:          "google",
 			AzureTenant:           "common",
 			ApprovalPrompt:        "force",
-			UserIDClaim:           "email",
 			OIDCEmailClaim:        "email",
 			OIDCGroupsClaim:       "groups",
 			OIDCAudienceClaims:    []string{"aud"},

--- a/pkg/apis/options/providers.go
+++ b/pkg/apis/options/providers.go
@@ -313,7 +313,9 @@ type OIDCOptions struct {
 	// default set to 'groups'
 	GroupsClaim string `yaml:"groupsClaim,omitempty"`
 	// UserIDClaim indicates which claim contains the user ID
-	// default set to 'email'
+	//
+	// Deprecated: this option has been removed and is no longer accepted.
+	// Use EmailClaim instead. OAuth2 Proxy will refuse to start if it is set.
 	UserIDClaim string `yaml:"userIDClaim,omitempty"`
 	// AudienceClaim allows to define any claim that is verified against the client id
 	// By default `aud` claim is used for verification.
@@ -349,7 +351,6 @@ func providerDefaults() Providers {
 				InsecureAllowUnverifiedEmail: ptr.To(DefaultInsecureAllowUnverifiedEmail),
 				InsecureSkipNonce:            ptr.To(DefaultInsecureSkipNonce),
 				SkipDiscovery:                ptr.To(DefaultSkipDiscovery),
-				UserIDClaim:                  OIDCEmailClaim, // Deprecated: Use OIDCEmailClaim
 				EmailClaim:                   OIDCEmailClaim,
 				GroupsClaim:                  OIDCGroupsClaim,
 				AudienceClaims:               OIDCAudienceClaims,
@@ -393,9 +394,6 @@ func (o *OIDCOptions) EnsureDefaults() {
 	}
 	if o.SkipDiscovery == nil {
 		o.SkipDiscovery = ptr.To(DefaultSkipDiscovery)
-	}
-	if o.UserIDClaim == "" {
-		o.UserIDClaim = OIDCEmailClaim
 	}
 	if o.EmailClaim == "" {
 		o.EmailClaim = OIDCEmailClaim

--- a/pkg/validation/providers.go
+++ b/pkg/validation/providers.go
@@ -88,7 +88,9 @@ func validateProvider(provider options.Provider, providerIDs map[string]struct{}
 // could not be honoured. Rather than change what a session's email resolves to
 // behind the user's back, refuse to start and name the replacement.
 func validateOIDCUserIDClaim(provider options.Provider) []string {
-	claim := provider.OIDCConfig.UserIDClaim
+	// Reading the deprecated field is the point here: it exists only so that a
+	// configuration still setting it can be detected and rejected.
+	claim := provider.OIDCConfig.UserIDClaim //nolint:staticcheck
 	switch claim {
 	case "":
 		return nil

--- a/pkg/validation/providers.go
+++ b/pkg/validation/providers.go
@@ -78,7 +78,25 @@ func validateProvider(provider options.Provider, providerIDs map[string]struct{}
 
 	msgs = append(msgs, validateOIDCSigningAlgorithms(provider)...)
 
+	msgs = append(msgs, validateOIDCUserIDClaim(provider)...)
+
 	return msgs
+}
+
+// validateOIDCUserIDClaim rejects the removed user-id-claim option. It used to
+// silently override the email claim, which meant an explicit oidc-email-claim
+// could not be honoured. Rather than change what a session's email resolves to
+// behind the user's back, refuse to start and name the replacement.
+func validateOIDCUserIDClaim(provider options.Provider) []string {
+	claim := provider.OIDCConfig.UserIDClaim
+	switch claim {
+	case "":
+		return nil
+	case options.OIDCEmailClaim:
+		return []string{fmt.Sprintf("provider %s: user-id-claim has been removed and must be unset; it had no effect as oidc-email-claim already defaults to %q (in alpha config: remove userIDClaim)", provider.ID, options.OIDCEmailClaim)}
+	default:
+		return []string{fmt.Sprintf("provider %s: user-id-claim has been removed; use oidc-email-claim=%s instead (in alpha config: replace userIDClaim with emailClaim)", provider.ID, claim)}
+	}
 }
 
 func validateOIDCSigningAlgorithms(provider options.Provider) []string {

--- a/pkg/validation/providers_test.go
+++ b/pkg/validation/providers_test.go
@@ -57,12 +57,32 @@ var _ = Describe("Providers", func() {
 		ClientSecret: "ClientSecret",
 	}
 
+	removedUserIDClaimProvider := options.Provider{
+		ID:           "ProviderIDRemovedUserIDClaim",
+		ClientID:     "ClientID",
+		ClientSecret: "ClientSecret",
+		OIDCConfig: options.OIDCOptions{
+			UserIDClaim: "sub",
+		},
+	}
+
+	redundantUserIDClaimProvider := options.Provider{
+		ID:           "ProviderIDRedundantUserIDClaim",
+		ClientID:     "ClientID",
+		ClientSecret: "ClientSecret",
+		OIDCConfig: options.OIDCOptions{
+			UserIDClaim: "email",
+		},
+	}
+
 	missingProvider := "at least one provider has to be defined"
 	emptyIDMsg := "provider has empty id: ids are required for all providers"
 	duplicateProviderIDMsg := "multiple providers found with id ProviderID: provider ids must be unique"
 	skipButtonAndMultipleProvidersMsg := "SkipProviderButton and multiple providers are mutually exclusive"
 	invalidOIDCSigningAlgorithmMsg := "provider ProviderIDInvalidOIDCSigningAlgorithms has invalid EnabledSigningAlgs entry \"invalid\""
 	invalidOIDCSigningAlgorithmCaseMsg := "provider ProviderIDInvalidOIDCSigningAlgorithmCase has invalid EnabledSigningAlgs entry \"rs256\""
+	removedUserIDClaimMsg := "provider ProviderIDRemovedUserIDClaim: user-id-claim has been removed; use oidc-email-claim=sub instead (in alpha config: replace userIDClaim with emailClaim)"
+	redundantUserIDClaimMsg := "provider ProviderIDRedundantUserIDClaim: user-id-claim has been removed and must be unset; it had no effect as oidc-email-claim already defaults to \"email\" (in alpha config: remove userIDClaim)"
 
 	DescribeTable("validateProviders",
 		func(o *validateProvidersTableInput) {
@@ -131,6 +151,22 @@ var _ = Describe("Providers", func() {
 				},
 			},
 			errStrings: []string{invalidOIDCSigningAlgorithmCaseMsg},
+		}),
+		Entry("with the removed user-id-claim option set to a non-email claim", &validateProvidersTableInput{
+			options: &options.Options{
+				Providers: options.Providers{
+					removedUserIDClaimProvider,
+				},
+			},
+			errStrings: []string{removedUserIDClaimMsg},
+		}),
+		Entry("with the removed user-id-claim option set to the email claim", &validateProvidersTableInput{
+			options: &options.Options{
+				Providers: options.Providers{
+					redundantUserIDClaimProvider,
+				},
+			},
+			errStrings: []string{redundantUserIDClaimMsg},
 		}),
 	)
 })

--- a/pkg/validation/providers_test.go
+++ b/pkg/validation/providers_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Providers", func() {
 		ClientID:     "ClientID",
 		ClientSecret: "ClientSecret",
 		OIDCConfig: options.OIDCOptions{
-			UserIDClaim: "sub",
+			UserIDClaim: "sub", //nolint:staticcheck // deliberately setting the removed option to assert it is rejected
 		},
 	}
 
@@ -71,7 +71,7 @@ var _ = Describe("Providers", func() {
 		ClientID:     "ClientID",
 		ClientSecret: "ClientSecret",
 		OIDCConfig: options.OIDCOptions{
-			UserIDClaim: "email",
+			UserIDClaim: "email", //nolint:staticcheck // deliberately setting the removed option to assert it is rejected
 		},
 	}
 

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -157,17 +157,6 @@ func newProviderDataFromConfig(providerConfig options.Provider) (*ProviderData, 
 		logger.Printf("Warning: Your provider supports PKCE methods %+q, but you have not enabled one with --code-challenge-method", p.SupportedCodeChallengeMethods)
 	}
 
-	if providerConfig.OIDCConfig.UserIDClaim == "" {
-		providerConfig.OIDCConfig.UserIDClaim = "email"
-	}
-
-	// TODO (@NickMeves) - Remove This
-	// Backwards Compatibility for Deprecated UserIDClaim option
-	if providerConfig.OIDCConfig.EmailClaim == options.OIDCEmailClaim &&
-		providerConfig.OIDCConfig.UserIDClaim != options.OIDCEmailClaim {
-		p.EmailClaim = providerConfig.OIDCConfig.UserIDClaim
-	}
-
 	p.setAllowedGroups(providerConfig.AllowedGroups)
 
 	p.BackendLogoutURL = providerConfig.BackendLogoutURL

--- a/providers/providers_test.go
+++ b/providers/providers_test.go
@@ -396,7 +396,7 @@ func TestEmailClaimCorrectlySet(t *testing.T) {
 					IssuerURL:     msIssuerURL,
 					SkipDiscovery: ptr.To(true),
 					JwksURL:       msKeysURL,
-					UserIDClaim:   tc.userIDClaim,
+					UserIDClaim:   tc.userIDClaim, //nolint:staticcheck // asserting the removed option no longer affects EmailClaim
 					EmailClaim:    tc.emailClaim,
 				},
 			}

--- a/providers/providers_test.go
+++ b/providers/providers_test.go
@@ -364,16 +364,22 @@ func TestEmailClaimCorrectlySet(t *testing.T) {
 		expectedEmailClaim string
 	}{
 		{
-			name:               "do not override EmailClaim if UserIDClaim is empty",
+			name:               "use the default EmailClaim when UserIDClaim is empty",
 			userIDClaim:        "",
 			emailClaim:         "email",
 			expectedEmailClaim: "email",
 		},
 		{
-			name:               "set EmailClaim to UserIDClaim",
+			name:               "use an explicitly configured EmailClaim",
+			userIDClaim:        "",
+			emailClaim:         "custom_email_claim",
+			expectedEmailClaim: "custom_email_claim",
+		},
+		{
+			name:               "the removed UserIDClaim never overrides EmailClaim",
 			userIDClaim:        "user_id_claim",
 			emailClaim:         "email",
-			expectedEmailClaim: "user_id_claim",
+			expectedEmailClaim: "email",
 		},
 	}
 


### PR DESCRIPTION
## Description

Removes the backwards compatibility shim for the deprecated `--user-id-claim` option and rejects the option at startup.

The shim in `providers/providers.go` guarded on `EmailClaim == options.OIDCEmailClaim`, i.e. it compared the configured email claim against the literal default `"email"`. That cannot distinguish an explicit `--oidc-email-claim=email` from an unset one, so once `--user-id-claim` was set to anything else there was no way to opt out.

## Checklist:

- [x] I have added an entry for my changes to the [CHANGELOG.md](https://github.com/oauth2-proxy/oauth2-proxy/blob/master/CHANGELOG.md).
- [x] I have [signed off](https://github.com/apps/dco) all my commits.
- [x] I have created a feature (non-master) branch for my PR.
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#examples) for the PR title.
- [x] I have written tests for my code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tar1Vjithfc9ydDegyTAP9
