### PR TITLE
feat: return 401 for unauthenticated subresource requests

### DIFF
--- a/docs/docs/behaviour.md
+++ b/docs/docs/behaviour.md
@@ -11,6 +11,8 @@ title: Behaviour
 2. Unauthenticated Requests: When authentication is missing but required, the user is redirected to the configured Identity Provider (IdP) login page by default.
     - Ajax Requests: If the request has `Accept: application/json` header:
         - Returns `401 Unauthorized`.
+    - Subresource Requests: If the browser sends a `Sec-Fetch-Dest` header with a value other than `document` (e.g. `script`, `image`, `style`):
+        - Returns `401 Unauthorized`.
     - Invalid JWT Tokens: If `--skip-jwt-bearer-tokens` is set and the request includes an invalid JWT:
         - Redirects to the login page by default.
         - Returns `403 Forbidden` if `--bearer-token-login-fallback` is set to `false`.

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -1054,7 +1054,7 @@ func (p *OAuthProxy) Proxy(rw http.ResponseWriter, req *http.Request) {
 		p.headersChain.Then(p.upstreamProxy).ServeHTTP(rw, req)
 	case ErrNeedsLogin:
 		// we need to send the user to a login screen
-		if p.forceJSONErrors || isAjax(req) || p.isAPIPath(req) {
+		if p.forceJSONErrors || isAjax(req) || p.isAPIPath(req) || isSubresourceRequest(req) {
 			logger.Printf("No valid authentication in request. Access Denied.")
 			// no point redirecting an AJAX request
 			p.errorJSON(rw, http.StatusUnauthorized)
@@ -1333,6 +1333,11 @@ func isAjax(req *http.Request) bool {
 		}
 	}
 	return false
+}
+
+func isSubresourceRequest(req *http.Request) bool {
+	secFetchDest := req.Header.Get("Sec-Fetch-Dest")
+	return secFetchDest != "" && secFetchDest != "document"
 }
 
 // errorJSON returns the error code with an application/json mime type

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -1775,6 +1775,65 @@ func TestAjaxForbiddendRequest(t *testing.T) {
 	assert.NotEqual(t, applicationJSON, mime)
 }
 
+func TestSubresourceRequest(t *testing.T) {
+	tests := []struct {
+		name            string
+		dest            string
+		expectLoginPage bool
+	}{
+		{"script is denied without redirect", "script", false},
+		{"image is denied without redirect", "image", false},
+		{"document initiates login", "document", true},
+		{"absent header initiates login", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := baseTestOptions()
+			err := validation.Validate(opts)
+			assert.NoError(t, err)
+			proxy, err := NewOAuthProxy(opts, func(email string) bool {
+				return true
+			})
+			assert.NoError(t, err)
+
+			rw := httptest.NewRecorder()
+			req, err := http.NewRequest(http.MethodGet, "/test", nil)
+			assert.NoError(t, err)
+			if tt.dest != "" {
+				req.Header.Set("Sec-Fetch-Dest", tt.dest)
+			}
+			proxy.ServeHTTP(rw, req)
+
+			if tt.expectLoginPage {
+				assert.Contains(t, rw.Body.String(), "Sign in")
+			} else {
+				assert.Equal(t, http.StatusUnauthorized, rw.Code)
+			}
+		})
+	}
+}
+
+func TestIsSubresourceRequest(t *testing.T) {
+	tests := []struct {
+		name     string
+		dest     string
+		expected bool
+	}{
+		{"absent header", "", false},
+		{"document", "document", false},
+		{"non-document", "script", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, _ := http.NewRequest(http.MethodGet, "/", nil)
+			if tt.dest != "" {
+				req.Header.Set("Sec-Fetch-Dest", tt.dest)
+			}
+			assert.Equal(t, tt.expected, isSubresourceRequest(req))
+		})
+	}
+}
+
 func TestClearSplitCookie(t *testing.T) {
 	opts := baseTestOptions()
 	opts.Cookie.Secret = base64CookieSecret


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Browsers send a Sec-Fetch-Dest header indicating the type of resource being fetched. When its value is anything other than "document" (e.g. script, image, style), the request cannot meaningfully follow an auth redirect, so return 401 instead of initiating login.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In some cases browsers do not send the session cookie in all subresource request. We saw that in Safari with favicons. If `--skip-provider-button` is configured the browser follows the redirect chain to the oidc provider. Our oidc provider triggers MFA prompts directly if Kerberos succeeds.
I'd rather have it fail directly.

I assumed from the existing implementation of `isAjax` that there is no need for a configuration flag. However I see that this would make it a breaking change.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I ran `curl http://127.0.0.1:8080/ -H 'Sec-Fetch-Dest: image' -v`  against my own instance and checked the http response codes and answers. Basically what I also checked in the unit tests.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added an entry for my changes to the [CHANGELOG.md](https://github.com/oauth2-proxy/oauth2-proxy/blob/master/CHANGELOG.md).
- [x] I have [signed off](https://github.com/apps/dco) all my commits.
- [x] I have created a feature (non-master) branch for my PR.
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#examples) for the PR title.
- [x] I have written tests for my code changes.
