### PR TITLE
feat: Enable GitHub provider to be used with or without org claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## Breaking Changes
 
 ## Changes since v7.15.4
+- [#3482](https://github.com/oauth2-proxy/oauth2-proxy/issues/3482) Make GitHub support auth without read:org scope
 
 # V7.15.4
 

--- a/docs/docs/configuration/providers/github.md
+++ b/docs/docs/configuration/providers/github.md
@@ -21,6 +21,8 @@ title: GitHub
 The GitHub auth provider supports two additional ways to restrict authentication to either organization and optional 
 team level access, or to collaborators of a repository. Restricting by these options is normally accompanied with `--email-domain=*`. Additionally, all the organizations and teams a user belongs to are set as part of the `X-Forwarded-Groups` header. e.g. `org1:team1,org1:team2,org2:team1`
 
+By default, the provider requests the `user:email read:org` scopes. Organization and team memberships are retrieved during login only when the configured `scope` includes `read:org`; to avoid prompting users for organization access, set a `scope` that omits it, e.g. `scope = "user:email"`. Note that `X-Forwarded-Groups` will then be empty.
+
 NOTE: When `--github-user` is set, the specified users are allowed to log in even if they do not belong to the specified 
 org and team or collaborators.
 
@@ -38,6 +40,9 @@ To restrict access to specific teams within an organization:
     # restrict logins to members of any of these teams (slug), comma separated
     --github-team="team1,team2,team3"
 ```
+
+Configuring `--github-org` or `--github-team` requires the `read:org` scope, so it is added to the `scope`
+automatically if it is missing.
 
 To restrict to teams within different organizations, keep the organization flag empty and use `--github-team` like so:
 

--- a/providers/github.go
+++ b/providers/github.go
@@ -112,10 +112,16 @@ func (p *GitHubProvider) makeGitHubAPIEndpoint(endpoint string, params *url.Valu
 	}
 }
 
-// setOrgTeam adds GitHub org reading parameters to the OAuth2 scope
+// setOrgTeam restricts logins to the given organisation and/or team.
+// Organization and team membership can only be read with the read:org scope,
+// so it is added to the scope if it is missing.
 func (p *GitHubProvider) setOrgTeam(org, team string) {
 	p.Org = org
 	p.Team = team
+
+	if (org != "" || team != "") && !p.scopeContains("read:org") {
+		p.Scope += " read:org"
+	}
 }
 
 // setRepo configures the target repository and optional token to use
@@ -129,11 +135,15 @@ func (p *GitHubProvider) setUsers(users []string) {
 	p.Users = users
 }
 
-// EnrichSession updates the User & Email after the initial Redeem
+// EnrichSession updates the User, Email & Groups after the initial Redeem.
+// Organization and team memberships are only retrieved when the scope
+// includes read:org, as the /user/orgs and /user/teams endpoints require it.
 func (p *GitHubProvider) EnrichSession(ctx context.Context, s *sessions.SessionState) error {
 	// Construct user info JSON from multiple GitHub API endpoints to have a more detailed session state
-	if err := p.getOrgAndTeam(ctx, s); err != nil {
-		return err
+	if p.scopeContains("read:org") {
+		if err := p.getOrgAndTeam(ctx, s); err != nil {
+			return err
+		}
 	}
 
 	if err := p.checkRestrictions(ctx, s); err != nil {
@@ -145,6 +155,17 @@ func (p *GitHubProvider) EnrichSession(ctx context.Context, s *sessions.SessionS
 	}
 
 	return p.getUser(ctx, s)
+}
+
+// scopeContains reports whether the configured OAuth2 scope list includes the
+// given scope, matching scope names exactly.
+func (p *GitHubProvider) scopeContains(scope string) bool {
+	for _, s := range strings.Split(p.Scope, " ") {
+		if s == scope {
+			return true
+		}
+	}
+	return false
 }
 
 // ValidateSession validates the AccessToken

--- a/providers/github_test.go
+++ b/providers/github_test.go
@@ -620,3 +620,101 @@ func TestGitHubProvider_ValidateSessionWithUserEmails(t *testing.T) {
 	valid := p.ValidateSession(context.Background(), session)
 	assert.True(t, valid)
 }
+
+func TestGitHubProvider_EnrichSessionWithDefaultScope(t *testing.T) {
+	b := testGitHubBackend(map[string][]string{
+		"/user":        {`{"email": "michael.bland@gsa.gov", "login": "mbland"}`},
+		"/user/emails": {`[ {"email": "michael.bland@gsa.gov", "verified": true, "primary": true} ]`},
+		"/user/orgs": {
+			`[ { "login": "test-org-1" } ]`,
+			`[ ]`,
+		},
+		"/user/teams": {
+			`[ { "name": "test-team-1", "slug": "test-team-1", "organization": { "login": "test-org-1" } } ]`,
+			`[ ]`,
+		},
+	})
+	defer b.Close()
+
+	bURL, _ := url.Parse(b.URL)
+	p := testGitHubProvider(bURL.Host, options.GitHubOptions{})
+
+	session := CreateAuthorizedSession()
+	err := p.EnrichSession(context.Background(), session)
+	assert.NoError(t, err)
+	assert.Equal(t, "mbland", session.User)
+	assert.Equal(t, "michael.bland@gsa.gov", session.Email)
+	assert.ElementsMatch(t, []string{"test-org-1", "test-org-1:test-team-1"}, session.Groups)
+}
+
+func TestGitHubProvider_EnrichSessionWithoutReadOrgScope(t *testing.T) {
+	b := testGitHubBackend(map[string][]string{
+		"/user":        {`{"email": "michael.bland@gsa.gov", "login": "mbland"}`},
+		"/user/emails": {`[ {"email": "michael.bland@gsa.gov", "verified": true, "primary": true} ]`},
+	})
+	defer b.Close()
+
+	bURL, _ := url.Parse(b.URL)
+	p := testGitHubProvider(bURL.Host, options.GitHubOptions{})
+	p.Scope = "user:email"
+
+	session := CreateAuthorizedSession()
+	err := p.EnrichSession(context.Background(), session)
+	assert.NoError(t, err)
+	assert.Equal(t, "mbland", session.User)
+	assert.Equal(t, "michael.bland@gsa.gov", session.Email)
+	assert.Empty(t, session.Groups)
+}
+
+func TestNewGitHubProvider_OrgTeamAddsReadOrgScope(t *testing.T) {
+	testCases := []struct {
+		name          string
+		configured    options.GitHubOptions
+		initialScope  string
+		expectedScope string
+	}{
+		{
+			name:          "org only adds read:org",
+			configured:    options.GitHubOptions{Org: "test-org"},
+			initialScope:  "user:email",
+			expectedScope: "user:email read:org",
+		},
+		{
+			name:          "team only adds read:org",
+			configured:    options.GitHubOptions{Team: "test-team"},
+			initialScope:  "user:email",
+			expectedScope: "user:email read:org",
+		},
+		{
+			name:          "org and team add read:org once",
+			configured:    options.GitHubOptions{Org: "test-org", Team: "test-team"},
+			initialScope:  "user:email",
+			expectedScope: "user:email read:org",
+		},
+		{
+			name:          "read:org already present is not duplicated",
+			configured:    options.GitHubOptions{Org: "test-org", Team: "test-team"},
+			initialScope:  "user:email read:org",
+			expectedScope: "user:email read:org",
+		},
+		{
+			name:          "no org or team leaves scope unchanged",
+			configured:    options.GitHubOptions{},
+			initialScope:  "user:email",
+			expectedScope: "user:email",
+		},
+		{
+			name:          "default scope is unchanged",
+			configured:    options.GitHubOptions{Org: "test-org"},
+			initialScope:  "",
+			expectedScope: "user:email read:org",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewGitHubProvider(&ProviderData{Scope: tc.initialScope}, tc.configured)
+			assert.Equal(t, tc.expectedScope, p.Scope)
+		})
+	}
+}

--- a/providers/provider_data.go
+++ b/providers/provider_data.go
@@ -234,9 +234,10 @@ func defaultURL(u *url.URL, d *url.URL) *url.URL {
 		return u
 	}
 
-	// If the default is given, return that
+	// If the default is given, return a copy to avoid modifying the shared default
 	if d != nil {
-		return d
+		copied := *d
+		return &copied
 	}
 	return &url.URL{}
 }


### PR DESCRIPTION

## Description

- I fixed leaky mutable state in provider_data.go
- I added a check for the claims needed to grab GitHub teams and orgs before doing so.
- I added a condition that forces the read:org claim if the config asks to validate membership as part of authorizaiton
- I added a helper function to make sure that scopes are compared cleanly, to avoid accidental substring cases
- I added tests to confirm that both code paths work

## Motivation and Context

At present, the GitHub provider forces the use of the read:org scope, for which GitHub pushes a notification to all of a user's orgs. If you only need (and ask for) the email claim, the flow fails when retrieving the unneeded attribs in the second pass.
https://github.com/oauth2-proxy/oauth2-proxy/issues/3482

## How Has This Been Tested?

I've tested using my own GitHub org and app registration.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added an entry for my changes to the [CHANGELOG.md](https://github.com/oauth2-proxy/oauth2-proxy/blob/master/CHANGELOG.md).
- [ ] I have [signed off](https://github.com/apps/dco) all my commits.  **I'm happy to do so, but don't know how to do it retroactively.**
- [x] I have created a feature (non-master) branch for my PR.
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#examples) for the PR title.
- [x] I have written tests for my code changes.
