### PR TITLE
fix(encryption): return an error instead of panicking on a short GCM ciphertext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Changes since v7.15.4
 
+- [#3527](https://github.com/oauth2-proxy/oauth2-proxy/pull/3527) fix(encryption): return an error instead of panicking on a short GCM ciphertext @winklemad
+
 # V7.15.4
 
 ## Release Highlights

--- a/pkg/encryption/cipher.go
+++ b/pkg/encryption/cipher.go
@@ -122,6 +122,9 @@ func (c *gcmCipher) Decrypt(ciphertext []byte) ([]byte, error) {
 	}
 
 	nonceSize := gcm.NonceSize()
+	if len(ciphertext) < nonceSize {
+		return nil, fmt.Errorf("encrypted value should be at least %d bytes, but is only %d bytes", nonceSize, len(ciphertext))
+	}
 	nonce, ciphertext := ciphertext[:nonceSize], ciphertext[nonceSize:]
 
 	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)

--- a/pkg/encryption/cipher_test.go
+++ b/pkg/encryption/cipher_test.go
@@ -89,6 +89,24 @@ func TestEncryptAndDecrypt(t *testing.T) {
 	}
 }
 
+func TestDecryptShortCiphertextReturnsError(t *testing.T) {
+	// A ciphertext shorter than the cipher's IV/nonce prefix must yield an
+	// error, not a slice-bounds panic. CFB already guarded this; GCM must too.
+	cipherInits := map[string]func([]byte) (Cipher, error){
+		"CFB": NewCFBCipher,
+		"GCM": NewGCMCipher,
+	}
+	for name, initCipher := range cipherInits {
+		t.Run(name, func(t *testing.T) {
+			c, err := initCipher([]byte("0123456789abcdef"))
+			assert.NoError(t, err)
+
+			_, err = c.Decrypt([]byte{1, 2, 3, 4, 5})
+			assert.Error(t, err)
+		})
+	}
+}
+
 func runEncryptAndDecrypt(t *testing.T, c Cipher, dataSize int) {
 	data := make([]byte, dataSize)
 	_, err := io.ReadFull(rand.Reader, data)


### PR DESCRIPTION
## Description

`gcmCipher.Decrypt` slices `ciphertext[:nonceSize]` without first checking the length, so a ciphertext shorter than the 12-byte GCM nonce panics with `slice bounds out of range` instead of returning an error:

```go
c, _ := NewGCMCipher([]byte("0123456789abcdef"))
c.Decrypt([]byte{1, 2, 3, 4, 5}) // panic: slice bounds out of range [:12] with capacity 5
```

The sibling `cfbCipher.Decrypt` already guards its IV length and returns a descriptive error. This adds the equivalent guard (same error wording) to `gcmCipher.Decrypt`.

## Motivation and Context

`Decrypt` runs on attacker-controllable input — a truncated or malformed encrypted cookie decodes to a short byte slice and reaches this path. It should reject that cleanly with an error like every other bad-ciphertext case, not panic. The two cipher implementations should also behave consistently.

## How Has This Been Tested?

Added `TestDecryptShortCiphertextReturnsError`, which feeds a 5-byte ciphertext to both ciphers and asserts an error (not a panic). It fails on `master` for the GCM case and passes with the guard; `go test ./pkg/encryption/...` is green, `gofmt`/`go vet` clean.

## Checklist

- [x] My change requires a change to the documentation, and I have updated it accordingly. *(CHANGELOG.md entry added.)*
- [x] I have signed off all my commits as required by [DCO](https://github.com/oauth2-proxy/oauth2-proxy/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch and is not the `master` branch.
- [x] I have written a conventional-commit PR title.
- [x] I have added tests that prove my fix is effective.