### PR TITLE
Propagate Microsoft Graph errors during Entra group overage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Changes since v7.15.4
 
+- [#3535](https://github.com/oauth2-proxy/oauth2-proxy/pull/3535) fix: surface Microsoft Graph errors during Entra group overage instead of logging in with an incomplete group set @no-hup
+
 # V7.15.4
 
 ## Release Highlights

--- a/providers/ms_entra_id.go
+++ b/providers/ms_entra_id.go
@@ -247,7 +247,7 @@ func (p *MicrosoftEntraIDProvider) addGraphGroupsToSession(ctx context.Context, 
 			UnmarshalSimpleJSON()
 
 		if err != nil {
-			return fmt.Errorf("invalid response from microsoft graph: %v", err)
+			return fmt.Errorf("invalid response from microsoft graph: %w", err)
 		}
 		reqGroups := response.Get("value").MustArray()
 

--- a/providers/ms_entra_id.go
+++ b/providers/ms_entra_id.go
@@ -247,8 +247,7 @@ func (p *MicrosoftEntraIDProvider) addGraphGroupsToSession(ctx context.Context, 
 			UnmarshalSimpleJSON()
 
 		if err != nil {
-			logger.Errorf("invalid response from microsoft graph, no groups added to session: %v", err)
-			return nil
+			return fmt.Errorf("invalid response from microsoft graph: %v", err)
 		}
 		reqGroups := response.Get("value").MustArray()
 

--- a/providers/ms_entra_id_test.go
+++ b/providers/ms_entra_id_test.go
@@ -82,6 +82,41 @@ func TestAzureEntraOIDCProviderEnrichSessionGroupOverage(t *testing.T) {
 	assert.Contains(t, session.Groups, "b1aef995-6b55-4ac6-bbfe-e829810e9352", "Pagination using $skiptoken failed")
 }
 
+func TestAzureEntraOIDCProviderEnrichSessionGraphError(t *testing.T) {
+	// Create ID Token that indicates group overage with _claim_names
+	key, _ := rsa.GenerateKey(rand.Reader, 2048)
+	claimsWithGroupOverage := &claimsWithGroupOverage{
+		jwt.RegisteredClaims{
+			Issuer: "https://login.microsoftonline.com/18014347-dd57-41a1-8191-7a1f734ea457/v2.0",
+		},
+		map[string]string{"groups": "src1"},
+	}
+
+	jwtWithClaims := jwt.NewWithClaims(jwt.SigningMethodRS256, claimsWithGroupOverage)
+	signedJWT, err := jwtWithClaims.SignedString(key)
+	assert.NoError(t, err)
+
+	session := CreateAuthorizedSession()
+	session.IDToken = signedJWT
+	session.Email = "mock@example.com"
+
+	provider := NewMicrosoftEntraIDProvider(&ProviderData{},
+		options.Provider{OIDCConfig: options.OIDCOptions{
+			IssuerURL: "https://login.microsoftonline.com/18014347-dd57-41a1-8191-7a1f734ea457/v2.0",
+		}},
+	)
+
+	// Mock a Graph server that rejects the groups request
+	mockedGraph := mockGraphAPI(true)
+	mockedGraphURL, _ := url.Parse(mockedGraph.URL)
+	updateURL(provider.microsoftGraphURL, mockedGraphURL.Host)
+
+	// A failed Graph lookup during overage must surface as an error, not a
+	// silently under-populated session.
+	err = provider.EnrichSession(context.Background(), session)
+	assert.Error(t, err)
+}
+
 func TestAzureEntraOIDCProviderValidateSessionAllowedTenants(t *testing.T) {
 	// Create multi-tenant Azure Entra provider with allowed tenants
 	provider := NewMicrosoftEntraIDProvider(

--- a/providers/ms_entra_id_test.go
+++ b/providers/ms_entra_id_test.go
@@ -113,8 +113,11 @@ func TestAzureEntraOIDCProviderEnrichSessionGraphError(t *testing.T) {
 
 	// A failed Graph lookup during overage must surface as an error, not a
 	// silently under-populated session.
+	groupsBefore := session.Groups
 	err = provider.EnrichSession(context.Background(), session)
-	assert.Error(t, err)
+	assert.ErrorContains(t, err, "invalid response from microsoft graph")
+	// The session must be left exactly as it was, not half-populated.
+	assert.Equal(t, groupsBefore, session.Groups)
 }
 
 func TestAzureEntraOIDCProviderValidateSessionAllowedTenants(t *testing.T) {


### PR DESCRIPTION
Fixes #3534

On AAD group overage, `addGraphGroupsToSession` fetches the real group list from Microsoft Graph. If that request failed it logged the error and returned `nil`, so the caller's error handling never ran and the session was left with the overage placeholder instead of the user's groups — login still succeeded, just with the wrong groups.

This returns the error like every other error path in the file, so `EnrichSession` fails cleanly instead of continuing in an inconsistent state.

Added a regression test using the `mockGraphAPI(true)` (401) mock that already existed in the test file but wasn't used. It fails on `main` ("An error is expected but got nil") and passes with this change.

```
go test ./providers/   # 202 passed
gofmt -l providers/    # clean
```
