### PR TITLE
fix: match leading-dot cookie domains to apex hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Changes since v7.15.4
 
+- Fix leading-dot cookie domains not matching their apex hosts
+
 # V7.15.4
 
 ## Release Highlights

--- a/pkg/cookies/cookies.go
+++ b/pkg/cookies/cookies.go
@@ -61,11 +61,16 @@ func MakeCookieFromOptions(req *http.Request, opts *CookieOptions) *http.Cookie 
 func GetCookieDomain(req *http.Request, cookieDomains []string) string {
 	host := requestutil.GetRequestHost(req)
 	for _, domain := range cookieDomains {
-		if strings.HasSuffix(host, domain) {
+		if cookieDomainMatches(host, domain) {
 			return domain
 		}
 	}
 	return ""
+}
+
+func cookieDomainMatches(host, domain string) bool {
+	return host == strings.TrimPrefix(domain, ".") ||
+		strings.HasSuffix(host, domain)
 }
 
 // ParseSameSite a valid http.SameSite value from a user supplied string for use of making cookies.
@@ -95,7 +100,12 @@ func warnInvalidDomain(c *http.Cookie, req *http.Request) {
 	if h, _, err := net.SplitHostPort(host); err == nil {
 		host = h
 	}
-	if !strings.HasSuffix(host, c.Domain) {
-		logger.Errorf("Warning: request host is %q but using configured cookie domain of %q", host, c.Domain)
+
+	if !cookieDomainMatches(host, c.Domain) {
+		logger.Errorf(
+			"Warning: request host is %q but using configured cookie domain of %q",
+			host,
+			c.Domain,
+		)
 	}
 }

--- a/pkg/cookies/cookies_test.go
+++ b/pkg/cookies/cookies_test.go
@@ -80,6 +80,17 @@ var _ = Describe("Cookie Tests", func() {
 				cookieDomains:  []string{".cookies.wrong", ".cookies.false"},
 				expectedOutput: "",
 			}),
+			Entry("a leading-dot domain matches its apex Host header", getCookieDomainTableInput{
+				host:           "cookies.test",
+				cookieDomains:  []string{".cookies.test"},
+				expectedOutput: ".cookies.test",
+			}),
+			Entry("a leading-dot domain matches its apex X-Forwarded-Host header", getCookieDomainTableInput{
+				host:           "backend.cookies.internal",
+				xForwardedHost: "cookies.test",
+				cookieDomains:  []string{".cookies.test"},
+				expectedOutput: ".cookies.test",
+			}),
 		)
 	})
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Treat leading-dot cookie domains as matching both their apex host and subdomains.

For example, `.abc.com` now matches both:

- `abc.com`
- `app.abc.com`

The same matching logic is used for cookie-domain selection and validation warnings.

## Motivation and Context

The existing suffix check matched subdomains but not the apex host:

```text
strings.HasSuffix("abc.com", ".abc.com") == false
```
As a result, when multiple cookie domains are configured, OAuth2 Proxy could fail to select cookie domain for requests made directly to the apex host, resulting in authentication failures (invalid CSRF token).

```
Request host: abc.com

cookie_domains:
  - .abc.com
  - .other.com

Expected:
  .abc.com is selected

Actual:
  no domain matches and oauth2-proxy falls back to .other.com
```

This behavior is very confusing. I'll be happy to refine my current fix if it's too simplified or doesn't take into account some hidden logic.

## How Has This Been Tested?

- Added regression tests for the apex Host header.
- Added regression tests for the apex X-Forwarded-Host header.
- Ran make test.
- Ran go test -race ./pkg/cookies.
- Ran make lint.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added an entry for my changes to the [CHANGELOG.md](https://github.com/oauth2-proxy/oauth2-proxy/blob/master/CHANGELOG.md).
- [x] I have [signed off](https://github.com/apps/dco) all my commits.
- [x] I have created a feature (non-master) branch for my PR.
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#examples) for the PR title.
- [x] I have written tests for my code changes.
